### PR TITLE
Allow `roNDK.start()` with `SDKLauncher` to send an URL as `ChannelId`

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -562,7 +562,7 @@ function workerCallback(event: MessageEvent) {
         } else if (event.data.app === "SDKLauncher") {
             const channelId = event.data.params.find((el) => el.toLowerCase().startsWith("channelid="))?.split("=")[1];
             const app = deviceData.appList?.find((app) => app.id === channelId);
-            if (app) {
+            if (app || channelId?.startsWith("http")) {
                 const params = new Map();
                 event.data.params.forEach((el) => {
                     const [key, value] = el.split("=");
@@ -570,7 +570,9 @@ function workerCallback(event: MessageEvent) {
                         params.set(key, value);
                     }
                 });
-                notifyAll("launch", { app: app.id, params: params });
+                notifyAll("launch", { app: app?.id ?? channelId, params: params });
+            } else {
+                apiException("warning", `[api] NDKLauncher channel not found: ${channelId}`);
             }
         }
     } else if (typeof event.data !== "string") {


### PR DESCRIPTION
This enables and app launch another app sending a valid URL instead of an application id.