### PR TITLE
Added validation to `#if` to not allow extra text after the condition token

### DIFF
--- a/src/core/preprocessor/Parser.ts
+++ b/src/core/preprocessor/Parser.ts
@@ -104,6 +104,14 @@ export class Parser {
 
                 let isNegated = match(Lexeme.Not);
                 let ifCondition = advance();
+                if (!check(Lexeme.Newline)) {
+                    emitError(
+                        new ParseError(
+                            peek(),
+                            "Invalid #If/#ElseIf expression (True | False | <CONST-NAME>) (compile error &h93)"
+                        )
+                    );
+                }
                 match(Lexeme.Newline);
 
                 let thenChunk = nChunks();
@@ -113,6 +121,14 @@ export class Parser {
                 while (match(Lexeme.HashElseIf)) {
                     let isElseIfNegated = match(Lexeme.Not);
                     let condition = advance();
+                    if (!check(Lexeme.Newline)) {
+                        emitError(
+                            new ParseError(
+                                peek(),
+                                "Invalid #If/#ElseIf expression (True | False | <CONST-NAME>) (compile error &h93)"
+                            )
+                        );
+                    }
                     match(Lexeme.Newline);
 
                     elseIfs.push({

--- a/test/e2e/ConditionalCompilation.test.js
+++ b/test/e2e/ConditionalCompilation.test.js
@@ -49,5 +49,17 @@ describe("end to end conditional compilation", () => {
                 expect(err.message.trimEnd()).toMatch(/I'm a compile-time error!/);
             });
         });
+
+        test("conditional-compilation/invalid-expression.brs", async () => {
+            await execute(
+                [
+                    resourceFile("conditional-compilation", "manifest"),
+                    resourceFile("conditional-compilation", "invalid-expression.brs"),
+                ],
+                outputStreams
+            ).catch((err) => {
+                expect(err.message).toMatch(/Invalid #If\/#ElseIf expression/);
+            });
+        });
     });
 });

--- a/test/e2e/resources/conditional-compilation/invalid-expression.brs
+++ b/test/e2e/resources/conditional-compilation/invalid-expression.brs
@@ -1,0 +1,9 @@
+#const foo = true
+#const bar = false
+
+sub main()
+    ' This should cause a compile error
+#if foo and bar
+    print "This should not parse"
+#end if
+end sub

--- a/test/preprocessor/parser.test.js
+++ b/test/preprocessor/parser.test.js
@@ -142,5 +142,70 @@ describe("preprocessor parser", () => {
             expect(chunks).not.toBeNull();
             expect(chunks).toMatchSnapshot();
         });
+
+        test("rejects #if with extra tokens after condition", () => {
+            let { errors } = parser.parse([
+                token(Lexeme.HashIf, "#if"),
+                identifier("foo"),
+                token(Lexeme.And, "and"),
+                identifier("bar"),
+                token(Lexeme.Newline, "\n"),
+                identifier("something"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\n"),
+                token(Lexeme.HashEndIf, "#endif"),
+                token(Lexeme.Eof, "\0"),
+            ]);
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toMatch(/Invalid #If\/#ElseIf expression/);
+        });
+
+        test("rejects #else if with extra tokens after condition", () => {
+            let { errors } = parser.parse([
+                token(Lexeme.HashIf, "#if"),
+                identifier("foo"),
+                token(Lexeme.Newline, "\n"),
+                identifier("something"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\n"),
+                token(Lexeme.HashElseIf, "#elseif"),
+                identifier("bar"),
+                token(Lexeme.Or, "or"),
+                identifier("baz"),
+                token(Lexeme.Newline, "\n"),
+                identifier("other"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\n"),
+                token(Lexeme.HashEndIf, "#endif"),
+                token(Lexeme.Eof, "\0"),
+            ]);
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toMatch(/Invalid #If\/#ElseIf expression/);
+        });
+
+        test("rejects #if not with extra tokens after condition", () => {
+            let { errors } = parser.parse([
+                token(Lexeme.HashIf, "#if"),
+                token(Lexeme.Not, "not"),
+                identifier("foo"),
+                token(Lexeme.Equal, "="),
+                identifier("bar"),
+                token(Lexeme.Newline, "\n"),
+                identifier("something"),
+                token(Lexeme.LeftParen, "("),
+                token(Lexeme.RightParen, ")"),
+                token(Lexeme.Newline, "\n"),
+                token(Lexeme.HashEndIf, "#endif"),
+                token(Lexeme.Eof, "\0"),
+            ]);
+
+            expect(errors).toHaveLength(1);
+            expect(errors[0].message).toMatch(/Invalid #If\/#ElseIf expression/);
+        });
     });
 });


### PR DESCRIPTION
Parser now correctly rejects expressions like:

* `#if foo and bar`
* `#else if bar or baz`
* `#if not enabled = true`