### PR TITLE
Added `setDebugState` and `getDebugState` to the engine API

### DIFF
--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -36,6 +36,8 @@ Check the [documentation](./integrating.md) to learn how to start using it. The 
 |umountExt()|Unmounts the external volume `ext1:` ||
 |updateMemoryInfo(`used`, `total`)|A method for the host application to inject memory usage information to the engine. |<ul><li>`used` (number): Memory used by the app (in KB)</li><li>`total` (number): Total memory available for the app (in KB)</li></ul>|
 |debug(`command`)|Sends a debug command to the Engine|<ul><li>`command` (string): the Micro Debugger can be enabled sending `break` command, and after that, any valid BrightScript expression or [debug commands](https://developer.roku.com/docs/developer-program/debugging/debugging-channels.md#brightscript-console-port-8085-commands) can be sent. You can also send `pause` to interrupt the interpreter, for instance, when the app loses focus. The command `cont` restarts the app. You can use this method on the browser console to debug your app.|
+|getDebugState()|Returns `true` if debug functionality is enabled, `false` if disabled||
+|setDebugState(`enabled`)|Enables or disables the debug functionality|<ul><li>`enabled` (boolean): if `true` enables debug commands and data to be sent/received by the engine, if `false` disables debug functionality for production to avoid code injection.</li>|
 |getVersion()|Returns the version of the API library ||
 
 ## Events

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -168,6 +168,15 @@ export function sendInput(data: object) {
     saveDataBuffer(sharedArray, JSON.stringify(data), BufferType.INPUT);
 }
 
+// Debug API
+export function setDebugState(enabled: boolean) {
+    notifyAll("debugState", enabled);
+    disableDebug = !enabled;
+}
+export function getDebugState() {
+    return !disableDebug;
+}
+
 /// #if BROWSER
 
 // Keyboard Mapping

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -80,7 +80,15 @@ let brsWorker: Worker;
 export { deviceData, loadAppZip, updateAppZip, getSerialNumber, mountExt, umountExt } from "./package";
 
 // Control API
-export { setControlMode, getControlMode, setCustomKeys, setCustomPadButtons, sendInput } from "./control";
+export {
+    setControlMode,
+    getControlMode,
+    setCustomKeys,
+    setCustomPadButtons,
+    sendInput,
+    setDebugState,
+    getDebugState,
+} from "./control";
 
 // Display API
 export {
@@ -194,6 +202,8 @@ export function initialize(customDeviceInfo?: Partial<DeviceInfo>, options: any 
             notifyAll(event, data);
         } else if (["error", "warning"].includes(event)) {
             apiException(event, data);
+        } else if (event === "debugState") {
+            disableDebug = !data;
         }
     });
     subscribeSound("api", (event: string, data: any) => {


### PR DESCRIPTION
This new methods will allow a hosting app for the simulator to switch the debug state based on the context.