### PR TITLE
Raise type mismatch error when passing `Uninitialized` value to non-dynamic function parameters

### DIFF
--- a/src/core/brsTypes/Callable.ts
+++ b/src/core/brsTypes/Callable.ts
@@ -301,7 +301,7 @@ export class Callable implements Brs.BrsValue, Brs.Boxable {
             let received = args[index];
 
             let coercedValue = tryCoerce(received, expected.type.kind);
-            if (coercedValue != null) {
+            if (coercedValue !== undefined) {
                 coercedArgs[index] = coercedValue;
             } else {
                 reasons.push({

--- a/src/core/brsTypes/Coercion.ts
+++ b/src/core/brsTypes/Coercion.ts
@@ -12,11 +12,6 @@ export function tryCoerce(value: BrsType, target: ValueKind): BrsType | undefine
         return value;
     }
 
-    if (value.kind === ValueKind.Uninitialized) {
-        // allow uninitialized values to pass through unmodified, for handling by runtime code
-        return value;
-    }
-
     if (target === ValueKind.Object) {
         if (isBoxable(value)) {
             // boxable types should be promoted to their boxed equivalents whenever possible,

--- a/test/brsTypes/coercion.test.js
+++ b/test/brsTypes/coercion.test.js
@@ -55,8 +55,8 @@ describe("type coercion", () => {
             expect(tryCoerce(input, target)).toBe(input);
         });
 
-        it("returns uninitialized for any target type", () => {
-            expect(tryCoerce(Uninitialized.Instance, ValueKind.String)).toBe(Uninitialized.Instance);
+        it("returns uninitialized for dynamic type", () => {
+            expect(tryCoerce(Uninitialized.Instance, ValueKind.Dynamic)).toBe(Uninitialized.Instance);
         });
 
         describe("boxing", () => {


### PR DESCRIPTION
The code below should generate an error:

```brs
sub main()
  print getSomething(something)
end sub

function getSomething(param as string)
  return param
end function
```