### PR TITLE
(api) Fix: Added back API library types to the package

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -33,7 +33,7 @@
     "assets/",
     "lib/brs.worker.js",
     "lib/*.LICENSE.txt",
-    "types/src/api/",
+    "types/",
     "CHANGELOG.md"
   ],
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./api";
 export * from "./core";
 export * from "./core/brsTypes";
 export * from "./core/interpreter";


### PR DESCRIPTION
After the refactoring, the API types were not exposed in `types/index.d.ts`