### PR TITLE
Fixed ZIP based volumes `pkg:`, `common:` and `ext1:` to show the original case on path names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@lvcabral/node-ssdp": "^4.0.4",
         "@lvcabral/sprintf": "^1.2.2",
         "@lvcabral/upng": "^2.3.0",
-        "@lvcabral/zip": "^1.3.7",
+        "@lvcabral/zip": "^1.3.8",
         "@msgpack/msgpack": "^2.8.0",
         "@zenfs/core": "^2.4.3",
         "canvas": "^3.2.0",
@@ -1476,9 +1476,9 @@
       }
     },
     "node_modules/@lvcabral/zip": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@lvcabral/zip/-/zip-1.3.7.tgz",
-      "integrity": "sha512-kTPtPi1NlZ/fUPtHGHh3tf/0UqcPrwVRZNtOzxUVa/1Cau8WLft0CC5aOxCKnPnigTN1zocA4fXcugzg7lMtOw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@lvcabral/zip/-/zip-1.3.8.tgz",
+      "integrity": "sha512-Dpd0VSFcWiFaMlndkeTUpfeJF29HHl2I8oxQt0y5NLyNLTMM2dME81SbmfVW8yLWIceplZ4wkNngPlBnMpn9uA==",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "fflate": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@lvcabral/node-ssdp": "^4.0.4",
     "@lvcabral/sprintf": "^1.2.2",
     "@lvcabral/upng": "^2.3.0",
-    "@lvcabral/zip": "^1.3.7",
+    "@lvcabral/zip": "^1.3.8",
     "@msgpack/msgpack": "^2.8.0",
     "@zenfs/core": "^2.4.3",
     "canvas": "^3.2.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,7 @@
     "@lvcabral/libwebp": "^0.1.0",
     "@lvcabral/sprintf": "^1.2.2",
     "@lvcabral/upng": "^2.3.0",
-    "@lvcabral/zip": "^1.3.7",
+    "@lvcabral/zip": "^1.3.8",
     "@msgpack/msgpack": "^2.8.0",
     "@zenfs/core": "^2.4.3",
     "crc": "^3.8.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -51,7 +51,7 @@
     "@lvcabral/node-ssdp": "^4.0.4",
     "@lvcabral/sprintf": "^1.2.2",
     "@lvcabral/upng": "^2.3.0",
-    "@lvcabral/zip": "^1.3.7",
+    "@lvcabral/zip": "^1.3.8",
     "@msgpack/msgpack": "^2.8.0",
     "@zenfs/core": "^2.4.3",
     "canvas": "^3.2.0",


### PR DESCRIPTION
The `zip` module had an issue, upgraded to fix the casing of files and folders