### PR TITLE
Fixed `LabelList` and `MarkupList` vertical navigation in `floatingFocus` mode

### DIFF
--- a/src/core/brsTypes/nodes/ArrayGrid.ts
+++ b/src/core/brsTypes/nodes/ArrayGrid.ts
@@ -88,6 +88,7 @@ export class ArrayGrid extends Group {
     protected numRows: number = 0;
     protected numCols: number = 0;
     protected currRow: number = 0;
+    protected topRow: number = 0;
     protected wrap: boolean = false;
     protected lastPressHandled: string;
     protected hasNinePatch: boolean;
@@ -473,6 +474,61 @@ export class ArrayGrid extends Group {
             return Math.min(rowStep3, currentFocus);
         }
         return focusRow;
+    }
+
+    protected updateListCurrRow() {
+        if (this.wrap) {
+            this.topRow = 0;
+            return this.updateCurrRow();
+        }
+
+        const numCols = this.numCols || 1;
+        if (numCols <= 0) {
+            this.topRow = 0;
+            return 0;
+        }
+
+        const totalRows = Math.ceil(this.content.length / numCols);
+        if (totalRows <= 0) {
+            this.topRow = 0;
+            return 0;
+        }
+
+        const desiredRows = Number.isFinite(this.numRows) && this.numRows > 0 ? Math.floor(this.numRows) : totalRows;
+        const visibleRows = Math.max(1, Math.min(desiredRows, totalRows));
+
+        let focusRowIndex = Math.floor(this.focusIndex / numCols);
+        focusRowIndex = Math.max(0, Math.min(focusRowIndex, totalRows - 1));
+
+        if (focusRowIndex < this.topRow) {
+            this.topRow = focusRowIndex;
+        } else if (focusRowIndex > this.topRow + (visibleRows - 1)) {
+            this.topRow = focusRowIndex - (visibleRows - 1);
+        }
+
+        const maxTopRow = Math.max(0, totalRows - visibleRows);
+        this.topRow = Math.max(0, Math.min(this.topRow, maxTopRow));
+
+        return Math.max(0, focusRowIndex - this.topRow);
+    }
+
+    protected clampTopRow() {
+        const numCols = this.numCols || 1;
+        if (numCols <= 0) {
+            this.topRow = 0;
+            return;
+        }
+
+        const totalRows = Math.ceil(this.content.length / numCols);
+        if (totalRows <= 0) {
+            this.topRow = 0;
+            return;
+        }
+
+        const desiredRows = Number.isFinite(this.numRows) && this.numRows > 0 ? Math.floor(this.numRows) : totalRows;
+        const visibleRows = Math.max(1, Math.min(desiredRows, totalRows));
+        const maxTopRow = Math.max(0, totalRows - visibleRows);
+        this.topRow = Math.max(0, Math.min(this.topRow, maxTopRow));
     }
 
     protected updateRect(rect: Rect, numRows: number, itemSize: number[]) {

--- a/src/core/brsTypes/nodes/LabelList.ts
+++ b/src/core/brsTypes/nodes/LabelList.ts
@@ -55,7 +55,13 @@ export class LabelList extends ArrayGrid {
             // Invalid fields for LabelList
             return BrsInvalid.Instance;
         }
-        return super.set(index, value, alwaysNotify, kind);
+        const result = super.set(index, value, alwaysNotify, kind);
+        if (fieldName === "content" || fieldName === "vertfocusanimationstyle") {
+            this.topRow = 0;
+        } else if (fieldName === "numrows") {
+            this.clampTopRow();
+        }
+        return result;
     }
 
     protected handleUpDown(key: string) {
@@ -100,7 +106,7 @@ export class LabelList extends ArrayGrid {
         }
         const hasSections = this.metadata.length > 0;
         const nodeFocus = sgRoot.focused === this;
-        this.currRow = this.updateCurrRow();
+        this.currRow = this.updateListCurrRow();
         let lastIndex = -1;
         const displayRows = Math.min(this.content.length, this.numRows);
         const itemSize = this.getFieldValueJS("itemSize") as number[];

--- a/src/core/brsTypes/nodes/MarkupList.ts
+++ b/src/core/brsTypes/nodes/MarkupList.ts
@@ -49,7 +49,13 @@ export class MarkupList extends ArrayGrid {
             // Invalid fields for MarkupList
             return BrsInvalid.Instance;
         }
-        return super.set(index, value, alwaysNotify, kind);
+        const result = super.set(index, value, alwaysNotify, kind);
+        if (fieldName === "content" || fieldName === "vertfocusanimationstyle") {
+            this.topRow = 0;
+        } else if (fieldName === "numrows") {
+            this.clampTopRow();
+        }
+        return result;
     }
 
     protected handleUpDown(key: string) {
@@ -109,7 +115,7 @@ export class MarkupList extends ArrayGrid {
         const spacing = this.getFieldValueJS("itemSpacing") as number[];
         const rowHeights = this.getFieldValueJS("rowHeights") as number[];
         const rowSpacings = this.getFieldValueJS("rowSpacings") as number[];
-        this.currRow = this.updateCurrRow();
+        this.currRow = this.updateListCurrRow();
         let lastIndex = -1;
         let sectionIndex = 0;
         const displayRows = Math.min(Math.ceil(this.content.length), this.numRows);


### PR DESCRIPTION
When navigating up in float mode with numRows < total items, the focus would jump in the top page