### PR TITLE
Fixed `MicroDebugger` to properly handle a line with multiple statements separated by colon `:`

### DIFF
--- a/src/core/interpreter/MicroDebugger.ts
+++ b/src/core/interpreter/MicroDebugger.ts
@@ -167,10 +167,8 @@ async function debugHandleExpr(interpreter: Interpreter, expr: string) {
         BrsDevice.stderr.write(`error,${exprParse.errors[0].message}\r\n`);
         return;
     }
-    if (exprParse.statements.length > 0) {
-        for (const stmt of exprParse.statements) {
-            runStatement(interpreter, stmt);
-        }
+    for (const stmt of exprParse.statements) {
+        runStatement(interpreter, stmt);
     }
 }
 


### PR DESCRIPTION
Thanks to Nas Banov for pointing this out.