### PR TITLE
Refactored `RootObjects` into a separate module `SGRoot` to fix `Audio` and `Video` reset

### DIFF
--- a/src/core/brsTypes/SGRoot.ts
+++ b/src/core/brsTypes/SGRoot.ts
@@ -1,0 +1,280 @@
+import { ComponentDefinition } from "../scenegraph";
+import { BufferType, DataType, MediaEvent, MediaTrack } from "../common";
+import { RoSGNode } from "./components/RoSGNode";
+import { Global } from "./nodes/Global";
+import { Scene } from "./nodes/Scene";
+import { Timer } from "./nodes/Timer";
+import { Audio } from "./nodes/Audio";
+import { SoundEffect } from "./nodes/SoundEffect";
+import { Video } from "./nodes/Video";
+import { Task } from "./nodes/Task";
+import { BrsDevice } from "../device/BrsDevice";
+
+/**
+ * A singleton object that holds the Node that represents the m.global, the root Scene,
+ * the currently focused node, the arrays of tasks and timers and sound effects,
+ * and a map of node definitions. Optional Audio and Video instances are also included.
+ * */
+
+export class SGRoot {
+    readonly mGlobal: Global;
+    private _nodeDefMap: Map<string, ComponentDefinition>;
+    private _scene?: Scene;
+    private _focused?: RoSGNode;
+    private readonly _sfx: (SoundEffect | undefined)[];
+    private readonly _tasks: Task[];
+    private readonly _timers: Timer[];
+    private _audio?: Audio;
+    private _video?: Video;
+
+    get nodeDefMap(): Map<string, ComponentDefinition> {
+        return this._nodeDefMap;
+    }
+
+    get scene(): Scene | undefined {
+        return this._scene;
+    }
+
+    get focused(): RoSGNode | undefined {
+        return this._focused;
+    }
+
+    get sfx(): (SoundEffect | undefined)[] {
+        return this._sfx;
+    }
+
+    get tasks(): Task[] {
+        return this._tasks;
+    }
+
+    get timers(): Timer[] {
+        return this._timers;
+    }
+    get audio(): Audio | undefined {
+        return this._audio;
+    }
+
+    get video(): Video | undefined {
+        return this._video;
+    }
+
+    private audioFlags: number = -1;
+    private audioIndex: number = -1;
+    private audioDuration: number = -1;
+    private audioPosition: number = -1;
+    private videoEvent: number = -1;
+    private videoIndex: number = -1;
+    private videoProgress: number = -1;
+    private videoDuration: number = -1;
+    private videoPosition: number = -1;
+
+    constructor() {
+        this.mGlobal = new Global([]);
+        this._nodeDefMap = new Map<string, ComponentDefinition>();
+        this._sfx = [];
+        this._tasks = [];
+        this._timers = [];
+    }
+
+    /** Set the map of component definitions */
+    setNodeDefMap(nodeDefMap: Map<string, ComponentDefinition>) {
+        this._nodeDefMap = nodeDefMap;
+    }
+
+    /** Set the root Scene */
+    setScene(scene: Scene) {
+        this._scene = scene;
+    }
+
+    /** Set the currently focused node */
+    setFocused(node?: RoSGNode) {
+        this._focused = node;
+    }
+
+    /** Update all Application Tasks */
+    processTasks(): boolean {
+        let updates = false;
+        for (const task of this._tasks) {
+            updates = task.updateTask();
+            if (task.active) {
+                task.checkTask();
+            }
+        }
+        return updates;
+    }
+
+    /** Update all Application Timers */
+    processTimers(): boolean {
+        let fired = false;
+        for (const timer of this._timers) {
+            if (timer.active && timer.checkFire()) {
+                fired = true;
+            }
+        }
+        return fired;
+    }
+
+    /** Reset and prepare to track a new Audio instance */
+    setAudio(audio: Audio) {
+        this._audio = audio;
+        this.audioFlags = -1;
+        this.audioIndex = -1;
+        this.audioDuration = -1;
+        this.audioPosition = -1;
+        Atomics.store(BrsDevice.sharedArray, DataType.SND, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.SDX, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.SDR, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.SPS, -1);
+    }
+
+    /** Update the Audio instance based on data from render thread */
+    processAudio(): boolean {
+        if (!this._audio) {
+            return false;
+        }
+        let isDirty = false;
+        const flags = Atomics.load(BrsDevice.sharedArray, DataType.SND);
+        if (flags !== this.audioFlags) {
+            this.audioFlags = flags;
+            this._audio.setState(flags);
+            isDirty = true;
+        }
+        const index = Atomics.load(BrsDevice.sharedArray, DataType.SDX);
+        if (index !== this.audioIndex) {
+            this.audioIndex = index;
+            this._audio.setContentIndex(index);
+            isDirty = true;
+        }
+        const duration = Atomics.load(BrsDevice.sharedArray, DataType.SDR);
+        if (duration !== this.audioDuration) {
+            this.audioDuration = duration;
+            this._audio.setDuration(duration);
+            isDirty = true;
+        }
+        const position = Atomics.load(BrsDevice.sharedArray, DataType.SPS);
+        if (position !== this.audioPosition) {
+            this.audioPosition = position;
+            this._audio.setPosition(position);
+            isDirty = true;
+        }
+        return isDirty;
+    }
+
+    /** Reset and prepare to track a new Video instance */
+    setVideo(video: Video) {
+        this._video = video;
+        this.videoEvent = -1;
+        this.videoIndex = -1;
+        this.videoProgress = -1;
+        this.videoDuration = -1;
+        this.videoPosition = -1;
+        Atomics.store(BrsDevice.sharedArray, DataType.VDO, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.VDX, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.VSE, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.VDR, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.VPS, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.VAT, -1);
+        Atomics.store(BrsDevice.sharedArray, DataType.VTT, -1);
+    }
+
+    /** Update the Video instance based on data from render thread */
+    processVideo(): boolean {
+        if (!this._video) {
+            return false;
+        }
+        let isDirty = false;
+        const progress = Atomics.load(BrsDevice.sharedArray, DataType.VLP);
+        if (this.videoProgress !== progress && progress >= 0 && progress <= 1000) {
+            this._video.setState(MediaEvent.LOADING, Math.trunc(progress / 10));
+            console.debug(`Video Progress: ${progress}`);
+        }
+        this.videoProgress = progress;
+        const eventType = Atomics.load(BrsDevice.sharedArray, DataType.VDO);
+        const eventIndex = Atomics.load(BrsDevice.sharedArray, DataType.VDX);
+        if (eventType !== this.videoEvent) {
+            this.videoEvent = eventType;
+            if (eventType >= 0) {
+                this._video.setState(eventType, eventIndex);
+                console.debug(`Video State: ${this._video.getFieldValueJS("state")}  (${eventType}/${eventIndex})`);
+                Atomics.store(BrsDevice.sharedArray, DataType.VDO, -1);
+                isDirty = true;
+            }
+        }
+        const selected = Atomics.load(BrsDevice.sharedArray, DataType.VSE);
+        if (selected !== this.videoIndex) {
+            this.videoIndex = selected;
+            if (selected >= 0) {
+                this._video.setContentIndex(selected);
+                Atomics.store(BrsDevice.sharedArray, DataType.VSE, -1);
+                isDirty = true;
+            }
+        }
+        const duration = Atomics.load(BrsDevice.sharedArray, DataType.VDR);
+        if (duration !== this.videoDuration) {
+            this.videoDuration = duration;
+            this._video.setDuration(duration);
+            isDirty = true;
+        }
+        const position = Atomics.load(BrsDevice.sharedArray, DataType.VPS);
+        if (position !== this.videoPosition) {
+            this.videoPosition = position;
+            this._video.setPosition(position);
+            isDirty = true;
+        }
+
+        const bufferFlag = Atomics.load(BrsDevice.sharedArray, DataType.BUF);
+        if (bufferFlag === BufferType.MEDIA_TRACKS) {
+            const strTracks = BrsDevice.readDataBuffer();
+            let audioTracks: MediaTrack[] = [];
+            let textTracks: MediaTrack[] = [];
+            try {
+                const tracks = JSON.parse(strTracks);
+                audioTracks = tracks.audio ?? [];
+                textTracks = tracks.text ?? [];
+            } catch (e) {
+                audioTracks = [];
+                textTracks = [];
+            }
+            this._video.setAudioTracks(audioTracks);
+            this._video.setSubtitleTracks(textTracks);
+            isDirty = true;
+        }
+
+        const audioTrack = Atomics.load(BrsDevice.sharedArray, DataType.VAT);
+        if (audioTrack > -1) {
+            this._video.setCurrentAudioTrack(audioTrack);
+            Atomics.store(BrsDevice.sharedArray, DataType.VAT, -1);
+            isDirty = true;
+        }
+
+        const subtitleTrack = Atomics.load(BrsDevice.sharedArray, DataType.VTT);
+        if (subtitleTrack > -1) {
+            this._video.setCurrentSubtitleTrack(subtitleTrack);
+            Atomics.store(BrsDevice.sharedArray, DataType.VTT, -1);
+            isDirty = true;
+        }
+        return isDirty;
+    }
+
+    /** Update all SoundEffects based on data from render thread */
+    processSFX() {
+        let isDirty = false;
+        for (let i = 0; i < this._sfx.length; i++) {
+            const sfx = this._sfx[i];
+            if (!sfx) {
+                continue;
+            }
+            const sfxId = Atomics.load(BrsDevice.sharedArray, DataType.WAV + i);
+            if (sfxId >= 0 && sfxId === sfx.getAudioId() && sfx.getState() !== "playing") {
+                sfx.setState(MediaEvent.START_PLAY);
+                isDirty = true;
+            } else if (sfx.getState() !== "stopped") {
+                sfx.setState(MediaEvent.FINISHED);
+                this._sfx[i] = undefined;
+                isDirty = true;
+            }
+        }
+        return isDirty;
+    }
+}
+export const sgRoot: SGRoot = new SGRoot();

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -34,24 +34,20 @@ import { RoSGNodeEvent } from "./events/RoSGNodeEvent";
 import { RoSGScreenEvent } from "./events/RoSGScreenEvent";
 import { isUnboxable } from "./Boxing";
 import { RoSGNode } from "./components/RoSGNode";
-import { Global } from "./nodes/Global";
-import { Scene } from "./nodes/Scene";
 import { Task } from "./nodes/Task";
-import { Timer } from "./nodes/Timer";
-import { Audio } from "./nodes/Audio";
-import { SoundEffect } from "./nodes/SoundEffect";
-import { Video } from "./nodes/Video";
-import { Field } from "./nodes/Field";
-import { ComponentDefinition } from "../scenegraph";
 import { getNodeType, SGNodeFactory } from "../scenegraph/SGNodeFactory";
 import { BrsObjects } from "./components/BrsObjects";
 import { ContentNode } from "./nodes/ContentNode";
 
+// BrightScript Type exports
 export * from "./BrsType";
 export * from "./Int32";
 export * from "./Int64";
 export * from "./Float";
 export * from "./Double";
+export * from "./Boxing";
+export * from "./Callable";
+export * from "./Coercion";
 export * from "./interfaces/BrsInterface";
 export * from "./components/BrsComponent";
 export * from "./components/RoArray";
@@ -116,19 +112,14 @@ export * from "./events/RoSystemLogEvent";
 export * from "./events/RoDeviceInfoEvent";
 export * from "./events/RoChannelStoreEvent";
 export * from "./events/RoUniversalControlEvent";
+
+// SceneGraph Type exports
+export * from "../scenegraph/SGNodeFactory";
+export * from "./SGRoot";
 export * from "./components/RoSGNode";
 export * from "./components/RoSGScreen";
-export * from "./events/RoURLEvent";
-export * from "./events/RoInputEvent";
-export * from "./events/RoAudioPlayerEvent";
-export * from "./events/RoVideoPlayerEvent";
-export * from "./events/RoSystemLogEvent";
-export * from "./events/RoDeviceInfoEvent";
-export * from "./events/RoChannelStoreEvent";
-export * from "./events/RoUniversalControlEvent";
 export * from "./events/RoSGNodeEvent";
 export * from "./events/RoSGScreenEvent";
-export * from "../scenegraph/SGNodeFactory";
 export * from "./nodes/Group";
 export * from "./nodes/Scene";
 export * from "./nodes/Keyboard";
@@ -167,9 +158,6 @@ export * from "./nodes/StdDlgProgressItem";
 export * from "./nodes/BusySpinner";
 export * from "./nodes/RSGPalette";
 export * from "./nodes/ChannelStore";
-export * from "./Boxing";
-export * from "./Callable";
-export * from "./Coercion";
 
 /**
  * Determines whether or not the given value is a number.
@@ -669,29 +657,6 @@ export function fromSGNode(node: RoSGNode): FlexObject {
 export function isInvalid(value: BrsType): boolean {
     return value.equalTo(BrsInvalid.Instance).toBoolean();
 }
-
-/**
- * An object that holds the Node that represents the m.global, the root Scene,
- * the currently focused node and the arrays of tasks and timers.
- * */
-interface RootObjects {
-    mGlobal: Global;
-    nodeDefMap: Map<string, ComponentDefinition>;
-    rootScene?: Scene;
-    focused?: RoSGNode;
-    audio?: Audio;
-    video?: Video;
-    sfx: (SoundEffect | undefined)[];
-    tasks: Task[];
-    timers: Timer[];
-}
-export const rootObjects: RootObjects = {
-    mGlobal: new Global([]),
-    nodeDefMap: new Map(),
-    sfx: [],
-    tasks: [],
-    timers: [],
-};
 
 /**
  * Checks if a string represents a number and returns its precision.

--- a/src/core/brsTypes/nodes/ArrayGrid.ts
+++ b/src/core/brsTypes/nodes/ArrayGrid.ts
@@ -15,8 +15,7 @@ import {
     isBrsNumber,
     isBrsString,
     jsValueOf,
-    rootObjects,
-    RoSGNode,
+    sgRoot,
 } from "..";
 import { IfDraw2D, Rect } from "../interfaces/IfDraw2D";
 import { Interpreter } from "../../interpreter";
@@ -179,7 +178,7 @@ export class ArrayGrid extends Group {
             return;
         }
         const focusedIndex = this.getFieldValueJS("itemFocused") as number;
-        const nodeFocus = rootObjects.focused === this;
+        const nodeFocus = sgRoot.focused === this;
         this.updateItemFocus(this.focusIndex, false, nodeFocus);
         super.set(new BrsString("itemUnfocused"), new Int32(focusedIndex));
         this.focusIndex = newFocus;
@@ -297,7 +296,7 @@ export class ArrayGrid extends Group {
         draw2D?: IfDraw2D
     ) {
         const content = this.getContentItem(index);
-        const nodeFocus = rootObjects.focused === this;
+        const nodeFocus = sgRoot.focused === this;
         const focused = index === this.focusIndex;
         if (!this.itemComps[index]) {
             const itemComp = this.createItemComponent(interpreter, itemRect, content);

--- a/src/core/brsTypes/nodes/Audio.ts
+++ b/src/core/brsTypes/nodes/Audio.ts
@@ -10,7 +10,7 @@ import {
     isBrsBoolean,
     BrsString,
     Int32,
-    rootObjects,
+    sgRoot,
     Double,
 } from "..";
 import { BrsDevice } from "../../device/BrsDevice";
@@ -50,7 +50,7 @@ export class Audio extends RoSGNode {
         postMessage("audio,next,-1");
         postMessage("audio,mute,false");
 
-        rootObjects.audio = this;
+        sgRoot.setAudio(this);
     }
 
     set(index: BrsType, value: BrsType, alwaysNotify: boolean = false, kind?: FieldKind) {

--- a/src/core/brsTypes/nodes/Button.ts
+++ b/src/core/brsTypes/nodes/Button.ts
@@ -1,5 +1,5 @@
 import { FieldModel } from "./Field";
-import { AAMember, BrsString, Float, Label, Poster, rootObjects, Font } from "..";
+import { AAMember, BrsString, Float, Label, Poster, sgRoot, Font } from "..";
 import { Group } from "./Group";
 import { Interpreter } from "../../interpreter";
 import { IfDraw2D } from "../interfaces/IfDraw2D";
@@ -161,7 +161,7 @@ export class Button extends Group {
         if (!this.isVisible()) {
             return;
         }
-        const nodeFocus = rootObjects.focused === this;
+        const nodeFocus = sgRoot.focused === this;
         const nodeTrans = this.getTranslation();
         const drawTrans = angle !== 0 ? rotateTranslation(nodeTrans, angle) : nodeTrans.slice();
         drawTrans[0] += origin[0];

--- a/src/core/brsTypes/nodes/ButtonGroup.ts
+++ b/src/core/brsTypes/nodes/ButtonGroup.ts
@@ -18,7 +18,7 @@ import {
     Label,
     RoArray,
     RoFont,
-    rootObjects,
+    sgRoot,
     RoSGNode,
 } from "..";
 
@@ -217,7 +217,7 @@ export class ButtonGroup extends LayoutGroup {
     }
 
     private refreshFocus() {
-        const focusedNode = rootObjects.focused;
+        const focusedNode = sgRoot.focused;
         if (
             this.children.length &&
             focusedNode instanceof RoSGNode &&
@@ -225,7 +225,7 @@ export class ButtonGroup extends LayoutGroup {
         ) {
             const focusedButton = this.children[this.focusIndex];
             if (focusedNode !== focusedButton && focusedButton instanceof RoSGNode) {
-                rootObjects.focused = focusedButton;
+                sgRoot.setFocused(focusedButton);
             }
             this.wasFocused = true;
         } else if (this.wasFocused) {

--- a/src/core/brsTypes/nodes/Dialog.ts
+++ b/src/core/brsTypes/nodes/Dialog.ts
@@ -15,7 +15,7 @@ import {
     jsValueOf,
     Label,
     Poster,
-    rootObjects,
+    sgRoot,
     RoSGNode,
 } from "..";
 
@@ -168,11 +168,11 @@ export class Dialog extends Group {
             index = new BrsString("wasClosed");
             value = BrsBoolean.True;
             this.set(new BrsString("visible"), BrsBoolean.False);
-            if (rootObjects.rootScene?.dialog === this) {
-                rootObjects.rootScene.dialog = undefined;
+            if (sgRoot.scene?.dialog === this) {
+                sgRoot.scene.dialog = undefined;
             }
             if (this.lastFocus instanceof Group) {
-                rootObjects.focused = this.lastFocus;
+                sgRoot.setFocused(this.lastFocus);
                 this.lastFocus.isDirty = true;
                 this.lastFocus = undefined;
             }
@@ -184,9 +184,9 @@ export class Dialog extends Group {
     }
 
     setNodeFocus(_: Interpreter, focusOn: boolean): boolean {
-        if (focusOn && this.hasButtons && rootObjects.focused && this.lastFocus === undefined) {
-            this.lastFocus = rootObjects.focused;
-            rootObjects.focused = this.buttonGroup;
+        if (focusOn && this.hasButtons && sgRoot.focused && this.lastFocus === undefined) {
+            this.lastFocus = sgRoot.focused;
+            sgRoot.setFocused(this.buttonGroup);
             this.isDirty = true;
         }
         return true;

--- a/src/core/brsTypes/nodes/Font.ts
+++ b/src/core/brsTypes/nodes/Font.ts
@@ -2,7 +2,7 @@ import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind, FieldModel } from "./Field";
 import {
     BrsBoolean,
-    rootObjects,
+    sgRoot,
     BrsString,
     BrsType,
     getFontRegistry,
@@ -30,7 +30,7 @@ export class Font extends RoSGNode {
     constructor(members: AAMember[] = [], readonly name: string = "Font") {
         super([], name);
 
-        this.resolution = rootObjects.rootScene?.ui.resolution ?? "HD";
+        this.resolution = sgRoot.scene?.ui.resolution ?? "HD";
         this.defaultSize = this.resolution === "HD" ? 24 : 36;
 
         this.registerDefaultFields(this.defaultFields);

--- a/src/core/brsTypes/nodes/Group.ts
+++ b/src/core/brsTypes/nodes/Group.ts
@@ -16,7 +16,7 @@ import {
     jsValueOf,
     isBrsString,
     BrsBoolean,
-    rootObjects,
+    sgRoot,
     Rectangle,
     ScrollingLabel,
 } from "..";
@@ -53,7 +53,7 @@ export class Group extends RoSGNode {
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
 
-        const sceneUI = rootObjects.rootScene?.ui;
+        const sceneUI = sgRoot.scene?.ui;
         if (sceneUI) {
             this.resolution = sceneUI.resolution;
             this.sceneRect = { x: 0, y: 0, width: sceneUI.width, height: sceneUI.height };

--- a/src/core/brsTypes/nodes/Keyboard.ts
+++ b/src/core/brsTypes/nodes/Keyboard.ts
@@ -3,18 +3,7 @@ import { Group } from "./Group";
 import { AAMember } from "../components/RoAssociativeArray";
 import { Interpreter } from "../../interpreter";
 import { IfDraw2D, Rect } from "../interfaces/IfDraw2D";
-import {
-    BrsBoolean,
-    BrsInvalid,
-    BrsType,
-    Float,
-    Font,
-    Int32,
-    isBrsString,
-    RoBitmap,
-    rootObjects,
-    TextEditBox,
-} from "..";
+import { BrsBoolean, Float, Font, Int32, RoBitmap, sgRoot, TextEditBox } from "..";
 
 enum KeyboardModes {
     ALPHANUMERIC,
@@ -241,7 +230,7 @@ export class Keyboard extends Group {
         if (!this.isVisible()) {
             return;
         }
-        const isFocused = rootObjects.focused === this;
+        const isFocused = sgRoot.focused === this;
         this.textEditBox.setActive(isFocused);
         const nodeTrans = this.getTranslation();
         const drawTrans = nodeTrans.slice();

--- a/src/core/brsTypes/nodes/KeyboardDialog.ts
+++ b/src/core/brsTypes/nodes/KeyboardDialog.ts
@@ -1,7 +1,7 @@
 import { FieldModel } from "./Field";
 import { AAMember } from "../components/RoAssociativeArray";
 import { Dialog } from "./Dialog";
-import { Keyboard, BrsBoolean, BrsString, Float, isBrsString, rootObjects, Int32 } from "..";
+import { Keyboard, BrsBoolean, BrsString, Float, isBrsString, sgRoot } from "..";
 import { Interpreter } from "../../interpreter";
 
 export class KeyboardDialog extends Dialog {
@@ -76,9 +76,9 @@ export class KeyboardDialog extends Dialog {
     }
 
     setNodeFocus(_: Interpreter, focusOn: boolean): boolean {
-        if (focusOn && rootObjects.focused && this.lastFocus === undefined) {
-            this.lastFocus = rootObjects.focused;
-            rootObjects.focused = this.hasButtons ? this.buttonGroup : this.keyboard;
+        if (focusOn && sgRoot.focused && this.lastFocus === undefined) {
+            this.lastFocus = sgRoot.focused;
+            sgRoot.setFocused(this.hasButtons ? this.buttonGroup : this.keyboard);
             this.isDirty = true;
         }
         return true;
@@ -102,12 +102,12 @@ export class KeyboardDialog extends Dialog {
             return true;
         }
         if (press && key === "up" && this.focus === "buttons") {
-            rootObjects.focused = this.keyboard;
+            sgRoot.setFocused(this.keyboard);
             this.focus = "keyboard";
             this.isDirty = true;
             handled = true;
         } else if (press && key === "down" && this.focus === "keyboard") {
-            rootObjects.focused = this.buttonGroup;
+            sgRoot.setFocused(this.buttonGroup);
             this.focus = "buttons";
             this.isDirty = true;
             handled = true;

--- a/src/core/brsTypes/nodes/Label.ts
+++ b/src/core/brsTypes/nodes/Label.ts
@@ -1,7 +1,7 @@
 import { FieldKind, FieldModel } from "./Field";
 import { Group } from "./Group";
 import { Font } from "./Font";
-import { AAMember, BrsBoolean, BrsType, Float, isBrsString, rootObjects } from "..";
+import { AAMember, BrsBoolean, BrsType, Float, isBrsString, sgRoot } from "..";
 import { Interpreter } from "../../interpreter";
 import { IfDraw2D, MeasuredText, Rect } from "../interfaces/IfDraw2D";
 import { rotateTranslation } from "../../scenegraph/SGUtil";
@@ -33,7 +33,7 @@ export class Label extends Group {
 
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
-        if (rootObjects.rootScene?.ui.resolution === "FHD") {
+        if (sgRoot.scene?.ui.resolution === "FHD") {
             this.setFieldValue("lineSpacing", new Float(12));
         } else {
             this.setFieldValue("lineSpacing", new Float(8));

--- a/src/core/brsTypes/nodes/LabelList.ts
+++ b/src/core/brsTypes/nodes/LabelList.ts
@@ -2,7 +2,7 @@ import { FieldKind, FieldModel } from "./Field";
 import { AAMember } from "../components/RoAssociativeArray";
 import { ArrayGrid } from "./ArrayGrid";
 import { Font } from "./Font";
-import { BrsInvalid, BrsString, BrsType, brsValueOf, ContentNode, Int32, isBrsString, RoBitmap, rootObjects } from "..";
+import { BrsInvalid, BrsString, BrsType, brsValueOf, ContentNode, Int32, isBrsString, RoBitmap, sgRoot } from "..";
 import { Interpreter } from "../..";
 import { IfDraw2D, Rect, RectRect } from "../interfaces/IfDraw2D";
 
@@ -99,7 +99,7 @@ export class LabelList extends ArrayGrid {
             return;
         }
         const hasSections = this.metadata.length > 0;
-        const nodeFocus = rootObjects.focused === this;
+        const nodeFocus = sgRoot.focused === this;
         this.currRow = this.updateCurrRow();
         let lastIndex = -1;
         const displayRows = Math.min(this.content.length, this.numRows);

--- a/src/core/brsTypes/nodes/MiniKeyboard.ts
+++ b/src/core/brsTypes/nodes/MiniKeyboard.ts
@@ -3,19 +3,7 @@ import { Group } from "./Group";
 import { AAMember } from "../components/RoAssociativeArray";
 import { Interpreter } from "../../interpreter";
 import { IfDraw2D } from "../interfaces/IfDraw2D";
-import {
-    BrsBoolean,
-    BrsInvalid,
-    BrsString,
-    BrsType,
-    Float,
-    Font,
-    Int32,
-    isBrsString,
-    RoBitmap,
-    rootObjects,
-    TextEditBox,
-} from "..";
+import { BrsBoolean, BrsString, Float, Font, Int32, RoBitmap, sgRoot, TextEditBox } from "..";
 
 export class MiniKeyboard extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -195,7 +183,7 @@ export class MiniKeyboard extends Group {
         if (!this.isVisible()) {
             return;
         }
-        const isFocused = rootObjects.focused === this;
+        const isFocused = sgRoot.focused === this;
         this.textEditBox.setActive(isFocused);
         const nodeTrans = this.getTranslation();
         const drawTrans = nodeTrans.slice();

--- a/src/core/brsTypes/nodes/RowList.ts
+++ b/src/core/brsTypes/nodes/RowList.ts
@@ -13,7 +13,7 @@ import {
     isBrsString,
     jsValueOf,
     RoArray,
-    rootObjects,
+    sgRoot,
 } from "..";
 import { BrsDevice } from "../../device/BrsDevice";
 import { Interpreter } from "../../interpreter";
@@ -619,7 +619,7 @@ export class RowList extends ArrayGrid {
         draw2D?: IfDraw2D
     ) {
         const content = cols[colIndex];
-        const nodeFocus = rootObjects.focused === this;
+        const nodeFocus = sgRoot.focused === this;
 
         // Check if all items in this row fit on screen by checking if last item fits
         const numCols = cols.length;

--- a/src/core/brsTypes/nodes/Scene.ts
+++ b/src/core/brsTypes/nodes/Scene.ts
@@ -13,7 +13,7 @@ import {
     isBrsString,
     RoArray,
     RoMessagePort,
-    rootObjects,
+    sgRoot,
     RoSGNode,
     StandardDialog,
     toAssociativeArray,
@@ -137,8 +137,8 @@ export class Scene extends Group {
 
     /** Handle SceneGraph onKeyEvent event */
     handleOnKeyEvent(interpreter: Interpreter, key: BrsString, press: BrsBoolean) {
-        if (rootObjects.focused instanceof RoSGNode) {
-            const path = this.createPath(rootObjects.focused, false);
+        if (sgRoot.focused instanceof RoSGNode) {
+            const path = this.createPath(sgRoot.focused, false);
             for (let node of path) {
                 if (this.handleKeyByNode(interpreter, node, key, press)) {
                     return true;
@@ -151,7 +151,7 @@ export class Scene extends Group {
     }
 
     private handleKeyByNode(interpreter: Interpreter, hostNode: RoSGNode, key: BrsString, press: BrsBoolean): boolean {
-        const typeDef = rootObjects.nodeDefMap.get(hostNode.nodeSubtype.toLowerCase());
+        const typeDef = sgRoot.nodeDefMap.get(hostNode.nodeSubtype.toLowerCase());
         if (typeDef?.environment === undefined) {
             if (hostNode instanceof Group) {
                 return hostNode.handleKey(key.value, press.toBoolean());

--- a/src/core/brsTypes/nodes/SoundEffect.ts
+++ b/src/core/brsTypes/nodes/SoundEffect.ts
@@ -1,6 +1,6 @@
 import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind, FieldModel } from "./Field";
-import { AAMember, BrsType, isBrsString, BrsString, isBrsNumber, BrsInvalid, rootObjects, jsValueOf } from "..";
+import { AAMember, BrsType, isBrsString, BrsString, isBrsNumber, BrsInvalid, sgRoot, jsValueOf } from "..";
 import { BrsDevice } from "../../device/BrsDevice";
 import { MediaEvent } from "../../common";
 
@@ -121,7 +121,7 @@ export class SoundEffect extends RoSGNode {
             }
             this.setState(MediaEvent.TOO_MANY);
         } else {
-            rootObjects.sfx[this.stream] = this;
+            sgRoot.sfx[this.stream] = this;
             postMessage(`sfx,trigger,${this.uri},${volume},${this.stream}`);
             this.setState(MediaEvent.START_PLAY);
         }
@@ -129,8 +129,8 @@ export class SoundEffect extends RoSGNode {
 
     private stop() {
         postMessage(`sfx,stop,${this.uri}`);
-        if (rootObjects.sfx[this.stream] === this) {
-            rootObjects.sfx[this.stream] = undefined;
+        if (sgRoot.sfx[this.stream] === this) {
+            sgRoot.sfx[this.stream] = undefined;
         }
         this.setState(MediaEvent.PARTIAL);
     }

--- a/src/core/brsTypes/nodes/StandardDialog.ts
+++ b/src/core/brsTypes/nodes/StandardDialog.ts
@@ -8,7 +8,7 @@ import {
     isBrsString,
     jsValueOf,
     Poster,
-    rootObjects,
+    sgRoot,
     RSGPalette,
     toAssociativeArray,
 } from "..";
@@ -67,8 +67,8 @@ export class StandardDialog extends Group {
             index = new BrsString("wasClosed");
             value = BrsBoolean.True;
             this.set(new BrsString("visible"), BrsBoolean.False);
-            if (rootObjects.rootScene?.dialog === this) {
-                rootObjects.rootScene.dialog = undefined;
+            if (sgRoot.scene?.dialog === this) {
+                sgRoot.scene.dialog = undefined;
             }
         } else if (fieldName === "width") {
             const newWidth = jsValueOf(value) as number;
@@ -109,8 +109,8 @@ export class StandardDialog extends Group {
 
     getPaletteColors() {
         let palette = this.getFieldValue("palette");
-        if (!(palette instanceof RSGPalette) && rootObjects.rootScene) {
-            palette = rootObjects.rootScene.getFieldValue("palette");
+        if (!(palette instanceof RSGPalette) && sgRoot.scene) {
+            palette = sgRoot.scene.getFieldValue("palette");
         }
         if (palette instanceof RSGPalette) {
             const colors = palette.getFieldValue("colors");

--- a/src/core/brsTypes/nodes/Task.ts
+++ b/src/core/brsTypes/nodes/Task.ts
@@ -9,7 +9,7 @@ import {
     BrsEvent,
     brsValueOf,
     isBrsString,
-    rootObjects,
+    sgRoot,
 } from "..";
 import { Field, FieldKind, FieldModel } from "./Field";
 import { isThreadUpdate, TaskData, TaskState, ThreadUpdate } from "../../common";
@@ -165,7 +165,7 @@ export class Task extends RoSGNode {
                     update.global,
                     update.field
                 );
-                const node = update.global ? rootObjects.mGlobal : this;
+                const node = update.global ? sgRoot.mGlobal : this;
                 const field = new BrsString(update.field);
                 const value = brsValueOf(update.value);
                 node.set(field, value, false, undefined, false);

--- a/src/core/brsTypes/nodes/Timer.ts
+++ b/src/core/brsTypes/nodes/Timer.ts
@@ -1,6 +1,6 @@
 import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind, FieldModel } from "./Field";
-import { AAMember, BrsType, BrsString, BrsInvalid, isBrsString, rootObjects } from "..";
+import { AAMember, BrsType, BrsString, BrsInvalid, isBrsString, sgRoot } from "..";
 
 export class Timer extends RoSGNode {
     readonly defaultFields: FieldModel[] = [
@@ -21,7 +21,7 @@ export class Timer extends RoSGNode {
 
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(members);
-        rootObjects.timers.push(this);
+        sgRoot.timers.push(this);
     }
 
     set(index: BrsType, value: BrsType, alwaysNotify: boolean = false, kind?: FieldKind) {

--- a/src/core/brsTypes/nodes/Video.ts
+++ b/src/core/brsTypes/nodes/Video.ts
@@ -10,7 +10,7 @@ import {
     isBrsBoolean,
     BrsString,
     Int32,
-    rootObjects,
+    sgRoot,
     Double,
     Poster,
     BrsBoolean,
@@ -215,7 +215,7 @@ export class Video extends Group {
         postMessage({ captionStyle: new Array<CaptionStyleOption>() });
 
         // Set itself as the root video object
-        rootObjects.video = this;
+        sgRoot.setVideo(this);
     }
 
     get(index: BrsType) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -468,7 +468,7 @@ export async function executeFile(payload: AppPayload, customOptions?: Partial<E
     let interpreter: Interpreter;
     if (components.size > 0) {
         interpreter = await getInterpreterWithSubEnvs(components, payload.manifest, options);
-        BrsTypes.rootObjects.nodeDefMap = components;
+        BrsTypes.sgRoot.setNodeDefMap(components);
     } else {
         interpreter = new Interpreter(options);
     }
@@ -519,7 +519,7 @@ export async function executeTask(payload: TaskPayload, customOptions?: Partial<
     let interpreter: Interpreter;
     if (components.size > 0) {
         interpreter = await getInterpreterWithSubEnvs(components, payload.manifest, options);
-        BrsTypes.rootObjects.nodeDefMap = components;
+        BrsTypes.sgRoot.setNodeDefMap(components);
     } else {
         postMessage(`warning,No SceneGraph components found!`);
         return;
@@ -709,8 +709,8 @@ async function runSource(
             return { exitReason: AppExitReason.PACKAGED, cipherText: cipherText, iv: iv };
         }
         // Update Source Map with the SceneGraph components (if exists)
-        if (BrsTypes.rootObjects.nodeDefMap?.size) {
-            const components = BrsTypes.rootObjects.nodeDefMap;
+        if (BrsTypes.sgRoot.nodeDefMap?.size) {
+            const components = BrsTypes.sgRoot.nodeDefMap;
             for (const component of components.values()) {
                 for (const script of component.scripts) {
                     const sourcePath = script.uri ?? script.xmlPath;

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -39,7 +39,7 @@ import {
     RoSGNode,
     Task,
     initializeTask,
-    rootObjects,
+    sgRoot,
 } from "../brsTypes";
 import { tryCoerce } from "../brsTypes/Coercion";
 import { Lexeme, GlobalFunctions } from "../lexer";
@@ -354,7 +354,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             if (taskData.buffer) {
                 taskNode.setTaskBuffer(taskData.buffer);
             }
-            const typeDef = rootObjects.nodeDefMap.get(taskNode.nodeSubtype.toLowerCase());
+            const typeDef = sgRoot.nodeDefMap.get(taskNode.nodeSubtype.toLowerCase());
             const taskEnv = typeDef?.environment;
             if (taskEnv) {
                 const mPointer = taskNode.m;
@@ -1895,7 +1895,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             throw new Stmt.BlockEnd("debug-exit", statement.location);
         }
         if (BrsDevice.threadId > 0) {
-            rootObjects.tasks[0]?.updateTask();
+            sgRoot.tasks[0]?.updateTask();
         }
         this.location = statement.location;
         return statement.accept<BrsType>(this);


### PR DESCRIPTION
When a new instance of `Audio` or `Video` were created, the flags in the `SharedArrayBuffer` were not properly reset, so I decided to refactor the simple `RootObjects` instance, moving it to a separate module `SGRoot`, moved code from `BrsType` and `roSGScreen` to a better concise implementation.

This PR closes #693 