### PR TITLE
Refactors drawing Images, and simplifies roRegions to use the canvas of their associated Bitmap

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -39,6 +39,7 @@ if (supportedBrowser()) {
     customKeys.set("KeyZ", "b"); // Keep consistency with older versions
     customKeys.set("PageUp", "ignore"); // do not handle on browser
     customKeys.set("PageDown", "ignore"); // do not handle on browser
+    customKeys.set("Digit8", "info");
 
     // Initialize Device Emulator and subscribe to events
     libVersion.innerHTML = brsEmu.getVersion();

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -30,6 +30,7 @@ keysMap.set("Shift+Escape", "home");
 keysMap.set("Control+Escape", "home");
 keysMap.set("Backspace", "instantreplay");
 keysMap.set("End", "play");
+keysMap.set("Digit8", "info");
 if (isMacOS) {
     keysMap.set("Command+Backspace", "backspace");
     keysMap.set("Command+Enter", "play");

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -30,7 +30,6 @@ keysMap.set("Shift+Escape", "home");
 keysMap.set("Control+Escape", "home");
 keysMap.set("Backspace", "instantreplay");
 keysMap.set("End", "play");
-keysMap.set("Digit8", "info");
 if (isMacOS) {
     keysMap.set("Command+Backspace", "backspace");
     keysMap.set("Command+Enter", "play");

--- a/src/brsTypes/components/RoBitmap.ts
+++ b/src/brsTypes/components/RoBitmap.ts
@@ -15,7 +15,7 @@ import UPNG from "upng-js";
 import * as JPEG from "jpeg-js";
 import { GifReader } from "omggif";
 import BMP from "decode-bmp";
-import { drawImageToContext, drawObjectToContext } from "../draw2d";
+import { drawImageToContext, drawObjectToContext, getDimensions, getDrawOffset } from "../draw2d";
 
 export class RoBitmap extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -163,7 +163,7 @@ export class RoBitmap extends BrsComponent implements BrsValue {
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
         this.rgbaRedraw = true;
         const ctx = this.context;
-        return drawObjectToContext(ctx, this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
+        return drawObjectToContext(ctx, getDrawOffset(this), getDimensions(this), this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
     }
 
     drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
@@ -185,6 +185,10 @@ export class RoBitmap extends BrsComponent implements BrsValue {
 
     getContext(): OffscreenCanvasRenderingContext2D {
         return this.context;
+    }
+
+    getAlphaEnableValue(): boolean {
+        return this.alphaEnable;
     }
 
     getRgbaCanvas(rgba: number): OffscreenCanvas {
@@ -461,11 +465,11 @@ export class RoBitmap extends BrsComponent implements BrsValue {
     /** If enable is true, do alpha blending when this bitmap is the destination */
     private setAlphaEnable = new Callable("setAlphaEnable", {
         signature: {
-            args: [new StdlibArgument("alphaEnabled", ValueKind.Boolean)],
+            args: [new StdlibArgument("alphaEnable", ValueKind.Boolean)],
             returns: ValueKind.Void,
         },
-        impl: (_: Interpreter, alphaEnabled: BrsBoolean) => {
-            return this.setCanvasAlpha(alphaEnabled.toBoolean());
+        impl: (_: Interpreter, alphaEnable: BrsBoolean) => {
+            return this.setCanvasAlpha(alphaEnable.toBoolean());
         },
     });
 

--- a/src/brsTypes/components/RoBitmap.ts
+++ b/src/brsTypes/components/RoBitmap.ts
@@ -15,7 +15,7 @@ import UPNG from "upng-js";
 import * as JPEG from "jpeg-js";
 import { GifReader } from "omggif";
 import BMP from "decode-bmp";
-import { drawObjectToContext, getCanvasFromDraw2d, getPreTranslation, getSourceOffset, isCanvasValid, setContextAlpha } from "../draw2d";
+import { drawObjectToContext } from "../draw2d";
 
 export class RoBitmap extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -80,7 +80,6 @@ export class RoBitmap extends BrsComponent implements BrsValue {
         //TODO: Review alpha enable, it should only affect bitmap as destination.
         this.context = this.canvas.getContext("2d", {
             alpha: true,
-            willReadFrequently: true
         }) as OffscreenCanvasRenderingContext2D;
         if (image) {
             try {

--- a/src/brsTypes/components/RoBitmap.ts
+++ b/src/brsTypes/components/RoBitmap.ts
@@ -15,7 +15,7 @@ import UPNG from "upng-js";
 import * as JPEG from "jpeg-js";
 import { GifReader } from "omggif";
 import BMP from "decode-bmp";
-import { drawObjectToContext } from "../draw2d";
+import { drawImageToContext, drawObjectToContext } from "../draw2d";
 
 export class RoBitmap extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -164,6 +164,11 @@ export class RoBitmap extends BrsComponent implements BrsValue {
         this.rgbaRedraw = true;
         const ctx = this.context;
         return drawObjectToContext(ctx, this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
+    }
+
+    drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
+        const ctx = this.context;
+        return drawImageToContext(ctx, image, this.alphaEnable, x, y)
     }
 
     getImageWidth(): number {

--- a/src/brsTypes/components/RoBitmap.ts
+++ b/src/brsTypes/components/RoBitmap.ts
@@ -15,7 +15,7 @@ import UPNG from "upng-js";
 import * as JPEG from "jpeg-js";
 import { GifReader } from "omggif";
 import BMP from "decode-bmp";
-import { drawImageToContext, drawObjectToContext, getDimensions, getDrawOffset } from "../draw2d";
+import { drawImageToContext, drawObjectToComponent } from "../draw2d";
 
 export class RoBitmap extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -162,8 +162,7 @@ export class RoBitmap extends BrsComponent implements BrsValue {
 
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
         this.rgbaRedraw = true;
-        const ctx = this.context;
-        return drawObjectToContext(ctx, getDrawOffset(this), getDimensions(this), this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
+        return drawObjectToComponent(this, object, rgba, x, y, scaleX, scaleY);
     }
 
     drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {

--- a/src/brsTypes/components/RoBitmap.ts
+++ b/src/brsTypes/components/RoBitmap.ts
@@ -1,6 +1,6 @@
 import { BrsValue, ValueKind, BrsString, BrsInvalid, BrsBoolean } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
-import { BrsType, Double } from "..";
+import { BrsType, Double, roInvalid } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
@@ -15,6 +15,7 @@ import UPNG from "upng-js";
 import * as JPEG from "jpeg-js";
 import { GifReader } from "omggif";
 import BMP from "decode-bmp";
+import { drawObjectToContext, getCanvasFromDraw2d, getPreTranslation, getSourceOffset, isCanvasValid, setContextAlpha } from "../draw2d";
 
 export class RoBitmap extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -79,6 +80,7 @@ export class RoBitmap extends BrsComponent implements BrsValue {
         //TODO: Review alpha enable, it should only affect bitmap as destination.
         this.context = this.canvas.getContext("2d", {
             alpha: true,
+            willReadFrequently: true
         }) as OffscreenCanvasRenderingContext2D;
         if (image) {
             try {
@@ -159,22 +161,18 @@ export class RoBitmap extends BrsComponent implements BrsValue {
         return BrsInvalid.Instance;
     }
 
-    drawImage(image: OffscreenCanvas, x: number, y: number) {
+    drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
         this.rgbaRedraw = true;
         const ctx = this.context;
-        if (this.alphaEnable) {
-            ctx.drawImage(image, x, y);
-        } else {
-            const ctc = image.getContext("2d", {
-                alpha: true,
-            }) as OffscreenCanvasRenderingContext2D;
-            let imageData = ctc.getImageData(0, 0, image.width, image.height);
-            let pixels = imageData.data;
-            for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
-                pixels[i] = 255;
-            }
-            ctx.putImageData(imageData, x, y);
-        }
+        return drawObjectToContext(ctx, this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
+    }
+
+    getImageWidth(): number {
+        return this.canvas.width;
+    }
+
+    getImageHeight(): number {
+        return this.canvas.height;
     }
 
     getCanvas(): OffscreenCanvas {
@@ -259,36 +257,12 @@ export class RoBitmap extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             const ctx = this.context;
-            if (object instanceof RoBitmap) {
-                let cvs: OffscreenCanvas;
-                if (rgba instanceof Int32) {
-                    const alpha = rgba.getValue() & 255;
-                    if (alpha < 255) {
-                        ctx.globalAlpha = alpha / 255;
-                    }
-                    cvs = object.getRgbaCanvas(rgba.getValue());
-                } else {
-                    cvs = object.getCanvas();
-                }
-                if (cvs.width === 0 || cvs.height === 0) {
-                    return BrsBoolean.False;
-                }
-                this.drawImage(cvs, x.getValue(), y.getValue());
-            } else if (object instanceof RoRegion) {
-                let rcv = object.getRegionCanvas();
-                if (rcv.width === 0 || rcv.height === 0) {
-                    return BrsBoolean.False;
-                }
-                this.drawImage(
-                    rcv,
-                    x.getValue() + object.getTransX(),
-                    y.getValue() + object.getTransY()
-                );
-            } else {
-                return BrsBoolean.False;
-            }
+            const didDraw = this.drawImage(object, rgba, x.getValue(), y.getValue())
             ctx.globalAlpha = 1.0;
             this.rgbaRedraw = true;
+            if (!didDraw) {
+                return BrsBoolean.False;
+            }
             return BrsBoolean.True;
         },
     });
@@ -319,44 +293,14 @@ export class RoBitmap extends BrsComponent implements BrsValue {
             const angleInRad = (-theta.getValue() * Math.PI) / 180;
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
-            if (object instanceof RoBitmap) {
-                let cvs: OffscreenCanvas;
-                if (rgba instanceof Int32) {
-                    const alpha = rgba.getValue() & 255;
-                    if (alpha < 255) {
-                        ctx.globalAlpha = alpha / 255;
-                    }
-                    cvs = object.getRgbaCanvas(rgba.getValue());
-                } else {
-                    cvs = object.getCanvas();
-                }
-                if (cvs.width === 0 || cvs.height === 0) {
-                    return BrsBoolean.False;
-                }
-                ctx.drawImage(cvs, 0, 0, cvs.width, cvs.height);
-            } else if (object instanceof RoRegion) {
-                let rcv = object.getRegionCanvas();
-                if (rcv.width === 0 || rcv.height === 0) {
-                    return BrsBoolean.False;
-                }
-                ctx.drawImage(
-                    rcv,
-                    object.getPosX(),
-                    object.getPosY(),
-                    object.getImageWidth(),
-                    object.getImageHeight(),
-                    object.getTransX(),
-                    object.getTransY(),
-                    object.getImageWidth(),
-                    object.getImageHeight()
-                );
-            } else {
-                return BrsBoolean.False;
-            }
+            const didDraw = this.drawImage(object, rgba, 0, 0)
             ctx.rotate(-angleInRad);
             ctx.translate(-positionX, -positionY);
             ctx.globalAlpha = 1.0;
             this.rgbaRedraw = true;
+            if (!didDraw) {
+                return BrsBoolean.False;
+            }
             return BrsBoolean.True;
         },
     });
@@ -384,48 +328,12 @@ export class RoBitmap extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             const ctx = this.context;
-            if (object instanceof RoBitmap) {
-                let cvs: OffscreenCanvas;
-                if (rgba instanceof Int32) {
-                    const alpha = rgba.getValue() & 255;
-                    if (alpha < 255) {
-                        ctx.globalAlpha = alpha / 255;
-                    }
-                    cvs = object.getRgbaCanvas(rgba.getValue());
-                } else {
-                    cvs = object.getCanvas();
-                }
-                if (cvs.width === 0 || cvs.height === 0) {
-                    return BrsBoolean.False;
-                }
-                ctx.imageSmoothingEnabled = false;
-                ctx.drawImage(
-                    cvs,
-                    x.getValue(),
-                    y.getValue(),
-                    cvs.width * scaleX.getValue(),
-                    cvs.height * scaleY.getValue()
-                );
-            } else if (object instanceof RoRegion) {
-                let rcv = object.getRegionCanvas();
-                if (rcv.width === 0 || rcv.height === 0) {
-                    return BrsBoolean.False;
-                }
-                let tx = object.getTransX() * scaleX.getValue();
-                let ty = object.getTransY() * scaleY.getValue();
-                ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
-                ctx.drawImage(
-                    rcv,
-                    x.getValue() + tx,
-                    y.getValue() + ty,
-                    object.getImageWidth() * scaleX.getValue(),
-                    object.getImageHeight() * scaleY.getValue()
-                );
-            } else {
-                return BrsBoolean.False;
-            }
+            const didDraw = this.drawImage(object, rgba, x.getValue(), y.getValue(), scaleX.getValue(), scaleY.getValue())
             ctx.globalAlpha = 1.0;
             this.rgbaRedraw = true;
+            if (!didDraw) {
+                return BrsBoolean.False;
+            }
             return BrsBoolean.True;
         },
     });

--- a/src/brsTypes/components/RoBitmap.ts
+++ b/src/brsTypes/components/RoBitmap.ts
@@ -291,12 +291,11 @@ export class RoBitmap extends BrsComponent implements BrsValue {
             const positionX = x.getValue();
             const positionY = y.getValue();
             const angleInRad = (-theta.getValue() * Math.PI) / 180;
+            ctx.save()
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
             const didDraw = this.drawImage(object, rgba, 0, 0)
-            ctx.rotate(-angleInRad);
-            ctx.translate(-positionX, -positionY);
-            ctx.globalAlpha = 1.0;
+            ctx.restore()
             this.rgbaRedraw = true;
             if (!didDraw) {
                 return BrsBoolean.False;

--- a/src/brsTypes/components/RoCompositor.ts
+++ b/src/brsTypes/components/RoCompositor.ts
@@ -7,7 +7,6 @@ import { Int32 } from "../Int32";
 import { RoBitmap, rgbaIntToHex } from "./RoBitmap";
 import { RoSprite } from "./RoSprite";
 import { RoArray } from "./RoArray";
-import { drawImageToContext, drawObjectToContext } from "../draw2d";
 
 export class RoCompositor extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -139,9 +138,8 @@ export class RoCompositor extends BrsComponent implements BrsValue {
             ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
         }
         if (this.destBitmap) {
-            const ctx = this.destBitmap.getContext()
-            drawImageToContext(ctx, this.canvas, 0, 0)
-            // this.destBitmap.drawImage(this.canvas, 0, 0);
+            const destContext = this.destBitmap.getContext()
+            destContext.drawImage(this.canvas, 0, 0);
             let layers = [...this.sprites.keys()].sort((a, b) => a - b);
             layers.forEach((z) => {
                 const layer = this.sprites.get(z);
@@ -153,8 +151,7 @@ export class RoCompositor extends BrsComponent implements BrsValue {
                                 sprite.getPosX(),
                                 sprite.getPosY()
                             );
-                            drawImageToContext(ctx, this.canvas, 0, 0)
-                            //  this.destBitmap?.drawImage(this.canvas, 0, 0);
+                            destContext.drawImage(this.canvas, 0, 0);
                         }
                     });
                 }

--- a/src/brsTypes/components/RoCompositor.ts
+++ b/src/brsTypes/components/RoCompositor.ts
@@ -7,6 +7,7 @@ import { Int32 } from "../Int32";
 import { RoBitmap, rgbaIntToHex } from "./RoBitmap";
 import { RoSprite } from "./RoSprite";
 import { RoArray } from "./RoArray";
+import { drawImageToContext, drawObjectToContext } from "../draw2d";
 
 export class RoCompositor extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -23,6 +24,7 @@ export class RoCompositor extends BrsComponent implements BrsValue {
         this.canvas = new OffscreenCanvas(10, 10);
         let context = this.canvas.getContext("2d", {
             alpha: true,
+            willReadFrequently: true,
         }) as OffscreenCanvasRenderingContext2D;
         this.context = context;
         this.spriteId = 0;
@@ -137,7 +139,9 @@ export class RoCompositor extends BrsComponent implements BrsValue {
             ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
         }
         if (this.destBitmap) {
-            this.destBitmap.drawImage(this.canvas, 0, 0);
+            const ctx = this.destBitmap.getContext()
+            drawImageToContext(ctx, this.canvas, 0, 0)
+            // this.destBitmap.drawImage(this.canvas, 0, 0);
             let layers = [...this.sprites.keys()].sort((a, b) => a - b);
             layers.forEach((z) => {
                 const layer = this.sprites.get(z);
@@ -149,7 +153,8 @@ export class RoCompositor extends BrsComponent implements BrsValue {
                                 sprite.getPosX(),
                                 sprite.getPosY()
                             );
-                            this.destBitmap?.drawImage(this.canvas, 0, 0);
+                            drawImageToContext(ctx, this.canvas, 0, 0)
+                            //  this.destBitmap?.drawImage(this.canvas, 0, 0);
                         }
                     });
                 }

--- a/src/brsTypes/components/RoCompositor.ts
+++ b/src/brsTypes/components/RoCompositor.ts
@@ -7,7 +7,7 @@ import { Int32 } from "../Int32";
 import { RoBitmap, rgbaIntToHex } from "./RoBitmap";
 import { RoSprite } from "./RoSprite";
 import { RoArray } from "./RoArray";
-import { drawObjectToContext } from "../draw2d";
+import { drawObjectToContext, getDrawOffset } from "../draw2d";
 
 export class RoCompositor extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -138,17 +138,17 @@ export class RoCompositor extends BrsComponent implements BrsValue {
             ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
         }
         if (this.destBitmap) {
-            this.destBitmap.drawImageToContext(this.canvas, 0, 0)
+            this.destBitmap.drawImageToContext(this.canvas, 0, 0);
             let layers = [...this.sprites.keys()].sort((a, b) => a - b);
             layers.forEach((z) => {
                 const layer = this.sprites.get(z);
                 if (layer) {
                     layer.forEach((sprite) => {
                         if (sprite.visible()) {
-                            drawObjectToContext(ctx, true, sprite.getRegionObject(), BrsInvalid.Instance, sprite.getPosX(), sprite.getPosY())
+                            drawObjectToContext(ctx, true, sprite.getRegionObject(), BrsInvalid.Instance, sprite.getPosX(), sprite.getPosY());
                         }
-                        this.destBitmap?.drawImageToContext(this.canvas, 0, 0);
                     });
+                    this.destBitmap?.drawImageToContext(this.canvas, 0, 0);
                 }
             });
         }

--- a/src/brsTypes/components/RoCompositor.ts
+++ b/src/brsTypes/components/RoCompositor.ts
@@ -7,6 +7,7 @@ import { Int32 } from "../Int32";
 import { RoBitmap, rgbaIntToHex } from "./RoBitmap";
 import { RoSprite } from "./RoSprite";
 import { RoArray } from "./RoArray";
+import { drawObjectToContext } from "../draw2d";
 
 export class RoCompositor extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -23,7 +24,6 @@ export class RoCompositor extends BrsComponent implements BrsValue {
         this.canvas = new OffscreenCanvas(10, 10);
         let context = this.canvas.getContext("2d", {
             alpha: true,
-            willReadFrequently: true,
         }) as OffscreenCanvasRenderingContext2D;
         this.context = context;
         this.spriteId = 0;
@@ -138,21 +138,16 @@ export class RoCompositor extends BrsComponent implements BrsValue {
             ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
         }
         if (this.destBitmap) {
-            const destContext = this.destBitmap.getContext()
-            destContext.drawImage(this.canvas, 0, 0);
+            this.destBitmap.drawImageToContext(this.canvas, 0, 0)
             let layers = [...this.sprites.keys()].sort((a, b) => a - b);
             layers.forEach((z) => {
                 const layer = this.sprites.get(z);
                 if (layer) {
                     layer.forEach((sprite) => {
                         if (sprite.visible()) {
-                            ctx.putImageData(
-                                sprite.getImageData(),
-                                sprite.getPosX(),
-                                sprite.getPosY()
-                            );
-                            destContext.drawImage(this.canvas, 0, 0);
+                            drawObjectToContext(ctx, true, sprite.getRegionObject(), BrsInvalid.Instance, sprite.getPosX(), sprite.getPosY())
                         }
+                        this.destBitmap?.drawImageToContext(this.canvas, 0, 0);
                     });
                 }
             });

--- a/src/brsTypes/components/RoRegion.ts
+++ b/src/brsTypes/components/RoRegion.ts
@@ -9,15 +9,13 @@ import { RoScreen } from "./RoScreen";
 import { Rect, Circle } from "./RoCompositor";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
-import { drawObjectToContext, getCanvasFromDraw2d, getPreTranslation, getSourceOffset, isCanvasValid, setContextAlpha } from "../draw2d";
+import { drawObjectToContext } from "../draw2d";
 
 export class RoRegion extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
     private valid: boolean;
     private alphaEnabled: boolean;
     private bitmap: RoBitmap | RoScreen;
-    //private canvas: OffscreenCanvas;
-    //private context: OffscreenCanvasRenderingContext2D;
     private x: number;
     private y: number;
     private width: number;
@@ -60,14 +58,7 @@ export class RoRegion extends BrsComponent implements BrsValue {
         this.collisionCircle = { x: 0, y: 0, r: width.getValue() }; // TODO: double check Roku default
         this.collisionRect = { x: 0, y: 0, w: width.getValue(), h: height.getValue() }; // TODO: double check Roku default
         this.alphaEnabled = true;
-        // Create new canvas
-        /*
-        this.canvas = new OffscreenCanvas(this.width, this.height);
-        this.context = this.canvas.getContext("2d", {
-            alpha: true,
-            willReadFrequently: true,
-        }) as OffscreenCanvasRenderingContext2D;
-        */
+
         if (
             this.x + this.width <= bitmap.getCanvas().width &&
             this.y + this.height <= bitmap.getCanvas().height
@@ -151,7 +142,6 @@ export class RoRegion extends BrsComponent implements BrsValue {
                 this.y = newY;
             }
         }
-        //this.redrawCanvas();
         // TODO: Check what is the effect on collision parameters
     }
 
@@ -159,7 +149,6 @@ export class RoRegion extends BrsComponent implements BrsValue {
         const ctx = this.bitmap.getContext();
         ctx.fillStyle = rgbaIntToHex(rgba);
         ctx.fillRect(this.x, this.y, this.width, this.height);
-        //this.redrawCanvas();
     }
 
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1) {
@@ -174,10 +163,6 @@ export class RoRegion extends BrsComponent implements BrsValue {
     getContext(): OffscreenCanvasRenderingContext2D {
         return this.bitmap.getContext();
     }
-
-    // getRegionCanvas(): OffscreenCanvas {
-    //     return this.canvas;
-    // }
 
     getRgbaCanvas(rgba: number): OffscreenCanvas {
         if (this.bitmap instanceof RoBitmap) {
@@ -234,116 +219,6 @@ export class RoRegion extends BrsComponent implements BrsValue {
     getRegionScaleMode(): number {
         return this.scaleMode;
     }
-
-    /*
-    redrawCanvas(): void {
-        // TODO: Check the impact of translate on this method
-        const bmp = this.bitmap.getCanvas();
-        this.canvas.width = this.width;
-        this.canvas.height = this.height;
-        let ctx = this.context;
-        if (
-            this.wrap &&
-            (this.x + this.width > bmp.width ||
-                this.y + this.height > bmp.height ||
-                this.x < 0 ||
-                this.y < 0)
-        ) {
-            let clippedWidth = Math.min(bmp.width - this.x, this.width);
-            let clippedHeight = Math.min(bmp.height - this.y, this.height);
-            // fill top/left part of canvas with (clipped) image.
-            ctx.drawImage(
-                bmp,
-                this.x,
-                this.y,
-                clippedWidth,
-                clippedHeight,
-                0,
-                0,
-                clippedWidth,
-                clippedHeight
-            );
-            if (clippedWidth < this.width && clippedHeight < this.height) {
-                // wrap both horizontal and vertical
-                let diffWidth = this.width - clippedWidth;
-                let diffHeight = this.height - clippedHeight;
-                ctx.drawImage(
-                    bmp,
-                    0,
-                    this.y,
-                    diffWidth,
-                    clippedHeight,
-                    clippedWidth,
-                    0,
-                    diffWidth,
-                    clippedHeight
-                );
-                ctx.drawImage(
-                    bmp,
-                    this.x,
-                    0,
-                    clippedWidth,
-                    diffHeight,
-                    0,
-                    clippedHeight,
-                    clippedWidth,
-                    diffHeight
-                );
-                ctx.drawImage(
-                    bmp,
-                    0,
-                    0,
-                    diffWidth,
-                    diffHeight,
-                    clippedWidth,
-                    clippedHeight,
-                    diffWidth,
-                    diffHeight
-                );
-            } else if (clippedWidth < this.width) {
-                // wrap horizontal
-                let diffWidth = this.width - clippedWidth;
-                ctx.drawImage(
-                    bmp,
-                    0,
-                    this.y,
-                    diffWidth,
-                    this.height,
-                    clippedWidth,
-                    0,
-                    diffWidth,
-                    this.height
-                );
-            } else if (clippedHeight < this.height) {
-                // wrap vertical
-                let diffHeight = this.height - clippedHeight;
-                ctx.drawImage(
-                    bmp,
-                    this.x,
-                    0,
-                    this.width,
-                    diffHeight,
-                    0,
-                    clippedHeight,
-                    this.width,
-                    diffHeight
-                );
-            }
-        } else {
-            ctx.drawImage(
-                bmp,
-                this.x,
-                this.y,
-                this.width,
-                this.height,
-                0,
-                0,
-                this.width,
-                this.height
-            );
-        }
-    }
-    */
 
     getAnimaTime(): number {
         return this.time;

--- a/src/brsTypes/components/RoRegion.ts
+++ b/src/brsTypes/components/RoRegion.ts
@@ -9,7 +9,7 @@ import { RoScreen } from "./RoScreen";
 import { Rect, Circle } from "./RoCompositor";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
-import { drawObjectToContext } from "../draw2d";
+import { drawImageToContext, drawObjectToContext } from "../draw2d";
 
 export class RoRegion extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -58,7 +58,14 @@ export class RoRegion extends BrsComponent implements BrsValue {
         this.collisionCircle = { x: 0, y: 0, r: width.getValue() }; // TODO: double check Roku default
         this.collisionRect = { x: 0, y: 0, w: width.getValue(), h: height.getValue() }; // TODO: double check Roku default
         this.alphaEnabled = true;
-
+        // Create new canvas
+        /*
+        this.canvas = new OffscreenCanvas(this.width, this.height);
+        this.context = this.canvas.getContext("2d", {
+            alpha: true,
+            willReadFrequently: true,
+        }) as OffscreenCanvasRenderingContext2D;
+        */
         if (
             this.x + this.width <= bitmap.getCanvas().width &&
             this.y + this.height <= bitmap.getCanvas().height
@@ -156,6 +163,12 @@ export class RoRegion extends BrsComponent implements BrsValue {
         return drawObjectToContext(ctx, this.alphaEnabled, object, rgba, x, y, scaleX, scaleY)
     }
 
+    drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
+        const ctx = this.bitmap.getContext();
+        return drawImageToContext(ctx, image, this.alphaEnabled, x, y)
+    }
+
+
     getCanvas(): OffscreenCanvas {
         return this.bitmap.getCanvas();
     }
@@ -212,7 +225,7 @@ export class RoRegion extends BrsComponent implements BrsValue {
     }
 
     getImageData(): ImageData {
-        //let ctx = this.context;
+        console.log("getImageData", this.x, this.y, this.width, this.height)
         return this.bitmap.getContext().getImageData(this.x, this.y, this.width, this.height);
     }
 

--- a/src/brsTypes/components/RoRegion.ts
+++ b/src/brsTypes/components/RoRegion.ts
@@ -153,12 +153,12 @@ export class RoRegion extends BrsComponent implements BrsValue {
 
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1) {
         const ctx = this.bitmap.getContext();
-        return drawObjectToContext(ctx, this.alphaEnabled, object, rgba, x, y, scaleX, scaleY)
+        return drawObjectToContext(ctx, this.alphaEnabled, object, rgba, x + this.getPosX(), y + this.getPosY(), scaleX, scaleY)
     }
 
     drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
         const ctx = this.bitmap.getContext();
-        return drawImageToContext(ctx, image, this.alphaEnabled, x, y)
+        return drawImageToContext(ctx, image, this.alphaEnabled, x + this.getPosX(), y + this.getPosY())
     }
 
 

--- a/src/brsTypes/components/RoRegion.ts
+++ b/src/brsTypes/components/RoRegion.ts
@@ -709,12 +709,11 @@ export class RoRegion extends BrsComponent implements BrsValue {
             const positionX = x.getValue();
             const positionY = y.getValue();
             const angleInRad = (-theta.getValue() * Math.PI) / 180;
+            ctx.save()
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
             const didDraw = this.drawImage(object, rgba, 0, 0)
-            ctx.rotate(-angleInRad);
-            ctx.translate(-positionX, -positionY);
-            ctx.globalAlpha = 1.0;
+            ctx.restore()
             if (!didDraw) {
                 return BrsBoolean.False;
             }

--- a/src/brsTypes/components/RoRegion.ts
+++ b/src/brsTypes/components/RoRegion.ts
@@ -58,14 +58,7 @@ export class RoRegion extends BrsComponent implements BrsValue {
         this.collisionCircle = { x: 0, y: 0, r: width.getValue() }; // TODO: double check Roku default
         this.collisionRect = { x: 0, y: 0, w: width.getValue(), h: height.getValue() }; // TODO: double check Roku default
         this.alphaEnabled = true;
-        // Create new canvas
-        /*
-        this.canvas = new OffscreenCanvas(this.width, this.height);
-        this.context = this.canvas.getContext("2d", {
-            alpha: true,
-            willReadFrequently: true,
-        }) as OffscreenCanvasRenderingContext2D;
-        */
+
         if (
             this.x + this.width <= bitmap.getCanvas().width &&
             this.y + this.height <= bitmap.getCanvas().height
@@ -225,7 +218,6 @@ export class RoRegion extends BrsComponent implements BrsValue {
     }
 
     getImageData(): ImageData {
-        console.log("getImageData", this.x, this.y, this.width, this.height)
         return this.bitmap.getContext().getImageData(this.x, this.y, this.width, this.height);
     }
 

--- a/src/brsTypes/components/RoRegion.ts
+++ b/src/brsTypes/components/RoRegion.ts
@@ -9,7 +9,7 @@ import { RoScreen } from "./RoScreen";
 import { Rect, Circle } from "./RoCompositor";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
-import { drawImageToContext, drawObjectToContext, getDimensions, getDrawOffset } from "../draw2d";
+import { drawImageToContext, drawObjectToComponent } from "../draw2d";
 
 export class RoRegion extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -152,8 +152,7 @@ export class RoRegion extends BrsComponent implements BrsValue {
     }
 
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1) {
-        const ctx = this.bitmap.getContext();
-        return drawObjectToContext(ctx, getDrawOffset(this), getDimensions(this), this.alphaEnable, object, rgba, x + this.getPosX(), y + this.getPosY(), scaleX, scaleY)
+        return drawObjectToComponent(this, object, rgba, x, y, scaleX, scaleY);
     }
 
     drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {

--- a/src/brsTypes/components/RoScreen.ts
+++ b/src/brsTypes/components/RoScreen.ts
@@ -5,13 +5,12 @@ import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
 import { Float } from "../Float";
-import { RoBitmap, rgbaIntToHex, rgbaToTransparent } from "./RoBitmap";
-import { RoRegion } from "./RoRegion";
+import { rgbaIntToHex, rgbaToTransparent } from "./RoBitmap";
 import { RoMessagePort } from "./RoMessagePort";
 import { RoFont } from "./RoFont";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
-import { drawImageToContext, drawObjectToContext } from "../draw2d";
+import { drawImageToContext, drawObjectToContext, getDimensions, getDrawOffset } from "../draw2d";
 
 export class RoScreen extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -99,6 +98,10 @@ export class RoScreen extends BrsComponent implements BrsValue {
         return this.context[this.currentBuffer];
     }
 
+    getAlphaEnableValue(): boolean {
+        return this.alphaEnable;
+    }
+
     clearCanvas(rgba: number) {
         let ctx = this.context[this.currentBuffer];
         if (rgbaToTransparent(rgba) === 0) {
@@ -112,7 +115,7 @@ export class RoScreen extends BrsComponent implements BrsValue {
 
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
         const ctx = this.context[this.currentBuffer];
-        return drawObjectToContext(ctx, this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
+        return drawObjectToContext(ctx, getDrawOffset(this), getDimensions(ctx.canvas), this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
     }
 
     drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
@@ -384,11 +387,11 @@ export class RoScreen extends BrsComponent implements BrsValue {
     /** If enable is true, do alpha blending when this bitmap is the destination */
     private setAlphaEnable = new Callable("setAlphaEnable", {
         signature: {
-            args: [new StdlibArgument("alphaEnabled", ValueKind.Boolean)],
+            args: [new StdlibArgument("alphaEnable", ValueKind.Boolean)],
             returns: ValueKind.Void,
         },
-        impl: (_: Interpreter, alphaEnabled: BrsBoolean) => {
-            return this.setCanvasAlpha(alphaEnabled.toBoolean());
+        impl: (_: Interpreter, alphaEnable: BrsBoolean) => {
+            return this.setCanvasAlpha(alphaEnable.toBoolean());
         },
     });
 

--- a/src/brsTypes/components/RoScreen.ts
+++ b/src/brsTypes/components/RoScreen.ts
@@ -152,7 +152,6 @@ export class RoScreen extends BrsComponent implements BrsValue {
                     this.currentBuffer = 0;
                 }
             }
-            this.context[this.currentBuffer].clearRect(0, 0, this.width, this.height);
             return BrsInvalid.Instance;
         },
     });
@@ -226,9 +225,6 @@ export class RoScreen extends BrsComponent implements BrsValue {
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
             const didDraw = this.drawImage(object, rgba, 0, 0)
-            //ctx.rotate(-angleInRad);
-            //ctx.translate(-positionX, -positionY);
-            //ctx.globalAlpha = 1.0;
             ctx.restore()
             if (!didDraw) {
                 return BrsBoolean.False;

--- a/src/brsTypes/components/RoScreen.ts
+++ b/src/brsTypes/components/RoScreen.ts
@@ -11,7 +11,7 @@ import { RoMessagePort } from "./RoMessagePort";
 import { RoFont } from "./RoFont";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
-import { drawObjectToContext } from "../draw2d";
+import { drawImageToContext, drawObjectToContext } from "../draw2d";
 
 export class RoScreen extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -114,6 +114,12 @@ export class RoScreen extends BrsComponent implements BrsValue {
         const ctx = this.context[this.currentBuffer];
         return drawObjectToContext(ctx, this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
     }
+
+    drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
+        const ctx = this.context[this.currentBuffer];
+        return drawImageToContext(ctx, image, this.alphaEnable, x, y)
+    }
+
 
     setCanvasAlpha(enable: boolean) {
         this.alphaEnable = enable;

--- a/src/brsTypes/components/RoScreen.ts
+++ b/src/brsTypes/components/RoScreen.ts
@@ -63,7 +63,6 @@ export class RoScreen extends BrsComponent implements BrsValue {
             this.canvas[index] = new OffscreenCanvas(this.width, this.height);
             this.context[index] = this.canvas[index].getContext("2d", {
                 alpha: false,
-                willReadFrequently: true,
             }) as OffscreenCanvasRenderingContext2D;
             this.canvas[index].width = this.width;
             this.canvas[index].height = this.height;
@@ -217,12 +216,14 @@ export class RoScreen extends BrsComponent implements BrsValue {
             const positionX = x.getValue();
             const positionY = y.getValue();
             const angleInRad = (-theta.getValue() * Math.PI) / 180;
+            ctx.save()
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
             const didDraw = this.drawImage(object, rgba, 0, 0)
-            ctx.rotate(-angleInRad);
-            ctx.translate(-positionX, -positionY);
-            ctx.globalAlpha = 1.0;
+            //ctx.rotate(-angleInRad);
+            //ctx.translate(-positionX, -positionY);
+            //ctx.globalAlpha = 1.0;
+            ctx.restore()
             if (!didDraw) {
                 return BrsBoolean.False;
             }

--- a/src/brsTypes/components/RoScreen.ts
+++ b/src/brsTypes/components/RoScreen.ts
@@ -10,7 +10,7 @@ import { RoMessagePort } from "./RoMessagePort";
 import { RoFont } from "./RoFont";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
-import { drawImageToContext, drawObjectToContext, getDimensions, getDrawOffset } from "../draw2d";
+import { drawImageToContext, drawObjectToComponent } from "../draw2d";
 
 export class RoScreen extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -114,8 +114,7 @@ export class RoScreen extends BrsComponent implements BrsValue {
     }
 
     drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
-        const ctx = this.context[this.currentBuffer];
-        return drawObjectToContext(ctx, getDrawOffset(this), getDimensions(ctx.canvas), this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
+        return drawObjectToComponent(this, object, rgba, x, y, scaleX, scaleY);
     }
 
     drawImageToContext(image: OffscreenCanvas, x: number, y: number): boolean {
@@ -155,6 +154,7 @@ export class RoScreen extends BrsComponent implements BrsValue {
                     this.currentBuffer = 0;
                 }
             }
+            this.getContext().clearRect(0, 0, this.width, this.height)
             return BrsInvalid.Instance;
         },
     });

--- a/src/brsTypes/components/RoScreen.ts
+++ b/src/brsTypes/components/RoScreen.ts
@@ -11,6 +11,7 @@ import { RoMessagePort } from "./RoMessagePort";
 import { RoFont } from "./RoFont";
 import { RoByteArray } from "./RoByteArray";
 import UPNG from "upng-js";
+import { drawObjectToContext } from "../draw2d";
 
 export class RoScreen extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -62,6 +63,7 @@ export class RoScreen extends BrsComponent implements BrsValue {
             this.canvas[index] = new OffscreenCanvas(this.width, this.height);
             this.context[index] = this.canvas[index].getContext("2d", {
                 alpha: false,
+                willReadFrequently: true,
             }) as OffscreenCanvasRenderingContext2D;
             this.canvas[index].width = this.width;
             this.canvas[index].height = this.height;
@@ -109,21 +111,9 @@ export class RoScreen extends BrsComponent implements BrsValue {
         return BrsInvalid.Instance;
     }
 
-    drawImage(image: OffscreenCanvas, x: number, y: number) {
+    drawImage(object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
         const ctx = this.context[this.currentBuffer];
-        if (this.alphaEnable) {
-            ctx.drawImage(image, x, y);
-        } else {
-            const ctc = image.getContext("2d", {
-                alpha: true,
-            }) as OffscreenCanvasRenderingContext2D;
-            let imageData = ctc.getImageData(0, 0, image.width, image.height);
-            let pixels = imageData.data;
-            for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
-                pixels[i] = 255;
-            }
-            ctx.putImageData(imageData, x, y);
-        }
+        return drawObjectToContext(ctx, this.alphaEnable, object, rgba, x, y, scaleX, scaleY)
     }
 
     setCanvasAlpha(enable: boolean) {
@@ -194,35 +184,11 @@ export class RoScreen extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             const ctx = this.context[this.currentBuffer];
-            if (object instanceof RoBitmap) {
-                let cvs: OffscreenCanvas;
-                if (rgba instanceof Int32) {
-                    const alpha = rgba.getValue() & 255;
-                    if (alpha < 255) {
-                        ctx.globalAlpha = alpha / 255;
-                    }
-                    cvs = object.getRgbaCanvas(rgba.getValue());
-                } else {
-                    cvs = object.getCanvas();
-                }
-                if (cvs.width === 0 || cvs.height === 0) {
-                    return BrsBoolean.False;
-                }
-                this.drawImage(cvs, x.getValue(), y.getValue());
-            } else if (object instanceof RoRegion) {
-                let rcv = object.getRegionCanvas();
-                if (rcv.width === 0 || rcv.height === 0) {
-                    return BrsBoolean.False;
-                }
-                this.drawImage(
-                    rcv,
-                    x.getValue() + object.getTransX(),
-                    y.getValue() + object.getTransY()
-                );
-            } else {
+            const didDraw = this.drawImage(object, rgba, x.getValue(), y.getValue())
+            ctx.globalAlpha = 1.0;
+            if (!didDraw) {
                 return BrsBoolean.False;
             }
-            ctx.globalAlpha = 1.0;
             return BrsBoolean.True;
         },
     });
@@ -253,43 +219,13 @@ export class RoScreen extends BrsComponent implements BrsValue {
             const angleInRad = (-theta.getValue() * Math.PI) / 180;
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
-            if (object instanceof RoBitmap) {
-                let cvs: OffscreenCanvas;
-                if (rgba instanceof Int32) {
-                    const alpha = rgba.getValue() & 255;
-                    if (alpha < 255) {
-                        ctx.globalAlpha = alpha / 255;
-                    }
-                    cvs = object.getRgbaCanvas(rgba.getValue());
-                } else {
-                    cvs = object.getCanvas();
-                }
-                if (cvs.width === 0 || cvs.height === 0) {
-                    return BrsBoolean.False;
-                }
-                ctx.drawImage(cvs, 0, 0, cvs.width, cvs.height);
-            } else if (object instanceof RoRegion) {
-                let rcv = object.getRegionCanvas();
-                if (rcv.width === 0 || rcv.height === 0) {
-                    return BrsBoolean.False;
-                }
-                ctx.drawImage(
-                    rcv,
-                    object.getPosX(),
-                    object.getPosY(),
-                    object.getImageWidth(),
-                    object.getImageHeight(),
-                    object.getTransX(),
-                    object.getTransY(),
-                    object.getImageWidth(),
-                    object.getImageHeight()
-                );
-            } else {
-                return BrsBoolean.False;
-            }
+            const didDraw = this.drawImage(object, rgba, 0, 0)
             ctx.rotate(-angleInRad);
             ctx.translate(-positionX, -positionY);
             ctx.globalAlpha = 1.0;
+            if (!didDraw) {
+                return BrsBoolean.False;
+            }
             return BrsBoolean.True;
         },
     });
@@ -317,48 +253,12 @@ export class RoScreen extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             const ctx = this.context[this.currentBuffer];
-            if (object instanceof RoBitmap) {
-                let cvs: OffscreenCanvas;
-                if (rgba instanceof Int32) {
-                    const alpha = rgba.getValue() & 255;
-                    if (alpha < 255) {
-                        ctx.globalAlpha = alpha / 255;
-                    }
-                    cvs = object.getRgbaCanvas(rgba.getValue());
-                } else {
-                    cvs = object.getCanvas();
-                }
-                if (cvs.width === 0 || cvs.height === 0) {
-                    return BrsBoolean.False;
-                }
-                ctx.imageSmoothingEnabled = false;
-                ctx.drawImage(
-                    cvs,
-                    x.getValue(),
-                    y.getValue(),
-                    cvs.width * scaleX.getValue(),
-                    cvs.height * scaleY.getValue()
-                );
-            } else if (object instanceof RoRegion) {
-                let rcv = object.getRegionCanvas();
-                if (rcv.width === 0 || rcv.height === 0) {
-                    return BrsBoolean.False;
-                }
-                let tx = object.getTransX() * scaleX.getValue();
-                let ty = object.getTransY() * scaleY.getValue();
-                ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
-                ctx.drawImage(
-                    rcv,
-                    x.getValue() + tx,
-                    y.getValue() + ty,
-                    object.getImageWidth() * scaleX.getValue(),
-                    object.getImageHeight() * scaleY.getValue()
-                );
-            } else {
+            const didDraw = this.drawImage(object, rgba, x.getValue(), y.getValue(), scaleX.getValue(), scaleY.getValue())
+            ctx.globalAlpha = 1.0;
+            if (!didDraw) {
                 return BrsBoolean.False;
             }
-            ctx.globalAlpha = 1.0;
-            return BrsBoolean.True;
+            return BrsBoolean.True
         },
     });
 

--- a/src/brsTypes/components/RoSprite.ts
+++ b/src/brsTypes/components/RoSprite.ts
@@ -81,6 +81,10 @@ export class RoSprite extends BrsComponent implements BrsValue {
         return this.region.getImageData();
     }
 
+    getRegionObject(): RoRegion {
+        return this.region;
+    }
+
     getId(): number {
         return this.id;
     }

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -104,12 +104,8 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
         for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
             pixels[i] = 255;
         }
-        //ctx.scale(scaleX, scaleY);
         ctx.putImageData(imageData, x, y,);
-        //ctx.scale(1, 1);
     }
-
-
     return true;
 }
 

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -1,0 +1,111 @@
+import { BrsInvalid, RoBitmap, RoRegion } from ".";
+import { BrsComponent } from "./components/BrsComponent";
+import { Int32 } from "./Int32";
+
+export function setContextAlpha(ctx: OffscreenCanvasRenderingContext2D, rgba: Int32 | BrsInvalid) {
+    if (rgba instanceof Int32) {
+        const alpha = rgba.getValue() & 255;
+        if (alpha < 255) {
+            ctx.globalAlpha = alpha / 255;
+        }
+    }
+}
+
+
+export function getCanvasFromDraw2d(object: RoBitmap | RoRegion, rgba: Int32 | BrsInvalid): OffscreenCanvas {
+    let cvs: OffscreenCanvas;
+    if (rgba instanceof Int32) {
+        cvs = object.getRgbaCanvas(rgba.getValue());
+    } else {
+        cvs = object.getCanvas();
+    }
+    return cvs
+}
+
+
+export function isCanvasValid(cvs?: OffscreenCanvas): boolean {
+    if (!cvs) {
+        return false;
+    }
+    const sizeOk = !!(cvs.height && cvs.height >= 1 && cvs.width && cvs.width >= 1);
+    return sizeOk;
+}
+
+export function getSourceOffset(object: RoBitmap | RoRegion): { x: number, y: number } {
+    let x = 0, y = 0;
+    if (object instanceof RoRegion) {
+        x = object.getPosX();
+        y = object.getPosY();
+    }
+    return { x, y }
+}
+
+export function getPreTranslation(object: RoBitmap | RoRegion): { x: number, y: number } {
+    let x = 0, y = 0;
+    if (object instanceof RoRegion) {
+        x = object.getTransX();
+        y = object.getTransY();
+    }
+    return { x, y }
+}
+
+
+export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alphaEnable: boolean, object: BrsComponent, rgba: Int32 | BrsInvalid, x: number, y: number, scaleX: number = 1, scaleY: number = 1): boolean {
+    let image: OffscreenCanvas;
+    if (object instanceof RoBitmap || object instanceof RoRegion) {
+        image = getCanvasFromDraw2d(object, rgba)
+    } else {
+        return false;
+    }
+    if (!isCanvasValid(image)) {
+        return false
+    }
+    const offset = getSourceOffset(object);
+    const preTrans = getPreTranslation(object);
+    const tx = preTrans.x * scaleX;
+    const ty = preTrans.y * scaleY;
+    const sx = offset.x + tx;
+    const sy = offset.y + ty;
+    const sw = object.getImageWidth();
+    const sh = object.getImageHeight();
+
+    if (object instanceof RoRegion) {
+        ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
+    }
+    if (alphaEnable) {
+        ctx.drawImage(
+            image,
+            sx,
+            sy,
+            sw,
+            sh,
+            x + preTrans.x,
+            y + preTrans.y,
+            sw * scaleX,
+            sh * scaleY
+        );
+    } else {
+        const ctc = image.getContext("2d", {
+            alpha: true,
+        }) as OffscreenCanvasRenderingContext2D;
+        let imageData = ctc.getImageData(sx, sy, sw, sh);
+        let pixels = imageData.data;
+        for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
+            pixels[i] = 255;
+        }
+        ctx.scale(scaleX, scaleY);
+        ctx.putImageData(imageData, x, y,);
+        ctx.scale(1, 1);
+    }
+    return true;
+}
+
+
+export function drawImageToContext(ctx: OffscreenCanvasRenderingContext2D, image: OffscreenCanvas, x: number, y: number): boolean {
+    if (!isCanvasValid(image)) {
+        return false
+    }
+    ctx.drawImage(image, x, y);
+
+    return true;
+}

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -79,33 +79,34 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
     else {
         ctx.imageSmoothingEnabled = false
     }
-    if (alphaEnable) {
-        // ctx.clearRect(dx, dy, sw * scaleX, sh * scaleY);
-        // }
-        ctx.drawImage(
-            image,
-            sx,
-            sy,
-            sw,
-            sh,
-            dx,
-            dy,
-            sw * scaleX,
-            sh * scaleY
-        );
-    } else {
-        // This code seems slower - it is the "original" non-alpha code
-
-        const ctc = image.getContext("2d", {
-            alpha: true,
-        }) as OffscreenCanvasRenderingContext2D;
-        let imageData = ctc.getImageData(sx, sy, sw, sh);
-        let pixels = imageData.data;
-        for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
-            pixels[i] = 255;
-        }
-        ctx.putImageData(imageData, x, y,);
+    if (!alphaEnable) {
+        ctx.clearRect(dx, dy, sw * scaleX, sh * scaleY);
     }
+
+    ctx.drawImage(
+        image,
+        sx,
+        sy,
+        sw,
+        sh,
+        dx,
+        dy,
+        sw * scaleX,
+        sh * scaleY
+    );
+
+    // This code seems slower - it is the "original" non-alpha code
+    /*
+    const ctc = image.getContext("2d", {
+        alpha: true,
+    }) as OffscreenCanvasRenderingContext2D;
+    let imageData = ctc.getImageData(sx, sy, sw, sh);
+    let pixels = imageData.data;
+    for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
+        pixels[i] = 255;
+    }
+    ctx.putImageData(imageData, x, y,);
+    */
     return true;
 }
 
@@ -114,18 +115,22 @@ export function drawImageToContext(ctx: OffscreenCanvasRenderingContext2D, image
     if (!isCanvasValid(image)) {
         return false;
     }
-    if (alphaEnable) {
-        ctx.drawImage(image, x, y);
-    } else {
-        const ctc = image.getContext("2d", {
-            alpha: true,
-        }) as OffscreenCanvasRenderingContext2D;
-        let imageData = ctc.getImageData(0, 0, image.width, image.height);
-        let pixels = imageData.data;
-        for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
-            pixels[i] = 255;
-        }
-        ctx.putImageData(imageData, x, y);
+    if (!alphaEnable) {
+        ctx.clearRect(x, y, image.width, image.height);
     }
+    ctx.drawImage(image, x, y);
+
+    //Old Non-Alpha Way (slow)
+    /*const ctc = image.getContext("2d", {
+        alpha: true,
+    }) as OffscreenCanvasRenderingContext2D;
+    let imageData = ctc.getImageData(0, 0, image.width, image.height);
+    let pixels = imageData.data;
+    for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
+        pixels[i] = 255;
+    }
+    ctx.putImageData(imageData, x, y);
+    */
+
     return true;
 }

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -89,5 +89,19 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
         sw * scaleX,
         sh * scaleY
     );
+    // This code seems slower - it is the "original" non-alpha code
+    /*
+    const ctc = image.getContext("2d", {
+        alpha: true,
+    }) as OffscreenCanvasRenderingContext2D;
+    let imageData = ctc.getImageData(sx, sy, sw, sh);
+    let pixels = imageData.data;
+    for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
+        pixels[i] = 255;
+    }
+    ctx.scale(scaleX, scaleY);
+    ctx.putImageData(imageData, x, y,);
+    ctx.scale(1, 1);
+    */
     return true;
 }

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -54,6 +54,7 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
     let image: OffscreenCanvas;
     if (object instanceof RoBitmap || object instanceof RoRegion) {
         image = getCanvasFromDraw2d(object, rgba)
+        setContextAlpha(ctx, rgba)
     } else {
         return false;
     }
@@ -75,33 +76,60 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
     if (object instanceof RoRegion) {
         ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
     }
-    if (!alphaEnable) {
-        ctx.clearRect(dx, dy, sw * scaleX, sh * scaleY);
+    else {
+        ctx.imageSmoothingEnabled = false
     }
-    ctx.drawImage(
-        image,
-        sx,
-        sy,
-        sw,
-        sh,
-        dx,
-        dy,
-        sw * scaleX,
-        sh * scaleY
-    );
-    // This code seems slower - it is the "original" non-alpha code
-    /*
-    const ctc = image.getContext("2d", {
-        alpha: true,
-    }) as OffscreenCanvasRenderingContext2D;
-    let imageData = ctc.getImageData(sx, sy, sw, sh);
-    let pixels = imageData.data;
-    for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
-        pixels[i] = 255;
+    if (alphaEnable) {
+        // ctx.clearRect(dx, dy, sw * scaleX, sh * scaleY);
+        // }
+        ctx.drawImage(
+            image,
+            sx,
+            sy,
+            sw,
+            sh,
+            dx,
+            dy,
+            sw * scaleX,
+            sh * scaleY
+        );
+    } else {
+        // This code seems slower - it is the "original" non-alpha code
+
+        const ctc = image.getContext("2d", {
+            alpha: true,
+        }) as OffscreenCanvasRenderingContext2D;
+        let imageData = ctc.getImageData(sx, sy, sw, sh);
+        let pixels = imageData.data;
+        for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
+            pixels[i] = 255;
+        }
+        //ctx.scale(scaleX, scaleY);
+        ctx.putImageData(imageData, x, y,);
+        //ctx.scale(1, 1);
     }
-    ctx.scale(scaleX, scaleY);
-    ctx.putImageData(imageData, x, y,);
-    ctx.scale(1, 1);
-    */
+
+
+    return true;
+}
+
+
+export function drawImageToContext(ctx: OffscreenCanvasRenderingContext2D, image: OffscreenCanvas, alphaEnable: boolean, x: number, y: number): boolean {
+    if (!isCanvasValid(image)) {
+        return false;
+    }
+    if (alphaEnable) {
+        ctx.drawImage(image, x, y);
+    } else {
+        const ctc = image.getContext("2d", {
+            alpha: true,
+        }) as OffscreenCanvasRenderingContext2D;
+        let imageData = ctc.getImageData(0, 0, image.width, image.height);
+        let pixels = imageData.data;
+        for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
+            pixels[i] = 255;
+        }
+        ctx.putImageData(imageData, x, y);
+    }
     return true;
 }

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -75,9 +75,8 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
 
     if (object instanceof RoRegion) {
         ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
-    }
-    else {
-        ctx.imageSmoothingEnabled = false
+    } else {
+        ctx.imageSmoothingEnabled = false;
     }
     if (!alphaEnable) {
         ctx.clearRect(dx, dy, sw * scaleX, sh * scaleY);

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -134,20 +134,16 @@ function getDrawChunks(ctx: OffscreenCanvasRenderingContext2D, destOffset: DrawO
 
     if (missingHorizontal > 0) {
         // missing right chunk
-
-        chunks.push({ sx: 0, sy: offset.y, sw: missingHorizontal, sh: actualDrawHeight, dx: Math.max(actualDrawWidth, dx), dy, dw: missingHorizontal, dh: actualDrawHeight })
+        chunks.push({ sx: 0, sy: offset.y, sw: missingHorizontal, sh: actualDrawHeight, dx: actualDrawWidth + dx, dy, dw: missingHorizontal, dh: actualDrawHeight })
     }
-    /* if (cutOffOnBottom > 0) {
-         // bottom chunk that wrapped to top
-         chunks.push({ sx: 0, sy: offset.y, sw: missingHorizontal, sh: actualDrawHeight, dx: dw, dy, dw: missingHorizontal, dh: actualDrawHeight })
-
-         //chunks.push({ sx, sy: bottomWrapSy, sw: sourceKeepRW, sh: bottomWrapSh, dx, dy: destOffset.y, dw: destKeepRW, dh: cutOffOnBottom })
-     }
-     if (cutOffOnRight > 0 && cutOffOnBottom > 0) {
-         // bottom/right chunk that wrapped to top/left
-         chunks.push({ sx: rightWrapSx, sy: bottomWrapSy, sw: rightWrapSw, sh: bottomWrapSh, dx: destOffset.x, dy: destOffset.y, dw: cutOffOnRight, dh: cutOffOnBottom });
-     }
- */
+    if (missingVertical > 0) {
+        // missing bottom chunk
+        chunks.push({ sx: offset.x, sy: 0, sw: actualDrawWidth, sh: missingVertical, dx: dx, dy: actualDrawHeight + dy, dw: actualDrawWidth, dh: missingVertical })
+    }
+    if (missingHorizontal > 0 && missingVertical > 0) {
+        // missing bottom/right chunk
+        chunks.push({ sx: 0, sy: 0, sw: missingHorizontal, sh: missingVertical, dx: actualDrawWidth + dx, dy: actualDrawHeight + dy, dw: missingHorizontal, dh: missingVertical });
+    }
     return chunks;
 }
 

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -72,19 +72,22 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
     if (object instanceof RoRegion) {
         ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
     }
-    if (alphaEnable) {
-        ctx.drawImage(
-            image,
-            sx,
-            sy,
-            sw,
-            sh,
-            x + preTrans.x,
-            y + preTrans.y,
-            sw * scaleX,
-            sh * scaleY
-        );
-    } else {
+    if (!alphaEnable) {
+        ctx.clearRect(x + preTrans.x, y + preTrans.y, sw * scaleX, sh * scaleY);
+    }
+    ctx.drawImage(
+        image,
+        sx,
+        sy,
+        sw,
+        sh,
+        x + preTrans.x,
+        y + preTrans.y,
+        sw * scaleX,
+        sh * scaleY
+    );
+
+    /*else {
         const ctc = image.getContext("2d", {
             alpha: true,
         }) as OffscreenCanvasRenderingContext2D;
@@ -96,7 +99,7 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
         ctx.scale(scaleX, scaleY);
         ctx.putImageData(imageData, x, y,);
         ctx.scale(1, 1);
-    }
+    }*/
     return true;
 }
 

--- a/src/brsTypes/draw2d.ts
+++ b/src/brsTypes/draw2d.ts
@@ -64,16 +64,19 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
     const preTrans = getPreTranslation(object);
     const tx = preTrans.x * scaleX;
     const ty = preTrans.y * scaleY;
-    const sx = offset.x + tx;
-    const sy = offset.y + ty;
+    const sx = offset.x;
+    const sy = offset.y;
     const sw = object.getImageWidth();
     const sh = object.getImageHeight();
+
+    const dx = x + tx;
+    const dy = y + ty;
 
     if (object instanceof RoRegion) {
         ctx.imageSmoothingEnabled = object.getRegionScaleMode() === 1;
     }
     if (!alphaEnable) {
-        ctx.clearRect(x + preTrans.x, y + preTrans.y, sw * scaleX, sh * scaleY);
+        ctx.clearRect(dx, dy, sw * scaleX, sh * scaleY);
     }
     ctx.drawImage(
         image,
@@ -81,34 +84,10 @@ export function drawObjectToContext(ctx: OffscreenCanvasRenderingContext2D, alph
         sy,
         sw,
         sh,
-        x + preTrans.x,
-        y + preTrans.y,
+        dx,
+        dy,
         sw * scaleX,
         sh * scaleY
     );
-
-    /*else {
-        const ctc = image.getContext("2d", {
-            alpha: true,
-        }) as OffscreenCanvasRenderingContext2D;
-        let imageData = ctc.getImageData(sx, sy, sw, sh);
-        let pixels = imageData.data;
-        for (let i = 3, n = image.width * image.height * 4; i < n; i += 4) {
-            pixels[i] = 255;
-        }
-        ctx.scale(scaleX, scaleY);
-        ctx.putImageData(imageData, x, y,);
-        ctx.scale(1, 1);
-    }*/
-    return true;
-}
-
-
-export function drawImageToContext(ctx: OffscreenCanvasRenderingContext2D, image: OffscreenCanvas, x: number, y: number): boolean {
-    if (!isCanvasValid(image)) {
-        return false
-    }
-    ctx.drawImage(image, x, y);
-
     return true;
 }


### PR DESCRIPTION
Changes:
 - Refactored much of the "drawing an image to the canvas" code so that it all uses the same function
 - Changed the "AlphaDisabled" code to NOT use `GetImageData()` (this was slow!)
 - Changed some canvas context changes to use `save()` / `restore()`
 - Removed the concept of a region owning its own canvas - draws to a region will draw to the parent bitmap's canvas
 - Added pressing "8" as "info" --- "Command+8" in chrome opens the 8th tab ☹️
 

In particular, these changes increase the speed of certain operations:
 - Drawing To a non-alpha enabled canvas increased ~30x increase
 - Creating Regions ~ 6x increase
 - Drawing to Regions ~12x increase 