### PR TITLE
Support rendering during wait() on local roMessagePort

### DIFF
--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -82,7 +82,7 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
 
     private updateMessageQueue(interpreter?: Interpreter, wait?: number) {
         BrsDevice.refreshExtVolume();
-        if (this.callbackMap.size > 0) {
+        if (interpreter && this.callbackMap.size > 0) {
             for (const [_, callback] of this.callbackMap.entries()) {
                 const events = callback(interpreter, wait);
                 this.messageQueue.push(...events.filter((e: BrsType) => e instanceof BrsEvent));

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -5,7 +5,7 @@
  *
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { BrsDevice, BufferType, DataType, genHexAddress, Interpreter, MediaEvent, MediaTrack } from "brs-engine";
+import { BrsDevice, BufferType, DataType, genHexAddress, Interpreter, MediaEvent, MediaTrack, RoMessagePort } from "brs-engine";
 import { ComponentDefinition } from "./parser/ComponentDefinition";
 import { Global } from "./nodes/Global";
 import { ThreadInfo } from "./SGTypes";
@@ -37,6 +37,7 @@ export class SGRoot {
     private _audio?: Audio;
     private _video?: Video;
     private _dirty: boolean = false;
+    private _pendingPorts: RoMessagePort[] = [];
 
     get interpreter(): Interpreter | undefined {
         return this._interpreter;
@@ -170,11 +171,24 @@ export class SGRoot {
     }
 
     /**
+     * Stores a port to be registered with the screen once it is created.
+     * @param port RoMessagePort to register later
+     */
+    addPendingPort(port: RoMessagePort) {
+        this._pendingPorts.push(port);
+    }
+
+    /**
      * Sets the RoSGScreen instance for the application.
+     * Retroactively registers any ports created before the screen.
      * @param screen RoSGScreen instance to set
      */
     setScreen(screen: RoSGScreen) {
         this._screen = screen;
+        for (const port of this._pendingPorts) {
+            screen.registerPort(port);
+        }
+        this._pendingPorts.length = 0;
     }
 
     /**

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -5,7 +5,16 @@
  *
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { BrsDevice, BufferType, DataType, genHexAddress, Interpreter, MediaEvent, MediaTrack, RoMessagePort } from "brs-engine";
+import {
+    BrsDevice,
+    BufferType,
+    DataType,
+    genHexAddress,
+    Interpreter,
+    MediaEvent,
+    MediaTrack,
+    RoMessagePort,
+} from "brs-engine";
 import { ComponentDefinition } from "./parser/ComponentDefinition";
 import { Global } from "./nodes/Global";
 import { ThreadInfo } from "./SGTypes";

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -46,7 +46,7 @@ export class SGRoot {
     private _audio?: Audio;
     private _video?: Video;
     private _dirty: boolean = false;
-    private _pendingPorts: RoMessagePort[] = [];
+    private readonly _pendingPorts: RoMessagePort[] = [];
 
     get interpreter(): Interpreter | undefined {
         return this._interpreter;

--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -62,6 +62,7 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
     private sceneType?: BrsString;
     private alphaEnable: boolean;
     private lastMessage: number;
+    private rendering: boolean;
     width: number;
     height: number;
     scaleMode: number;
@@ -75,6 +76,7 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
         this.alphaEnable = true;
         this.scaleMode = 1;
         this.isDirty = false;
+        this.rendering = false;
         this.lastMessage = performance.now();
         const maxFps = BrsDevice.deviceInfo.maxFps;
         this.maxMs = Math.trunc((1 / maxFps) * 1000);
@@ -174,43 +176,55 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
 
     /** Message callback to handle control keys and Scene rendering */
     private getNewEvents(interpreter: Interpreter) {
-        const events: BrsEvent[] = [];
-        // Handle control keys
-        const event = this.handleNextKey(interpreter);
-        if (event instanceof BrsEvent) {
-            events.push(event);
+        if (this.rendering || !interpreter) {
+            return [];
         }
-        // Handle Scene Events
-        if (sgRoot.scene instanceof Scene) {
-            const timersFired = sgRoot.processTimers();
-            const animUpdated = sgRoot.processAnimations();
-            const tasksUpdated = sgRoot.processTasks();
-            const audioUpdated = sgRoot.processAudio();
-            const sfxUpdated = sgRoot.processSFX();
-            const videoUpdated = sgRoot.processVideo();
-            this.isDirty ||= timersFired || animUpdated || tasksUpdated || audioUpdated || sfxUpdated || videoUpdated;
-            // Render Scene and Dialog
-            const showDialog = sgRoot.scene?.dialog instanceof Node;
-            if (sgRoot.isDirty || this.isDirty || showDialog) {
-                sgRoot.clearDirty();
-                sgRoot.scene.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+        this.rendering = true;
+        try {
+            const events: BrsEvent[] = [];
+            // Handle control keys
+            const event = this.handleNextKey(interpreter);
+            if (event instanceof RoSGScreenEvent) {
+                // Route screen events to the screen's own port (matches Roku behavior)
+                this.port?.pushMessage(event);
+            } else if (event instanceof BrsEvent) {
+                events.push(event);
             }
-            if (showDialog) {
-                const dialog = sgRoot.scene.dialog!;
-                dialog.setValueSilent("visible", BrsBoolean.True);
-                const screenRect = { x: 0, y: 0, width: this.width, height: this.height };
-                this.draw2D.doDrawRotatedRect(screenRect, 255, 0, [0, 0], 0.5);
-                dialog.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+            // Handle Scene Events
+            if (sgRoot.scene instanceof Scene) {
+                const timersFired = sgRoot.processTimers();
+                const animUpdated = sgRoot.processAnimations();
+                const tasksUpdated = sgRoot.processTasks();
+                const audioUpdated = sgRoot.processAudio();
+                const sfxUpdated = sgRoot.processSFX();
+                const videoUpdated = sgRoot.processVideo();
+                this.isDirty ||=
+                    timersFired || animUpdated || tasksUpdated || audioUpdated || sfxUpdated || videoUpdated;
+                // Render Scene and Dialog
+                const showDialog = sgRoot.scene?.dialog instanceof Node;
+                if (sgRoot.isDirty || this.isDirty || showDialog) {
+                    sgRoot.clearDirty();
+                    sgRoot.scene.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+                }
+                if (showDialog) {
+                    const dialog = sgRoot.scene.dialog!;
+                    dialog.setValueSilent("visible", BrsBoolean.True);
+                    const screenRect = { x: 0, y: 0, width: this.width, height: this.height };
+                    this.draw2D.doDrawRotatedRect(screenRect, 255, 0, [0, 0], 0.5);
+                    dialog.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+                }
+                // Limited FPS enforcement
+                let timeStamp = Date.now();
+                while (timeStamp - this.lastMessage < this.maxMs) {
+                    timeStamp = Date.now();
+                }
+                this.finishDraw();
+                this.lastMessage = timeStamp;
             }
-            // Limited FPS enforcement
-            let timeStamp = Date.now();
-            while (timeStamp - this.lastMessage < this.maxMs) {
-                timeStamp = Date.now();
-            }
-            this.finishDraw();
-            this.lastMessage = timeStamp;
+            return events;
+        } finally {
+            this.rendering = false;
         }
-        return events;
     }
 
     /** Handle control keys */

--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -26,7 +26,6 @@ import { sgRoot } from "./SGRoot";
 import { Task } from "./nodes/Task";
 import { initializeTask, createNode, updateTypeDefHierarchy, getNodeType } from "./factory/NodeFactory";
 import { RoSGScreen } from "./components/RoSGScreen";
-import { RoSGNode } from "./components/RoSGNode";
 import packageInfo from "../../../packages/scenegraph/package.json";
 
 export * from "./SGRoot";
@@ -60,10 +59,11 @@ export class BrightScriptExtension implements BrsExtension {
     private createMessagePort(interpreter?: Interpreter): RoMessagePort {
         const port = new RoMessagePort();
         if (interpreter && !sgRoot.inTaskThread()) {
-            const inRender = interpreter.environment.getRootM().elements.get("top") instanceof RoSGNode;
-            if (!inRender) {
-                // All ports created in Main thread are registered to the screen
-                sgRoot.screen?.registerPort(port);
+            // All ports created in Main thread are registered to the screen
+            if (sgRoot.screen) {
+                sgRoot.screen.registerPort(port);
+            } else {
+                sgRoot.addPendingPort(port);
             }
         }
         return port;

--- a/test/e2e/SceneGraph.test.js
+++ b/test/e2e/SceneGraph.test.js
@@ -206,6 +206,34 @@ describe("SceneGraph node tests", () => {
             "All subtype tests completed successfully!",
         ]);
     });
+    test("local-port-rendering.brs", async () => {
+        await execute([resourceFile("scenegraph", "local-port-rendering.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            "=== Local Port Rendering Tests ===",
+            "Test 1: Screen and screen port created",
+            "Test 2: wait() on local port returned: Invalid",
+            "Test 3: getMessage() on local port returned: Invalid",
+            "Test 4: peekMessage() on local port returned: Invalid",
+            "Test 5: Field change event received on local port: roSGNodeEvent",
+            "Test 6: Field change event received on second local port: roSGNodeEvent",
+            "=== All Local Port Rendering Tests Passed ===",
+        ]);
+    });
+
+    test("port-before-screen.brs", async () => {
+        await execute([resourceFile("scenegraph", "port-before-screen.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            "=== Port Before Screen Tests ===",
+            "Test 1: Port created before screen",
+            "Test 2: Screen created after port",
+            "Test 3: wait() on early port returned: Invalid",
+            "Test 4: Field change event on early port: roSGNodeEvent",
+            "=== All Port Before Screen Tests Passed ===",
+        ]);
+    });
+
     test("update-fields.brs", async () => {
         await execute([resourceFile("scenegraph", "update-fields.brs")], outputStreams);
 

--- a/test/e2e/resources/scenegraph/local-port-rendering.brs
+++ b/test/e2e/resources/scenegraph/local-port-rendering.brs
@@ -1,0 +1,49 @@
+sub main()
+    print "=== Local Port Rendering Tests ==="
+
+    ' Test 1: Create screen and screen port (baseline)
+    screen = CreateObject("roSGScreen")
+    screenPort = CreateObject("roMessagePort")
+    screen.setMessagePort(screenPort)
+    print "Test 1: Screen and screen port created"
+
+    ' Test 2: Create a local port and wait on it with a short timeout
+    ' This should not crash — the screen's render callback should run safely
+    localPort = CreateObject("roMessagePort")
+    msg = wait(50, localPort)
+    print "Test 2: wait() on local port returned: "; type(msg)
+
+    ' Test 3: getMessage() on local port should not crash
+    msg = localPort.getMessage()
+    print "Test 3: getMessage() on local port returned: "; type(msg)
+
+    ' Test 4: peekMessage() on local port should not crash
+    msg = localPort.peekMessage()
+    print "Test 4: peekMessage() on local port returned: "; type(msg)
+
+    ' Test 5: Create a node, observe a field on the local port, change it,
+    ' and verify the event arrives on the local port
+    node = CreateObject("roSGNode", "Node")
+    node.observeField("id", localPort)
+    node.id = "testNode"
+    msg = wait(100, localPort)
+    if msg <> invalid
+        print "Test 5: Field change event received on local port: "; type(msg)
+    else
+        print "Test 5: No event received on local port"
+    end if
+
+    ' Test 6: Multiple local ports should work independently
+    localPort2 = CreateObject("roMessagePort")
+    node2 = CreateObject("roSGNode", "Node")
+    node2.observeField("id", localPort2)
+    node2.id = "testNode2"
+    msg2 = wait(100, localPort2)
+    if msg2 <> invalid
+        print "Test 6: Field change event received on second local port: "; type(msg2)
+    else
+        print "Test 6: No event received on second local port"
+    end if
+
+    print "=== All Local Port Rendering Tests Passed ==="
+end sub

--- a/test/e2e/resources/scenegraph/port-before-screen.brs
+++ b/test/e2e/resources/scenegraph/port-before-screen.brs
@@ -1,0 +1,31 @@
+sub main()
+    print "=== Port Before Screen Tests ==="
+
+    ' Test 1: Create a port BEFORE the screen exists
+    ' The port should be retroactively registered when the screen is created
+    earlyPort = CreateObject("roMessagePort")
+    print "Test 1: Port created before screen"
+
+    ' Now create the screen — pending ports should be flushed
+    screen = CreateObject("roSGScreen")
+    screenPort = CreateObject("roMessagePort")
+    screen.setMessagePort(screenPort)
+    print "Test 2: Screen created after port"
+
+    ' Test 3: wait() on the early port should work (render callback registered)
+    msg = wait(50, earlyPort)
+    print "Test 3: wait() on early port returned: "; type(msg)
+
+    ' Test 4: Observe a field on the early port and verify events arrive
+    node = CreateObject("roSGNode", "Node")
+    node.observeField("id", earlyPort)
+    node.id = "earlyTest"
+    msg = wait(100, earlyPort)
+    if msg <> invalid
+        print "Test 4: Field change event on early port: "; type(msg)
+    else
+        print "Test 4: No event received on early port"
+    end if
+
+    print "=== All Port Before Screen Tests Passed ==="
+end sub


### PR DESCRIPTION
Fixes #912

On a real Roku the render thread runs independently of which `roMessagePort` BrightScript is blocking on. Currently, rendering and `onKeyEvent` dispatch only happen when `wait()` is called on a port that has the screen's callback registered. This causes apps like [JellyRock](https://github.com/nickneos/jellyrock) that use local ports for screen-specific event loops to stay frozen on the splash screen.

Verified at [demo.jellyrock.app](https://demo.jellyrock.app) — the server select and user select screens now render with this change.

## Changes

- Guard `updateMessageQueue` against undefined interpreter so `getMessage()`/`peekMessage()` don't invoke render callbacks without one
- Add re-entrancy guard to `RoSGScreen.getNewEvents()` to prevent double rendering when multiple ports carry the screen callback
- Route `RoSGScreenEvent` to the screen's own port rather than whichever port triggered the callback, matching real Roku behavior
- Remove the `inRender` restriction from `createMessagePort()` so ports created inside component scope also receive the screen's render callback
- Store pending ports on `SGRoot` and flush them when the screen is created, covering ports instantiated before `roSGScreen` exists
- Add e2e tests for local port `wait()`/`getMessage()`/`peekMessage()`, field observation on local ports, multiple independent ports, and ports created before the screen

## Test limitations

The core bug (component-scope port not receiving render callbacks due to the `inRender` check) requires a full SceneGraph app with custom component XML definitions and `callFunc` to reproduce in a test. The existing e2e test infrastructure doesn't support loading SceneGraph component XML via `executeFromFileMap`, so we couldn't write an automated test that fails on master and passes with this fix. The included e2e tests cover the surrounding local port patterns and serve as regression guards for the port/callback system.