### PR TITLE
Fixed when `Video` node field `contentIsPlaylist` is set after `content`

### DIFF
--- a/src/core/brsTypes/nodes/Video.ts
+++ b/src/core/brsTypes/nodes/Video.ts
@@ -260,6 +260,13 @@ export class Video extends Group {
             postMessage(`video,audio,${value.getValue()}`);
         } else if (fieldName === "subtitletrack" && isBrsString(value)) {
             postMessage(`video,subtitle,${value.getValue()}`);
+        } else if (fieldName === "contentisplaylist" && isBrsBoolean(value)) {
+            super.set(index, value, alwaysNotify, kind);
+            const content = this.getFieldValue("content");
+            if (content instanceof ContentNode) {
+                postMessage({ videoPlaylist: this.formatContent(content) });
+            }
+            return BrsInvalid.Instance;
         } else if (fieldName === "content" && value instanceof ContentNode) {
             postMessage({ videoPlaylist: this.formatContent(value) });
             if (this.contentTitles.length > 0) {


### PR DESCRIPTION
The playlist was empty in the scenario when the `content` field was being set before `contentIsPlaylist`, now it reformats the content and send to the render thread in both field updates.