### PR TITLE
fix(scenegraph): carry a custom node's script-scope m across threads

### DIFF
--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -32,6 +32,52 @@ import { FieldKind, ObservedField } from "../SGTypes";
 import { sgRoot } from "../SGRoot";
 
 /**
+ * A `visited` view that forwards to a base set but can undo its own additions.
+ *
+ * Nodes normally stay in `visited` for a whole pass so a node reachable twice is deduped as a
+ * `_circular_` stub. That is wrong for a node's script-scope `m` (`_m_`), which is an *extra* copy
+ * of state that is usually also reachable from the enclosing pass — a Task's `m` serializes `m.top`
+ * (emitting its `_m_`) before its own sibling entries, so those siblings would degrade to stubs the
+ * receiver cannot resolve (`loadTaskData` rebuilds each entry with its own node map) and read back
+ * as `invalid`. Serializing `_m_` through a scoped view keeps cycle detection intact for the `_m_`
+ * subtree while leaving the enclosing pass free to serialize those values in full.
+ */
+class ScopedVisited {
+    private readonly added: object[] = [];
+    readonly [Symbol.toStringTag] = "WeakSet";
+
+    constructor(private readonly base: WeakSet<object>) {}
+
+    has(value: object): boolean {
+        return this.base.has(value);
+    }
+
+    add(value: object): this {
+        if (!this.base.has(value)) {
+            this.added.push(value);
+        }
+        this.base.add(value);
+        return this;
+    }
+
+    delete(value: object): boolean {
+        const index = this.added.indexOf(value);
+        if (index >= 0) {
+            this.added.splice(index, 1);
+        }
+        return this.base.delete(value);
+    }
+
+    /** Removes everything this view added, restoring the base set to its pre-scope state. */
+    rollback() {
+        for (const value of this.added) {
+            this.base.delete(value);
+        }
+        this.added.length = 0;
+    }
+}
+
+/**
  * Converts a BrsType value to its representation as a JavaScript type.
  * @param {BrsType} value Some BrsType value.
  * @param {boolean} deep Whether to recursively convert nested structures. Defaults to true.
@@ -466,6 +512,7 @@ export function toSGNode(obj: any, type: string, subtype: string, child?: boolea
             newNode.setValueSilent(key, BrsInvalid.Instance, undefined, FieldKind.fromString(fieldTypes[key]));
         }
     }
+    restoreScriptScopeM(obj["_m_"], newNode, nodeMap);
     if (child && obj["_children_"]) {
         for (const child of obj["_children_"]) {
             const childInfo = getSerializedNodeInfo(child);
@@ -478,6 +525,37 @@ export function toSGNode(obj: any, type: string, subtype: string, child?: boolea
         }
     }
     return newNode;
+}
+
+/**
+ * Merges a serialized script-scope `m` (see fromSGNode's `_m_` entry) into a node's `m`,
+ * preserving the locally built `top`/`global` entries. No-op for payloads without `_m_`.
+ * @param serializedM The serialized `_m_` object, if present.
+ * @param node Node whose `m` receives the entries.
+ * @param nodeMap Optional map tracking nodes by address for resolving circular references.
+ */
+function restoreScriptScopeM(serializedM: any, node: Node, nodeMap?: Map<string, Node>) {
+    if (!serializedM || typeof serializedM !== "object") {
+        return;
+    }
+    for (const [key, value] of Object.entries(serializedM)) {
+        node.m.set(new BrsString(key), brsValueOf(value, undefined, nodeMap), true);
+    }
+}
+
+/**
+ * Checks whether a node's `m` holds any script-scope entries beyond the automatic `top`/`global`.
+ * @param node Node to inspect.
+ * @returns True when `m` was populated (locally or by a previous restore).
+ */
+function hasScriptScopeM(node: Node): boolean {
+    for (const key of node.m.elements.keys()) {
+        const lowerKey = key.toLowerCase();
+        if (lowerKey !== "top" && lowerKey !== "global") {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**
@@ -562,6 +640,12 @@ export function updateSGNode(obj: any, targetNode: Node, nodeMap?: Map<string, N
         if (!(key in obj)) {
             targetNode.setValueSilent(key, BrsInvalid.Instance, undefined, FieldKind.fromString(fieldTypes[key]));
         }
+    }
+    // Populate script-scope `m` only when the target never had one (a flat-created cross-thread
+    // copy holding just top/global): a locally populated `m` is authoritative and must not be
+    // clobbered by a stale copy from the other thread.
+    if (!hasScriptScopeM(targetNode)) {
+        restoreScriptScopeM(obj["_m_"], targetNode, nodeMap);
     }
     // Update children
     const serializedChildren = obj["_children_"];
@@ -701,6 +785,29 @@ export function fromSGNode(node: Node, deep: boolean = true, host?: Node, visite
     }
     if (observed.length) {
         result["_observed_"] = observed;
+    }
+    // A custom component's script-scope `m` (populated by its init() on the owning thread) must
+    // travel with the node: the receiving thread rebuilds the node without running init(), so a
+    // callFunc there would otherwise read init()-set variables back as invalid. `top`/`global`
+    // are excluded — the receiver rebuilds them locally, and serializing them here would re-walk
+    // the node and ship the entire global tree.
+    if (deep && sgRoot.nodeDefMap.has(node.nodeSubtype.toLowerCase())) {
+        const mData: FlexObject = {};
+        // Scoped so the values serialized here don't stay marked as visited: the enclosing pass may
+        // reach the same values by another route and must serialize them in full (see ScopedVisited).
+        const scoped = new ScopedVisited(visited);
+        const scopedVisited = scoped as unknown as WeakSet<object>;
+        for (const [key, value] of node.m.elements) {
+            const lowerKey = key.toLowerCase();
+            if (lowerKey === "top" || lowerKey === "global") {
+                continue;
+            }
+            mData[key] = jsValueOf(value, deep, host, scopedVisited);
+        }
+        scoped.rollback();
+        if (Object.keys(mData).length) {
+            result["_m_"] = mData;
+        }
     }
     const children = node.getNodeChildren();
     if (deep && children.length > 0 && node.serializesChildren()) {

--- a/test/extensions/scenegraph/NodeSerialization.test.js
+++ b/test/extensions/scenegraph/NodeSerialization.test.js
@@ -1,8 +1,9 @@
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { Node, fromSGNode, toSGNode, jsValueOf, fromAssociativeArray } = scenegraph;
-const { BrsInvalid, isInvalid, BrsString, RoAssociativeArray, RoArray } = core;
+const { Node, fromSGNode, toSGNode, updateSGNode, jsValueOf, fromAssociativeArray } = scenegraph;
+const { ComponentDefinition, sgRoot, createFlatNode } = scenegraph;
+const { BrsInvalid, isInvalid, BrsString, BrsBoolean, RoAssociativeArray, RoArray } = core;
 
 /** Simulates the structured/JSON round-trip a node undergoes when sent to a Task thread. */
 function transfer(serialized) {
@@ -108,6 +109,93 @@ describe("SceneGraph node serialization", () => {
             const serialized = fromSGNode(node, true);
             expect(serialized.payload.helper.plugin).toBeNull();
             expect(() => JSON.stringify(serialized)).not.toThrow();
+        });
+    });
+
+    describe("custom component script-scope m", () => {
+        // Mirrors the device contract: a node created on a Task thread runs init() there
+        // (populating its script-scope `m`), and a later callFunc on the receiving thread must
+        // still see that state — init() is never re-run on the other side.
+        beforeEach(() => {
+            const def = new ComponentDefinition("pkg:/components/CustomHelper.xml");
+            def.name = "CustomHelper";
+            def.xmlNode = { attr: { name: "CustomHelper", extends: "Node" } };
+            sgRoot.setNodeDefMap(new Map([["customhelper", def]]));
+        });
+
+        afterEach(() => {
+            sgRoot.setNodeDefMap(new Map());
+        });
+
+        function makeInitializedNode() {
+            // Simulates initializeNode(): m holds top/global plus init()-set variables
+            // (BrightScript m writes preserve key case).
+            const node = new Node([], "CustomHelper");
+            node.m.set(new BrsString("top"), node, true);
+            node.m.set(new BrsString("setupCalled"), BrsBoolean.False, true);
+            node.m.set(new BrsString("label"), new BrsString("ready"), true);
+            return node;
+        }
+
+        function mValue(node, key) {
+            return jsValueOf(node.m.get(new BrsString(key)));
+        }
+
+        test("serializes init()-set m entries, excluding top and global", () => {
+            const serialized = fromSGNode(makeInitializedNode(), true);
+            expect(serialized._m_).toEqual({ setupCalled: false, label: "ready" });
+        });
+
+        test("restores m on the receiving thread so callFunc-visible state survives", () => {
+            const serialized = fromSGNode(makeInitializedNode(), true);
+            const target = toSGNode(transfer(serialized), "Node", "CustomHelper");
+            expect(mValue(target, "setupCalled")).toBe(false);
+            expect(mValue(target, "label")).toBe("ready");
+            // The locally built m.top still points at the restored node itself.
+            expect(target.m.get(new BrsString("top"))).toBe(target);
+        });
+
+        test("does not mark m values as visited for the enclosing serialization", () => {
+            // A task's `m` serializes `m.top` (which emits `_m_`) before its sibling entries. If the
+            // `_m_` pass left those values marked as visited, the sibling would degrade to a
+            // `_circular_` stub that the receiver rebuilds as `invalid` (it restores each entry with
+            // its own node map), silently losing the task's own state.
+            const taskNode = new Node([], "CustomHelper");
+            const content = new Node([], "ContentNode");
+            content.setValueSilent("title", new BrsString("hello"));
+            const m = taskNode.m;
+            m.set(new BrsString("top"), taskNode, true);
+            m.set(new BrsString("mynode"), content, true);
+
+            const serialized = fromAssociativeArray(m, true, taskNode);
+            expect(serialized.mynode._circular_).toBeUndefined();
+            expect(serialized.mynode.title).toBe("hello");
+        });
+
+        test("a built-in node never emits _m_", () => {
+            const node = new Node([], "Node");
+            node.m.set(new BrsString("stuff"), new BrsString("internal"));
+            expect(fromSGNode(node, true)._m_).toBeUndefined();
+        });
+
+        test("a shallow serialization (deep = false) skips m", () => {
+            expect(fromSGNode(makeInitializedNode(), false)._m_).toBeUndefined();
+        });
+
+        test("updateSGNode populates m on a flat node but never clobbers local state", () => {
+            const serialized = transfer(fromSGNode(makeInitializedNode(), true));
+
+            const flat = createFlatNode("Node", "CustomHelper");
+            updateSGNode(serialized, flat);
+            expect(mValue(flat, "setupCalled")).toBe(false);
+            expect(mValue(flat, "label")).toBe("ready");
+
+            const local = createFlatNode("Node", "CustomHelper");
+            local.m.set(new BrsString("setupCalled"), BrsBoolean.True);
+            updateSGNode(serialized, local);
+            // Locally mutated m is authoritative; the stale serialized copy must not overwrite it.
+            expect(mValue(local, "setupCalled")).toBe(true);
+            expect(isInvalid(local.m.get(new BrsString("label")))).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Root cause

A node created on one thread runs its component's `init()` there, which populates its script-scope `m`. When that node crosses to another thread, the receiver rebuilds it through `createFlatNode`/`createNodeByTypeDef` and never re-runs `init()` — correctly, since Roku doesn't either. But `m` was rebuilt holding only the automatic `top`/`global`, so a `callFunc` on the receiving thread read every `init()`-set variable back as `invalid`:

```
Type Mismatch. Operator "not" can't be applied to "Invalid"   ' if not m.setupCalled
```

On a device the node is a single object and its `m` travels with it.

## Fix

- `fromSGNode` serializes a custom component's `m` entries as a new `_m_` metadata key; `toSGNode` merges them into the `m` the receiver already built. `top`/`global` are excluded — the receiver builds those locally, and serializing them would re-walk the node and ship the whole global tree.
- `updateSGNode` applies `_m_` only when the target has no script-scope entries yet, so a locally populated `m` is never clobbered by a stale copy from the other thread.
- `_m_` is serialized through a **scoped view of the `visited` set** that undoes its own additions. `_m_` duplicates state the enclosing pass often reaches by another route — a Task's `m` serializes `m.top` (emitting its `_m_`) before its own sibling entries — and a value left marked visited there would degrade to a `_circular_` stub the receiver cannot resolve, because `loadTaskData` rebuilds each entry with its own node map. That silently produced `invalid` for the task's own `m` values.

Legacy payloads without `_m_` behave exactly as before; built-in nodes emit nothing.

## Tests

`test/extensions/scenegraph/NodeSerialization.test.js` — 6 new cases covering the round-trip, the `top`/`global` exclusion, built-in nodes emitting no `_m_`, the shallow path skipping it, the `updateSGNode` no-clobber rule, and the `visited` scoping.

Full suite green (2234 tests), lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)