### PR TITLE
Fixed `Video` and `Audio` handling of changes in `content` field

### DIFF
--- a/src/core/brsTypes/nodes/Audio.ts
+++ b/src/core/brsTypes/nodes/Audio.ts
@@ -64,11 +64,13 @@ export class Audio extends RoSGNode {
             const validControl = ["start", "play", "pause", "resume", "stop"];
             const control = value.getValue().toLowerCase();
             if (validControl.includes(control)) {
+                this.checkContentChanged();
                 postMessage(`audio,${control}`);
             } else {
                 value = new BrsString("none");
             }
         } else if (fieldName === "seek" && isBrsNumber(value)) {
+            this.checkContentChanged();
             const position = jsValueOf(value) as number;
             postMessage(`audio,seek,${position * 1000}`);
         } else if (fieldName === "notificationInterval" && isBrsNumber(value)) {
@@ -127,6 +129,14 @@ export class Audio extends RoSGNode {
 
     setPosition(position: number) {
         super.set(new BrsString("position"), new Double(position / 1000));
+    }
+
+    private checkContentChanged() {
+        const content = this.getFieldValue("content");
+        if (content instanceof ContentNode && content.changed) {
+            postMessage({ audioPlaylist: this.formatContent(content) });
+            content.changed = false;
+        }
     }
 
     private formatContent(node: ContentNode) {

--- a/src/core/brsTypes/nodes/Video.ts
+++ b/src/core/brsTypes/nodes/Video.ts
@@ -242,12 +242,14 @@ export class Video extends Group {
             const validControl = ["play", "pause", "resume", "stop", "replay", "prebuffer", "skipcontent"];
             const control = value.getValue().toLowerCase();
             if (validControl.includes(control)) {
+                this.checkContentChanged();
                 postMessage(`video,${control}`);
             } else {
                 BrsDevice.stderr.write(`warning,${getNow()} [sg.video.cntrl.bad] control field set to invalid value`);
                 return BrsInvalid.Instance;
             }
         } else if (fieldName === "seek" && isBrsNumber(value)) {
+            this.checkContentChanged();
             const position = jsValueOf(value) as number;
             postMessage(`video,seek,${position * 1000}`);
         } else if (fieldName === "notificationinterval" && isBrsNumber(value)) {
@@ -714,6 +716,14 @@ export class Video extends Group {
         this.seekLevel = 0;
         this.seekTimeout = 0;
         this.trickPlayBar.setStateIcon("", 0);
+    }
+
+    private checkContentChanged() {
+        const content = this.getFieldValue("content");
+        if (content instanceof ContentNode && content.changed) {
+            this.resetContent(content);
+            content.changed = false;
+        }
     }
 
     private formatContent(node: ContentNode) {


### PR DESCRIPTION
The media playback nodes were only reacting to changes in `content` field if the field was set directly, changes on its fields were not triggering a content refresh