### PR TITLE
Only display closed captions with `Video` node

### DIFF
--- a/src/api/display.ts
+++ b/src/api/display.ts
@@ -47,6 +47,7 @@ let displayState = true;
 let overscanMode = "disabled";
 let aspectRatio = 16 / 9;
 let trickPlayBar = false;
+let supportCaptions = false;
 interface CachedSubtitleMeasurement {
     metricsWidth: number;
     calculatedBoxWidth: number; // Stores (metrics.width + padding * 2)
@@ -528,11 +529,15 @@ export function getCaptionMode() {
 
 function getCaptionState(): boolean {
     const mode = deviceData.captionMode;
-    return mode === "On" || (mode === "When mute" && isVideoMuted());
+    return supportCaptions && (mode === "On" || (mode === "When mute" && isVideoMuted()));
 }
 
 export function setTrickPlayBar(enabled: boolean) {
     trickPlayBar = enabled;
+}
+
+export function setSupportCaptions(support: boolean) {
+    supportCaptions = support;
 }
 
 // Get/Set Closed Captions Style Options

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -55,6 +55,7 @@ import {
     setCaptionMode,
     setAppCaptionStyle,
     setTrickPlayBar,
+    setSupportCaptions,
 } from "./display";
 import {
     initSoundModule,
@@ -604,6 +605,8 @@ function mainCallback(event: MessageEvent) {
         if (setCaptionMode(event.data.captionMode)) {
             notifyAll("captionMode", event.data.captionMode);
         }
+    } else if (typeof event.data.supportCaptions === "boolean") {
+        setSupportCaptions(event.data.supportCaptions);
     } else if (Array.isArray(event.data.captionStyle)) {
         setAppCaptionStyle(event.data.captionStyle);
     } else if (typeof event.data.trickPlayBarVisible === "boolean") {

--- a/src/core/brsTypes/components/RoVideoPlayer.ts
+++ b/src/core/brsTypes/components/RoVideoPlayer.ts
@@ -45,6 +45,7 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
         this.cookiesEnabled = false;
         this.customHeaders = new Map<string, string>();
         postMessage({ videoPlaylist: new Array<string>() });
+        postMessage({ supportCaptions: false });
         postMessage("video,loop,false");
         postMessage("video,next,-1");
         postMessage("video,mute,false");

--- a/src/core/brsTypes/nodes/Video.ts
+++ b/src/core/brsTypes/nodes/Video.ts
@@ -209,6 +209,7 @@ export class Video extends Group {
         postMessage("video,mute,false");
         postMessage(`video,notify,500`);
         postMessage({ videoPlaylist: new Array<string>() });
+        postMessage({ supportCaptions: true });
         postMessage({ captionMode: BrsDevice.deviceInfo.captionMode });
         postMessage({ captionStyle: new Array<CaptionStyleOption>() });
 


### PR DESCRIPTION
This PR fixed an issue that was displaying closed captions in HLS feeds when using `roVideoPlayer` that is not supported in Roku, so I introduced a new message from the interpreter to only enable it on `Video` nodes.