### PR TITLE
fix(scenegraph): deliver a task's pre-launch port events to its thread

### DIFF
--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -27,6 +27,21 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         this.messageQueue.push(object);
     }
 
+    /**
+     * Removes and returns the queued events matching the predicate, preserving their order.
+     * Events not matching stay queued.
+     */
+    drainMessages(predicate: (event: BrsEvent) => boolean): BrsEvent[] {
+        const drained: BrsEvent[] = [];
+        for (let i = 0; i < this.messageQueue.length; i++) {
+            if (predicate(this.messageQueue[i])) {
+                drained.push(...this.messageQueue.splice(i, 1));
+                i--;
+            }
+        }
+        return drained;
+    }
+
     pushCallback(callback: Function) {
         this.callbackQueue.push(callback);
     }

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -458,6 +458,8 @@ export type TaskData = {
     tmp?: SharedArrayBuffer;
     cacheFS?: SharedArrayBuffer;
     m?: any;
+    /** roSGNodeEvents queued on ports held by the task's `m` before launch, keyed by m entry name. */
+    portEvents?: Record<string, any[]>;
     render?: string;
 };
 

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -112,7 +112,7 @@ import {
 } from "../nodes";
 import { Field } from "../nodes/Field";
 import { ComponentDefinition, ComponentNode } from "../parser/ComponentDefinition";
-import { brsValueOf } from "./Serializer";
+import { brsValueOf, replayPortNodeEvents } from "./Serializer";
 import { sgRoot } from "../SGRoot";
 import { convertHexColor, convertLong, convertNumber } from "../SGUtil";
 import { FieldAliasTarget, FieldKind, ObservedField } from "../SGTypes";
@@ -723,6 +723,11 @@ function loadTaskData(interpreter: Interpreter, node: Node, taskData: TaskData) 
     }
     if (taskData.m?.top) {
         restoreNode(interpreter, taskData.m.top, node, port);
+    }
+    // Deliver events that were already queued on the task's ports before launch (a device task
+    // sees them because its copied `m` references the same native port).
+    if (taskData.portEvents) {
+        replayPortNodeEvents(taskData.portEvents, node.m, node, sgRoot.mGlobal);
     }
 }
 

--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -25,11 +25,13 @@ import {
     Expr,
     resolveAnonymousCallable,
     toCallable,
+    RoMessagePort,
 } from "brs-engine";
 import { createFlatNode } from "./NodeFactory";
 import { ContentNode, Node, SGNodeType } from "../nodes";
 import { FieldKind, ObservedField } from "../SGTypes";
 import { sgRoot } from "../SGRoot";
+import { RoSGNodeEvent } from "../events/RoSGNodeEvent";
 
 /**
  * Converts a BrsType value to its representation as a JavaScript type.
@@ -713,6 +715,110 @@ export function fromSGNode(node: Node, deep: boolean = true, host?: Node, visite
     }
 
     return result;
+}
+
+/** Serialized form of a roSGNodeEvent queued on a task's port before the task thread launched. */
+export interface SerializedPortEvent {
+    /** Address of the node the event originated from. */
+    node: string;
+    field: string;
+    value: any;
+    info?: any;
+}
+
+/**
+ * Drains the roSGNodeEvents queued on message ports held directly by a task's `m` and serializes
+ * them for the launching task thread. On a device the task's copied `m` references the same native
+ * port, so events queued before `control = "RUN"` (e.g. a field set right before launch, observed
+ * by the port in init()) are seen by the task function's wait(); the simulator must carry them
+ * across explicitly or the task blocks forever on a wait for an event that already fired.
+ * @param m The task node's script-scope `m`.
+ * @param host The task node (observer context for value serialization).
+ * @returns Events keyed by the `m` entry holding the port, or undefined when none are queued.
+ */
+export function collectPortNodeEvents(
+    m: RoAssociativeArray,
+    host: Node
+): Record<string, SerializedPortEvent[]> | undefined {
+    let result: Record<string, SerializedPortEvent[]> | undefined;
+    for (const [key, value] of m.elements) {
+        if (!(value instanceof RoMessagePort)) {
+            continue;
+        }
+        const events = value.drainMessages((event) => event instanceof RoSGNodeEvent) as RoSGNodeEvent[];
+        if (events.length === 0) {
+            continue;
+        }
+        result ??= {};
+        result[key] = events.map((event) => ({
+            node: event.node.getAddress(),
+            field: event.fieldName.getValue(),
+            value: jsValueOf(event.fieldValue, true, host),
+            info: event.infoFields ? fromAssociativeArray(event.infoFields, true, host) : undefined,
+        }));
+    }
+    return result;
+}
+
+/**
+ * Discards the node events queued on a task's render-side ports. While a task runs, field changes
+ * reach it live (the render thread pushes to the observing task), yet the render-side copy of the
+ * port keeps queueing the same events and nothing consumes them. Dropping them when the task stops
+ * keeps a restart replaying only what was queued while it was stopped — otherwise a stop/run cycle
+ * (the standard polling-task pattern) would replay the whole previous run's backlog at once.
+ * @param m The task node's script-scope `m`.
+ */
+export function dropPortNodeEvents(m: RoAssociativeArray): void {
+    for (const value of m.elements.values()) {
+        if (value instanceof RoMessagePort) {
+            value.drainMessages((event) => event instanceof RoSGNodeEvent);
+        }
+    }
+}
+
+/** One-shot warning when a pre-launch port event can't be re-targeted on the task thread. */
+let warnedUnresolvedPortEvent = false;
+
+/**
+ * Replays pre-launch port events (see `collectPortNodeEvents`) into the task thread's restored
+ * ports, re-targeting each event's node to its task-side instance. Events from nodes other than
+ * the task node or the global node can't be resolved this early and are dropped with a warning.
+ * @param portEvents Serialized events keyed by the `m` entry holding the port.
+ * @param m The task-side `m` holding the restored ports.
+ * @param taskNode The task node on the task thread.
+ * @param globalNode The task thread's global node.
+ */
+export function replayPortNodeEvents(
+    portEvents: Record<string, SerializedPortEvent[]>,
+    m: RoAssociativeArray,
+    taskNode: Node,
+    globalNode: Node
+): void {
+    for (const [key, events] of Object.entries(portEvents)) {
+        const port = m.get(new BrsString(key));
+        if (!(port instanceof RoMessagePort)) {
+            continue;
+        }
+        for (const event of events) {
+            let target: Node | undefined;
+            if (event.node === taskNode.getAddress()) {
+                target = taskNode;
+            } else if (event.node === globalNode.getAddress()) {
+                target = globalNode;
+            }
+            if (!target) {
+                if (!warnedUnresolvedPortEvent) {
+                    warnedUnresolvedPortEvent = true;
+                    BrsDevice.stderr.write(
+                        `warning,[sg] Dropped pre-launch port event for field "${event.field}": source node not available on the task thread`
+                    );
+                }
+                continue;
+            }
+            const info = event.info ? (brsValueOf(event.info) as RoAssociativeArray) : undefined;
+            port.pushMessage(new RoSGNodeEvent(target, new BrsString(event.field), brsValueOf(event.value), info));
+        }
+    }
 }
 
 /**

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -19,7 +19,15 @@ import {
     RuntimeErrorDetail,
 } from "brs-engine";
 import { sgRoot } from "../SGRoot";
-import { brsValueOf, fromAssociativeArray, fromSGNode, jsValueOf, updateSGNode } from "../factory/Serializer";
+import {
+    brsValueOf,
+    collectPortNodeEvents,
+    dropPortNodeEvents,
+    fromAssociativeArray,
+    fromSGNode,
+    jsValueOf,
+    updateSGNode,
+} from "../factory/Serializer";
 import { FieldKind, FieldModel, MethodCallPayload, isMethodCallPayload } from "../SGTypes";
 import { Node } from "./Node";
 import { ContentNode } from "./ContentNode";
@@ -297,6 +305,9 @@ export class Task extends Node {
             };
             postMessage(taskData);
             this.started = false;
+            // The task consumed its events live while running; drop the render-side copies so a
+            // restart doesn't replay the whole previous run as pre-launch events.
+            dropPortNodeEvents(this.m);
         }
         this.active = false;
     }
@@ -611,6 +622,13 @@ export class Task extends Node {
                 m: fromAssociativeArray(this.m, true, this),
                 render: sgRoot.getRenderThreadInfo()?.id,
             };
+            // Events already queued on the task's ports (e.g. an observed field set right before
+            // `control = "RUN"`) must cross with `m`: on a device the copied `m` references the
+            // same native port, so the task function's wait() drains them after launch.
+            const portEvents = collectPortNodeEvents(this.m, this);
+            if (portEvents) {
+                taskData.portEvents = portEvents;
+            }
             postMessage(taskData);
             this.started = true;
         }

--- a/test/extensions/scenegraph/TaskPortEvents.test.js
+++ b/test/extensions/scenegraph/TaskPortEvents.test.js
@@ -1,0 +1,100 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, RoSGNodeEvent, collectPortNodeEvents, replayPortNodeEvents, brsValueOf, jsValueOf } = scenegraph;
+const { dropPortNodeEvents } = scenegraph;
+const { BrsString, RoAssociativeArray, RoMessagePort } = core;
+
+/** Simulates the structured/JSON round-trip TaskData undergoes when posted to the task thread. */
+function transfer(serialized) {
+    return JSON.parse(JSON.stringify(serialized));
+}
+
+/**
+ * A Task component typically observes a field with a port in init() and blocks on wait() in the
+ * task function — with the field set BEFORE `control = "RUN"` (e.g. GetData-style tasks). On a
+ * device the copied `m` references the same native port, so the queued event is delivered to the
+ * task thread. These tests cover the simulator's explicit carry-over of those queued events.
+ */
+describe("pre-launch task port events", () => {
+    function makeM(node, portKey = "messagePort") {
+        const port = new RoMessagePort();
+        const m = new RoAssociativeArray([]);
+        m.set(new BrsString(portKey), port, true);
+        return { m, port };
+    }
+
+    test("collects queued roSGNodeEvents from ports in m, draining them", () => {
+        const node = new Node([], "Node");
+        const { m, port } = makeM(node);
+        port.pushMessage(new RoSGNodeEvent(node, new BrsString("params"), brsValueOf({ request: "geo" })));
+
+        const collected = collectPortNodeEvents(m, node);
+        expect(collected.messagePort).toHaveLength(1);
+        expect(collected.messagePort[0].node).toBe(node.getAddress());
+        expect(collected.messagePort[0].field).toBe("params");
+        expect(collected.messagePort[0].value).toEqual({ request: "geo" });
+        expect(() => JSON.stringify(collected)).not.toThrow();
+
+        // The queue was drained — a second collection has nothing to report.
+        expect(collectPortNodeEvents(m, node)).toBeUndefined();
+    });
+
+    test("returns undefined when no ports or no queued events exist", () => {
+        const node = new Node([], "Node");
+        const m = new RoAssociativeArray([]);
+        expect(collectPortNodeEvents(m, node)).toBeUndefined();
+
+        const withPort = makeM(node);
+        expect(collectPortNodeEvents(withPort.m, node)).toBeUndefined();
+    });
+
+    test("replays events into the restored port, re-targeting the task node", () => {
+        const renderNode = new Node([], "Node");
+        const renderSide = makeM(renderNode);
+        renderSide.port.pushMessage(
+            new RoSGNodeEvent(renderNode, new BrsString("params"), brsValueOf({ request: "geo", noParams: true }))
+        );
+        const portEvents = transfer(collectPortNodeEvents(renderSide.m, renderNode));
+
+        // Task-thread side: a rebuilt node with the same address and a freshly created port.
+        const taskNode = new Node([], "Node");
+        taskNode.setAddress(renderNode.getAddress());
+        const globalNode = new Node([], "Node");
+        const taskSide = makeM(taskNode);
+        replayPortNodeEvents(portEvents, taskSide.m, taskNode, globalNode);
+
+        const delivered = taskSide.port.drainMessages(() => true);
+        expect(delivered).toHaveLength(1);
+        expect(delivered[0].fieldName.getValue()).toBe("params");
+        expect(delivered[0].node).toBe(taskNode);
+        expect(jsValueOf(delivered[0].fieldValue)).toEqual({ request: "geo", noParams: true });
+    });
+
+    test("dropping the backlog leaves nothing to replay on a restart", () => {
+        // While a task runs, events reach it live and the render-side port copy just accumulates.
+        // A stop/run cycle must not replay that whole backlog as pre-launch events.
+        const node = new Node([], "Node");
+        const { m, port } = makeM(node);
+        port.pushMessage(new RoSGNodeEvent(node, new BrsString("params"), brsValueOf({ request: "a" })));
+        port.pushMessage(new RoSGNodeEvent(node, new BrsString("params"), brsValueOf({ request: "b" })));
+
+        dropPortNodeEvents(m);
+        expect(collectPortNodeEvents(m, node)).toBeUndefined();
+    });
+
+    test("drops events whose source node is unavailable on the task thread", () => {
+        const renderNode = new Node([], "Node");
+        const stranger = new Node([], "Node");
+        const renderSide = makeM(renderNode);
+        renderSide.port.pushMessage(new RoSGNodeEvent(stranger, new BrsString("someField"), new BrsString("x")));
+        const portEvents = transfer(collectPortNodeEvents(renderSide.m, renderNode));
+
+        const taskNode = new Node([], "Node");
+        taskNode.setAddress(renderNode.getAddress());
+        const taskSide = makeM(taskNode);
+        replayPortNodeEvents(portEvents, taskSide.m, taskNode, new Node([], "Node"));
+
+        expect(taskSide.port.drainMessages(() => true)).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Root cause

A Task component typically observes a field with a message port in `init()` and blocks on `wait()` in the task function. When the observed field is set **before** `control = "run"` — the common pattern for handing a request to a task — the event is queued on the port while the task thread does not exist yet.

On a device the task's copied `m` references the same native port, so `wait()` drains that event right after launch. Here the port was rebuilt empty on the task thread, the queued event was lost, and the task blocked forever waiting for an event that had already fired.

## Fix

- `collectPortNodeEvents` drains the `roSGNodeEvent`s queued on ports held by the task's `m` at launch and serializes them into `TaskData.portEvents`.
- `replayPortNodeEvents` (from `loadTaskData`) pushes them into the rebuilt ports on the task thread, re-targeting each event's node to its task-side instance. An event from a node not resolvable that early (neither the task node nor the global node) is dropped with a one-shot warning.
- `RoMessagePort.drainMessages(predicate)` removes matching queued events in order, leaving everything else queued.
- `dropPortNodeEvents` clears the render-side backlog when a task stops. While a task runs its events arrive live, yet the render-side copy of the port keeps queueing them with nothing consuming them — without this, a stop/run cycle (the standard polling-task pattern) would replay the entire previous run at once as "pre-launch" events.

## Tests

`test/extensions/scenegraph/TaskPortEvents.test.js` — collection + drain, the JSON transfer round-trip, replay with node re-targeting, dropping unresolvable nodes, and the restart backlog.

Full suite green, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)