### PR TITLE
Added support for interfaces `ifGetArray` and `ifSetArray`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jpeg-js": "^0.4.4",
     "jszip": "^3.10.1",
     "libwebpjs": "lvcabral/libwebpjs",
-    "linked-list-typescript": "^1.0.15",
     "long": "^3.2.0",
     "luxon": "^1.8.3",
     "memory-fs": "^0.5.0",

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -82,7 +82,7 @@ function sortCompare(
 
 export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
-    private elements: BrsType[];
+    elements: BrsType[];
 
     constructor(elements: BrsType[]) {
         super("roArray");
@@ -99,6 +99,8 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
                 this.clear,
                 this.append,
             ],
+            // ifArrayGet: [this.getEntry],
+            // ifArraySet: [this.setEntry],
             ifArrayJoin: [this.join],
             ifArraySort: [this.sort, this.sortBy, this.reverse],
             ifEnum: [this.isEmpty],

--- a/src/brsTypes/components/RoArray.ts
+++ b/src/brsTypes/components/RoArray.ts
@@ -1,9 +1,8 @@
+import { BrsType, isBrsString, isBrsNumber, Int32 } from "..";
 import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid, Comparable } from "../BrsType";
-import { BrsType, isBrsString, isBrsNumber, isBrsBoolean } from "..";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
-import { Int32 } from "../Int32";
 import { RoAssociativeArray } from "./RoAssociativeArray";
 
 /**
@@ -28,7 +27,7 @@ function getTypeSortIndex(a: BrsType): number {
 }
 
 /**
- * Sorts two BrsTypes in the order that ROku would sort them
+ * Sorts two BrsTypes in the order that Roku would sort them
  * @param originalArray A copy of the original array. Used to get the order of items
  * @param a
  * @param b
@@ -99,8 +98,8 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
                 this.clear,
                 this.append,
             ],
-            // ifArrayGet: [this.getEntry],
-            // ifArraySet: [this.setEntry],
+            ifArrayGet: [this.getEntry],
+            ifArraySet: [this.setEntry],
             ifArrayJoin: [this.join],
             ifArraySort: [this.sort, this.sortBy, this.reverse],
             ifEnum: [this.isEmpty],
@@ -141,20 +140,45 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             case ValueKind.String:
                 return this.getMethod(index.value) || BrsInvalid.Instance;
             default:
-                throw new Error(
-                    "Array indexes must be 32-bit integers, or method names must be strings"
+                postMessage(
+                    "warning,Array indexes must be 32-bit integers, or method names must be strings."
                 );
+                return BrsInvalid.Instance;
         }
     }
 
     set(index: BrsType, value: BrsType) {
-        if (index.kind !== ValueKind.Int32 && index.kind !== ValueKind.Float) {
-            throw new Error("Array indexes must be 32-bit integers");
+        if (index.kind === ValueKind.Int32 || index.kind === ValueKind.Float) {
+            this.elements[Math.trunc(index.getValue())] = value;
+        } else {
+            postMessage("warning,Array indexes must be 32-bit integers.");
         }
-
-        this.elements[Math.trunc(index.getValue())] = value;
-
         return BrsInvalid.Instance;
+    }
+
+    aaCompare(
+        fieldName: BrsString,
+        flags: BrsString,
+        a: RoAssociativeArray,
+        b: RoAssociativeArray
+    ) {
+        let compare = 0;
+        const originalArrayCopy = [...this.elements];
+        const caseInsensitive = flags.toString().indexOf("i") > -1;
+        const aHasField = a.elements.has(fieldName.toString().toLowerCase());
+        const bHasField = b.elements.has(fieldName.toString().toLowerCase());
+        if (aHasField && bHasField) {
+            const valueA = a.get(fieldName);
+            const valueB = b.get(fieldName);
+            compare = sortCompare(originalArrayCopy, valueA, valueB, caseInsensitive);
+        } else if (aHasField) {
+            // assocArray with fields come before assocArrays without
+            compare = -1;
+        } else if (bHasField) {
+            // assocArray with fields come before assocArrays without
+            compare = 1;
+        }
+        return compare;
     }
 
     private peek = new Callable("peek", {
@@ -264,6 +288,35 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             return BrsInvalid.Instance;
         },
     });
+
+    // ifArrayGet
+    private getEntry = new Callable("getEntry", {
+        signature: {
+            args: [new StdlibArgument("index", ValueKind.Dynamic)],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (_: Interpreter, index: BrsType) => {
+            if (index.kind === ValueKind.Int32 || index.kind === ValueKind.Float) {
+                return this.elements[Math.trunc(index.getValue())] || BrsInvalid.Instance;
+            }
+            return BrsInvalid.Instance;
+        },
+    });
+
+    // ifArraySet
+    private setEntry = new Callable("setEntry", {
+        signature: {
+            args: [
+                new StdlibArgument("index", ValueKind.Dynamic),
+                new StdlibArgument("tvalue", ValueKind.Dynamic),
+            ],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, index: BrsType, tvalue: BrsType) => {
+            return this.set(index, tvalue);
+        },
+    });
+
     // ifArrayJoin
     private join = new Callable("join", {
         signature: {
@@ -317,29 +370,11 @@ export class RoArray extends BrsComponent implements BrsValue, BrsIterable {
             if (flags.toString().match(/([^ir])/g) != null) {
                 postMessage("warning,roArray.SortBy: Flags contains invalid option(s).");
             } else {
-                const caseInsensitive = flags.toString().indexOf("i") > -1;
                 const originalArrayCopy = [...this.elements];
                 this.elements = this.elements.sort((a, b) => {
                     let compare = 0;
                     if (a instanceof RoAssociativeArray && b instanceof RoAssociativeArray) {
-                        const aHasField = a.elements.has(fieldName.toString().toLowerCase());
-                        const bHasField = b.elements.has(fieldName.toString().toLowerCase());
-                        if (aHasField && bHasField) {
-                            const valueA = a.get(fieldName);
-                            const valueB = b.get(fieldName);
-                            compare = sortCompare(
-                                originalArrayCopy,
-                                valueA,
-                                valueB,
-                                caseInsensitive
-                            );
-                        } else if (aHasField) {
-                            // assocArray with fields come before assocArrays without
-                            compare = -1;
-                        } else if (bHasField) {
-                            // assocArray with fields come before assocArrays without
-                            compare = 1;
-                        }
+                        compare = this.aaCompare(fieldName, flags, a, b);
                     } else if (a !== undefined && b !== undefined) {
                         compare = sortCompare(originalArrayCopy, a, b, false, false);
                     }

--- a/src/brsTypes/components/RoByteArray.ts
+++ b/src/brsTypes/components/RoByteArray.ts
@@ -44,6 +44,8 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
                 this.clear,
                 this.append,
             ],
+            // ifArrayGet: [this.getEntry],
+            // ifArraySet: [this.setEntry],
             ifEnum: [this.isEmpty],
         });
     }

--- a/src/brsTypes/components/RoByteArray.ts
+++ b/src/brsTypes/components/RoByteArray.ts
@@ -1,9 +1,8 @@
+import { BrsType, Int32 } from "..";
 import { BrsValue, ValueKind, BrsBoolean, BrsInvalid, BrsString } from "../BrsType";
-import { BrsType } from "..";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
-import { Int32 } from "../Int32";
 import { crc32 } from "crc";
 
 export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
@@ -44,8 +43,8 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
                 this.clear,
                 this.append,
             ],
-            // ifArrayGet: [this.getEntry],
-            // ifArraySet: [this.setEntry],
+            ifArrayGet: [this.getEntry],
+            ifArraySet: [this.setEntry],
             ifEnum: [this.isEmpty],
         });
     }
@@ -83,24 +82,28 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
 
     get(index: BrsType) {
         switch (index.kind) {
+            case ValueKind.Float:
+                return this.getElements()[Math.trunc(index.getValue())] || BrsInvalid.Instance;
             case ValueKind.Int32:
                 return this.getElements()[index.getValue()] || BrsInvalid.Instance;
             case ValueKind.String:
                 return this.getMethod(index.value) || BrsInvalid.Instance;
             default:
-                throw new Error(
-                    "Array indexes must be 32-bit integers, or method names must be strings"
+                postMessage(
+                    "warning,Array indexes must be 32-bit integers, or method names must be strings"
                 );
+                return BrsInvalid.Instance;
         }
     }
 
     set(index: BrsType, value: BrsType) {
-        if (index.kind !== ValueKind.Int32) {
-            throw new Error("Array indexes must be 32-bit integers");
+        if (index.kind !== ValueKind.Int32 && index.kind !== ValueKind.Float) {
+            postMessage("warning,Array indexes must be 32-bit integers.");
         } else if (value.kind !== ValueKind.Int32) {
-            throw new Error("Byte array values must be 32-bit integers");
+            postMessage("warning,Byte array values must be 32-bit integers");
+        } else {
+            this.elements[Math.trunc(index.getValue())] = value.getValue();
         }
-        this.elements[index.getValue()] = value.getValue();
         return BrsInvalid.Instance;
     }
 
@@ -217,7 +220,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("asciiStr", ValueKind.String)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, asciiStr: BrsString) => {
+        impl: (_: Interpreter, asciiStr: BrsString) => {
             this.elements = new Uint8Array(Buffer.from(asciiStr.value, "utf8"));
             return BrsInvalid.Instance;
         },
@@ -228,7 +231,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return new BrsString(Buffer.from(this.elements).toString("utf8"));
         },
     });
@@ -238,7 +241,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("hexStr", ValueKind.String)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, hexStr: BrsString) => {
+        impl: (_: Interpreter, hexStr: BrsString) => {
             const regex = new RegExp("[^a-f0-9]", "gi");
             const value = hexStr.value.replace(regex, "0");
             if (value.length % 2 === 0) {
@@ -253,7 +256,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             const hex = Buffer.from(this.elements).toString("hex");
             return new BrsString(hex.toUpperCase());
         },
@@ -264,7 +267,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("hexStr", ValueKind.String)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, hexStr: BrsString) => {
+        impl: (_: Interpreter, hexStr: BrsString) => {
             this.elements = new Uint8Array(Buffer.from(hexStr.value, "base64"));
             return BrsInvalid.Instance;
         },
@@ -275,7 +278,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return new BrsString(Buffer.from(this.elements).toString("base64"));
         },
     });
@@ -285,7 +288,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("index", ValueKind.Int32)],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter, index: Int32) => {
+        impl: (_: Interpreter, index: Int32) => {
             let byte = (this.elements[index.getValue()] << 24) >> 24;
             return new Int32(byte);
         },
@@ -296,7 +299,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("index", ValueKind.Int32)],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter, index: Int32) => {
+        impl: (_: Interpreter, index: Int32) => {
             const dataView = new DataView(this.elements.buffer, index.getValue(), 4);
             const long = dataView.getInt32(0, true);
             return new Int32(long);
@@ -311,7 +314,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             ],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter, index: Int32, length: Int32) => {
+        impl: (_: Interpreter, index: Int32, length: Int32) => {
             if (index.getValue() > 0 || length.getValue() > 0) {
                 let start = index.getValue();
                 let end = length.getValue() < 1 ? undefined : start + length.getValue();
@@ -329,7 +332,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             ],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, minSize: Int32, autoResize: BrsBoolean) => {
+        impl: (_: Interpreter, minSize: Int32, autoResize: BrsBoolean) => {
             this.resize = autoResize.toBoolean();
             // TODO: Resize byte array if length < minSize
             return BrsInvalid.Instance;
@@ -341,7 +344,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return BrsBoolean.True;
         },
     });
@@ -353,7 +356,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return new Int32(this.elements[this.elements.length - 1]) || BrsInvalid.Instance;
         },
     });
@@ -363,7 +366,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             const pop = new Int32(this.elements[this.elements.length - 1]) || BrsInvalid.Instance;
             // TODO: Remove last item from byte array (check how to behave with resize=true)
             return pop;
@@ -375,7 +378,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("byte", ValueKind.Int32)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, byte: Int32) => {
+        impl: (_: Interpreter, byte: Int32) => {
             let array = new Uint8Array(this.elements.length + 1);
             array.set(this.elements, 0);
             array[this.elements.length] = byte.getValue();
@@ -389,7 +392,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             const shift = new Int32(this.elements[0]) || BrsInvalid.Instance;
             // TODO: Remove first item from byte array (check how to behave with resize=true)
             return shift;
@@ -401,7 +404,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("tvalue", ValueKind.Dynamic)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, byte: Int32) => {
+        impl: (_: Interpreter, byte: Int32) => {
             let array = new Uint8Array(this.elements.length + 1);
             array[0] = byte.getValue();
             array.set(this.elements, 1);
@@ -415,7 +418,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("index", ValueKind.Int32)],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, index: Int32) => {
+        impl: (_: Interpreter, index: Int32) => {
             if (index.lessThan(new Int32(0)).toBoolean()) {
                 return BrsBoolean.False;
             }
@@ -429,7 +432,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return new Int32(this.elements.length);
         },
     });
@@ -439,7 +442,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             this.elements = new Uint8Array();
             return BrsInvalid.Instance;
         },
@@ -450,7 +453,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("array", ValueKind.Object)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, array: BrsComponent) => {
+        impl: (_: Interpreter, array: BrsComponent) => {
             if (!(array instanceof RoByteArray)) {
                 // TODO: validate against RBI
                 return BrsInvalid.Instance;
@@ -467,6 +470,36 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 
+    // ifArrayGet -------------------------------------------------------------------------
+
+    private getEntry = new Callable("getEntry", {
+        signature: {
+            args: [new StdlibArgument("index", ValueKind.Dynamic)],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (_: Interpreter, index: BrsType) => {
+            if (index.kind === ValueKind.Int32 || index.kind === ValueKind.Float) {
+                return this.getElements()[Math.trunc(index.getValue())] || BrsInvalid.Instance;
+            }
+            return BrsInvalid.Instance;
+        },
+    });
+
+    // ifArraySet  -------------------------------------------------------------------------
+
+    private setEntry = new Callable("setEntry", {
+        signature: {
+            args: [
+                new StdlibArgument("index", ValueKind.Dynamic),
+                new StdlibArgument("tvalue", ValueKind.Dynamic),
+            ],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, index: BrsType, tvalue: BrsType) => {
+            return this.set(index, tvalue);
+        },
+    });
+
     // ifEnum -------------------------------------------------------------------------
 
     private isEmpty = new Callable("isEmpty", {
@@ -474,7 +507,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             return BrsBoolean.from(this.elements.length === 0);
         },
     });

--- a/src/brsTypes/components/RoCompositor.ts
+++ b/src/brsTypes/components/RoCompositor.ts
@@ -76,7 +76,7 @@ export class RoCompositor extends BrsComponent implements BrsValue {
             });
         });
         if (animation) {
-            this.animations.some( (sprite, index, object) => {
+            this.animations.some((sprite, index, object) => {
                 if (sprite.getId() === id) {
                     object.splice(index, 1);
                     return true; // break

--- a/src/brsTypes/components/RoXMLList.ts
+++ b/src/brsTypes/components/RoXMLList.ts
@@ -1,20 +1,19 @@
 import { BrsValue, ValueKind, BrsBoolean, BrsInvalid, BrsString } from "../BrsType";
-import { BrsType } from "..";
+import { BrsType, RoList } from "..";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
-import { LinkedList } from "linked-list-typescript";
 import { RoArray } from "./RoArray";
 import { RoXMLElement } from "./RoXMLElement";
 
 export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
-    private elements: LinkedList<RoXMLElement>;
+    private roList: RoList;
 
     constructor() {
         super("roXMLList");
-        this.elements = new LinkedList<RoXMLElement>();
+        this.roList = new RoList();
         this.registerMethods({
             ifXMLList: [
                 this.getAttributes,
@@ -33,8 +32,12 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
                 this.removeTail,
                 this.count,
                 this.clear,
-                // this.resetIndex,
+                this.resetIndex,
+                this.getIndex,
+                this.removeIndex,
             ],
+            // ifArrayGet: [this.getEntry],
+            // ifArraySet: [this.setEntry],
             ifEnum: [this.isEmpty],
             ifListToArray: [this.toArray],
         });
@@ -48,7 +51,7 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
         return [
             "<Component: roXMLList> =",
             "(",
-            ...this.elements.toArray().map((el: BrsValue) => `    ${el.toString(this)}`),
+            ...this.roList.elements.map((el: BrsValue) => `    ${el.toString(this)}`),
             ")",
         ].join("\n");
     }
@@ -58,19 +61,19 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
     }
 
     getValue() {
-        return this.elements;
+        return this.roList.elements;
     }
 
     getElements() {
-        return this.elements.toArray().slice();
+        return this.roList.elements.slice();
     }
 
     getAttribute(index: BrsType) {
         if (index.kind !== ValueKind.String) {
             throw new Error("XML Element attribute must be strings");
         }
-        if (this.elements.length === 1) {
-            let xmlElm = this.elements.head;
+        if (this.length() === 1) {
+            let xmlElm = this.roList.elements[0];
             if (xmlElm instanceof RoXMLElement) {
                 return xmlElm.getAttribute(index);
             }
@@ -97,23 +100,16 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
         if (index.kind !== ValueKind.Int32 && index.kind !== ValueKind.Float) {
             throw new Error("List indexes must be 32-bit integers");
         }
-        let current = 0;
-        for (let item of this.elements) {
-            if (Math.trunc(index.getValue()) === current) {
-                item = value as RoXMLElement;
-                break;
-            }
-            current++;
-        }
+        this.roList.elements[Math.trunc(index.getValue())] = value;
         return BrsInvalid.Instance;
     }
 
     add(element: RoXMLElement) {
-        this.elements.append(element);
+        this.roList.add(element);
     }
 
     length() {
-        return this.elements.length;
+        return this.roList.length();
     }
 
     namedElements(name: string, ci: boolean) {
@@ -121,11 +117,11 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             name = name.toLocaleLowerCase();
         }
         let elements = new RoXMLList();
-        let xmlElm = this.elements.head;
+        let xmlElm = this.roList.elements[0];
         if (xmlElm instanceof RoXMLElement) {
             let childElm = xmlElm.childElements();
             for (let index = 0; index < childElm.length(); index++) {
-                const element = childElm.getElements()[index];
+                const element = childElm.getElements()[index] as RoXMLElement;
                 let key: string;
                 if (ci) {
                     key = element.name().value.toLocaleLowerCase();
@@ -147,9 +143,9 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter) => {
-            if (this.elements.length === 1) {
-                let xmlElm = this.elements.head;
+        impl: (_: Interpreter) => {
+            if (this.length() === 1) {
+                let xmlElm = this.roList.elements[0];
                 if (xmlElm instanceof RoXMLElement) {
                     return xmlElm.attributes();
                 }
@@ -164,9 +160,9 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            if (this.elements.length === 1) {
-                let xmlElm = this.elements.head;
+        impl: (_: Interpreter) => {
+            if (this.length() === 1) {
+                let xmlElm = this.roList.elements[0];
                 if (xmlElm instanceof RoXMLElement) {
                     return xmlElm.text();
                 }
@@ -181,9 +177,9 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter) => {
-            if (this.elements.length === 1) {
-                let xmlElm = this.elements.head;
+        impl: (_: Interpreter) => {
+            if (this.length() === 1) {
+                let xmlElm = this.roList.elements[0];
                 if (xmlElm instanceof RoXMLElement) {
                     return xmlElm.childElements();
                 }
@@ -198,7 +194,7 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("name", ValueKind.String)],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter, name: BrsString) => {
+        impl: (_: Interpreter, name: BrsString) => {
             return this.namedElements(name.value, false);
         },
     });
@@ -209,7 +205,7 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("name", ValueKind.String)],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter, name: BrsString) => {
+        impl: (_: Interpreter, name: BrsString) => {
             return this.namedElements(name.value, true);
         },
     });
@@ -220,9 +216,9 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter) => {
-            if (this.elements.length === 1) {
-                return this.elements.head;
+        impl: (_: Interpreter) => {
+            if (this.length() === 1) {
+                return this.roList.elements[0];
             }
             return this;
         },
@@ -236,8 +232,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("tvalue", ValueKind.Dynamic)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, tvalue: RoXMLElement) => {
-            this.elements.prepend(tvalue);
+        impl: (_: Interpreter, tvalue: RoXMLElement) => {
+            this.roList.add(tvalue, false);
             return BrsInvalid.Instance;
         },
     });
@@ -248,8 +244,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [new StdlibArgument("talue", ValueKind.Dynamic)],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter, tvalue: RoXMLElement) => {
-            this.elements.append(tvalue);
+        impl: (_: Interpreter, tvalue: RoXMLElement) => {
+            this.roList.add(tvalue, true);
             return BrsInvalid.Instance;
         },
     });
@@ -260,8 +256,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
-            return this.elements.head || BrsInvalid.Instance;
+        impl: (_: Interpreter) => {
+            return this.roList.elements[0] || BrsInvalid.Instance;
         },
     });
 
@@ -271,8 +267,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
-            return this.elements.tail || BrsInvalid.Instance;
+        impl: (_: Interpreter) => {
+            return this.roList.elements[this.roList.tail()] || BrsInvalid.Instance;
         },
     });
 
@@ -282,8 +278,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
-            return this.elements.removeHead() || BrsInvalid.Instance;
+        impl: (_: Interpreter) => {
+            return this.roList.remove(0) || BrsInvalid.Instance;
         },
     });
 
@@ -293,8 +289,42 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (interpreter: Interpreter) => {
-            return this.elements.removeTail() || BrsInvalid.Instance;
+        impl: (_: Interpreter) => {
+            return this.roList.remove(this.roList.tail()) || BrsInvalid.Instance;
+        },
+    });
+
+    /** Resets the current index or position in list to the head element */
+    private resetIndex = new Callable("resetIndex", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            this.roList.currentIndex = this.length() > 0 ? 0 : -1;
+            return BrsBoolean.from(this.roList.currentIndex === 0);
+        },
+    });
+
+    /** Gets the entry at current index or position from the list and increments the index or position in the list */
+    private getIndex = new Callable("getIndex", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (_: Interpreter) => {
+            return this.roList.getCurrent() ?? BrsInvalid.Instance;
+        },
+    });
+
+    /** Removes the entry at the current index or position from the list and increments the index or position in the list */
+    private removeIndex = new Callable("removeIndex", {
+        signature: {
+            args: [],
+            returns: ValueKind.Dynamic,
+        },
+        impl: (_: Interpreter) => {
+            return this.roList.remove(this.roList.currentIndex) || BrsInvalid.Instance;
         },
     });
 
@@ -304,8 +334,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter) => {
-            return new Int32(this.elements.length);
+        impl: (_: Interpreter) => {
+            return new Int32(this.length());
         },
     });
 
@@ -315,8 +345,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Void,
         },
-        impl: (interpreter: Interpreter) => {
-            this.elements = new LinkedList<RoXMLElement>();
+        impl: (_: Interpreter) => {
+            this.roList = new RoList();
             return BrsInvalid.Instance;
         },
     });
@@ -329,8 +359,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter) => {
-            return BrsBoolean.from(this.elements.length === 0);
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.length() === 0);
         },
     });
 
@@ -342,8 +372,8 @@ export class RoXMLList extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter) => {
-            return new RoArray(this.elements.toArray());
+        impl: (_: Interpreter) => {
+            return new RoArray(this.roList.elements);
         },
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,11 +3118,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linked-list-typescript@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/linked-list-typescript/-/linked-list-typescript-1.0.15.tgz#faeed93cf9203f102e2158c29edcddda320abe82"
-  integrity sha512-RIyUu9lnJIyIaMe63O7/aFv/T2v3KsMFuXMBbUQCHX+cgtGro86ETDj5ed0a8gQL2+DFjzYYsgVG4I36/cUwgw==
-
 lint-staged@>=8:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.0.0.tgz#24d0a95aa316ba28e257f5c4613369a75a10c712"


### PR DESCRIPTION
- Implemented #170 to add support for `ifGetArray` and `ifSetArray` for
  - roArray
  - roByteArray
  - roList
  - roXMLList
- Improved `roList` to remove dependency of 3rd party linked list package
- Improved `roXMLList` to use `roList` internally