### PR TITLE
(brs) Restored `roMessagePort` behavior when the `interpreter` instance is not passed to `updateMessageQueue`

### DIFF
--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -82,7 +82,7 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
 
     private updateMessageQueue(interpreter?: Interpreter, wait?: number) {
         BrsDevice.refreshExtVolume();
-        if (interpreter && this.callbackMap.size > 0) {
+        if (this.callbackMap.size > 0) {
             for (const [_, callback] of this.callbackMap.entries()) {
                 const events = callback(interpreter, wait);
                 this.messageQueue.push(...events.filter((e: BrsType) => e instanceof BrsEvent));


### PR DESCRIPTION
After #912 the behavior of `roMessagePort` was not correct, as sometimes the `updateMessageQueue` is called without an instance of the interpreter, this PR fixes this issue.