### PR TITLE
Generate a `registry` event when loading the registry during startup of the engine

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -518,6 +518,9 @@ function loadRegistry() {
     for (const key of transientKeys) {
         storage.removeItem(key);
     }
+    if (deviceData.registry instanceof Map) {
+        notifyAll("registry", deviceData.registry);
+    }
 }
 
 // Receive Messages from the Interpreter (Web Worker)


### PR DESCRIPTION
This allow hosting apps to properly get the latest state of the registry before running any app.