### PR TITLE
Fixed Dialog spacing to the divider in HD resolution

### DIFF
--- a/src/core/brsTypes/nodes/Dialog.ts
+++ b/src/core/brsTypes/nodes/Dialog.ts
@@ -126,7 +126,7 @@ export class Dialog extends Group {
             titleSize = 28;
             titleX = (this.sceneRect.width - titleWidth) / 2;
             titleY = this.dialogTrans[1] + 30;
-            dividerY = this.dialogTrans[1] + 105;
+            dividerY = this.dialogTrans[1] + 70;
             msgWidth = this.width - 118;
             msgX = (this.sceneRect.width - msgWidth) / 2;
             msgY = titleY + 74;


### PR DESCRIPTION
Before the fix:

<img width="489" height="206" alt="image" src="https://github.com/user-attachments/assets/55d0bcf3-0b6b-46be-9997-2e906807d2f2" />


After the fix:

<img width="470" height="202" alt="image" src="https://github.com/user-attachments/assets/569dcea7-4d16-4003-827e-2264e65c6f46" />
