### PR TITLE
Clear the display before showing icon as splash

### DIFF
--- a/src/api/display.ts
+++ b/src/api/display.ts
@@ -145,7 +145,8 @@ export function drawSplashScreen(imgBmp: ImageBitmap, icon = false) {
         if (icon) {
             const x = Math.trunc((w - imgBmp.width) / 2);
             const y = Math.trunc((h - imgBmp.height) / 2);
-            bufferCtx.clearRect(0, 0, w, h);
+            bufferCtx.fillStyle = "black";
+            bufferCtx.fillRect(0, 0, w, h);
             bufferCtx.drawImage(imgBmp, x, y);
         } else {
             bufferCtx.drawImage(imgBmp, 0, 0, w, h);


### PR DESCRIPTION
If an app starts before another is closed the buffer was dirty and the icon would show over the last app image