### PR TITLE
fix(scenegraph): let m.global.findNode() reach the scene tree

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1775,6 +1775,14 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                     // if not found, search from root
                     node = this.findNodeById(this.findRootNode(), id);
                 }
+                const globalNode: RoSGNode = sgRoot.mGlobal;
+                if (node instanceof BrsInvalid && globalNode === this && sgRoot.scene) {
+                    // On a device the global node shares the render tree root with the scene, so
+                    // m.global.findNode() reaches scene nodes (apps use it to locate screens from
+                    // detached components); the global singleton has no parent here, so search the
+                    // scene tree explicitly.
+                    node = this.findNodeById(sgRoot.scene, id);
+                }
                 return node;
             },
         });

--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1777,10 +1777,12 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 }
                 const globalNode: RoSGNode = sgRoot.mGlobal;
                 if (node instanceof BrsInvalid && globalNode === this && sgRoot.scene) {
-                    // On a device the global node shares the render tree root with the scene, so
-                    // m.global.findNode() reaches scene nodes (apps use it to locate screens from
-                    // detached components); the global singleton has no parent here, so search the
-                    // scene tree explicitly.
+                    // On a device the global node is parented to the Scene (`m.global.getParent()`
+                    // returns it), so its nearest component ancestor is the Scene and the ordinary
+                    // ifSGNodeDict search reaches the scene tree — apps rely on this to locate a
+                    // screen from a still-detached component. The global singleton has no parent
+                    // here, so search the scene tree explicitly to get the same result.
+                    // Its own descendants stay out of that search, matching the device.
                     node = this.findNodeById(sgRoot.scene, id);
                 }
                 return node;

--- a/test/extensions/scenegraph/GlobalFindNode.test.js
+++ b/test/extensions/scenegraph/GlobalFindNode.test.js
@@ -5,9 +5,11 @@ const { Node, sgRoot, SGNodeFactory } = scenegraph;
 const { Interpreter, BrsString, BrsInvalid, isInvalid } = core;
 
 /**
- * On a device the global node shares the render tree root with the scene, so
- * m.global.findNode() locates scene nodes. Apps rely on this to find a screen from a
- * still-detached component (e.g. a module whose setup runs before it is inserted).
+ * Device-confirmed: `m.global.getParent()` returns the Scene, so the global node's nearest
+ * component ancestor is the Scene and the ordinary ifSGNodeDict search reaches the scene tree.
+ * Apps rely on this to find a screen from a still-detached component (e.g. a module whose setup
+ * runs before it is inserted). The global singleton is parentless here, so findNode searches the
+ * scene explicitly to reach the same result.
  */
 describe("m.global.findNode scene fallback", () => {
     test("finds a scene node by id from the global node", () => {
@@ -33,7 +35,13 @@ describe("m.global.findNode scene fallback", () => {
         expect(isInvalid(found)).toBe(true);
     });
 
-    test("a regular detached node does not search the scene", () => {
+    // Scoping check, not a fidelity claim: the fallback applies to the global node only.
+    //
+    // A device resolves findNode against the *creating component's* scope, so a detached plain
+    // node built inside a component's script does reach that component's tree — which this engine
+    // does not model (it has no creation-context link). Keeping the fallback narrow avoids
+    // guessing at that scope; broadening it is tracked separately.
+    test("the scene fallback applies to the global node only, not any detached node", () => {
         const scene = SGNodeFactory.createNode("Scene");
         const screen = new Node([], "Group");
         screen.setValue("id", new BrsString("HomeScreen"), false);

--- a/test/extensions/scenegraph/GlobalFindNode.test.js
+++ b/test/extensions/scenegraph/GlobalFindNode.test.js
@@ -1,0 +1,50 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, sgRoot, SGNodeFactory } = scenegraph;
+const { Interpreter, BrsString, BrsInvalid, isInvalid } = core;
+
+/**
+ * On a device the global node shares the render tree root with the scene, so
+ * m.global.findNode() locates scene nodes. Apps rely on this to find a screen from a
+ * still-detached component (e.g. a module whose setup runs before it is inserted).
+ */
+describe("m.global.findNode scene fallback", () => {
+    test("finds a scene node by id from the global node", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        const screen = new Node([], "Group");
+        screen.setValue("id", new BrsString("HomeScreen"), false);
+        scene.appendChildToParent(screen);
+        sgRoot.setScene(scene);
+
+        const interpreter = new Interpreter();
+        const findNode = sgRoot.mGlobal.getMethod("findnode");
+        const found = interpreter.call(findNode, [new BrsString("HomeScreen")], sgRoot.mGlobal.m, interpreter.location);
+        expect(found).toBe(screen);
+    });
+
+    test("still returns invalid when the id exists nowhere", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        sgRoot.setScene(scene);
+
+        const interpreter = new Interpreter();
+        const findNode = sgRoot.mGlobal.getMethod("findnode");
+        const found = interpreter.call(findNode, [new BrsString("nowhere")], sgRoot.mGlobal.m, interpreter.location);
+        expect(isInvalid(found)).toBe(true);
+    });
+
+    test("a regular detached node does not search the scene", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        const screen = new Node([], "Group");
+        screen.setValue("id", new BrsString("HomeScreen"), false);
+        scene.appendChildToParent(screen);
+        sgRoot.setScene(scene);
+
+        const interpreter = new Interpreter();
+        const detached = new Node([], "Group");
+        const findNode = detached.getMethod("findnode");
+        const found = interpreter.call(findNode, [new BrsString("HomeScreen")], detached.m, interpreter.location);
+        expect(isInvalid(found)).toBe(true);
+        expect(found).toBe(BrsInvalid.Instance);
+    });
+});


### PR DESCRIPTION
## Root cause

An app calling `m.global.findNode(id)` to locate a screen from a component that isn't attached to the tree yet always got `invalid`. The global node is a detached singleton here, so `findRootNode()` returns the global node itself and the search never reaches the scene.

## Fix

Fall back to searching the scene tree when the lookup starts from the global node and the normal search finds nothing. Scoped to that node only, and the extra breadth-first walk runs only on a miss from `m.global`.

## ✅ Confirmed on a device

Verified with an instrumented sideloaded test app. This is **not** a divergence from `ifSGNodeDict` — the doc says findNode searches descendants of the subject node's *nearest component ancestor*, and on a device the global node's parent **is the Scene**, so the Scene is that ancestor and the ordinary search reaches the scene tree. This engine's global singleton is parentless, which is the actual divergence; searching the scene explicitly reproduces the device result.

| probe | device | this engine (before) | this engine (after) |
| --- | --- | --- | --- |
| `m.global.getParent()` | `MainScene#TheScene` | `invalid` | `invalid` |
| `m.global.findNode("SceneChild")` | `Group#SceneChild` | `invalid` | `Group#SceneChild` |
| `m.global.findNode("NestedLabel")` | `Label#NestedLabel` | `invalid` | `Label#NestedLabel` |
| `m.global.findNode(<id inside a custom component>)` | `Label#InnerPanelLabel` | `invalid` | `Label#InnerPanelLabel` |
| `m.global.findNode(<the scene's own id>)` | `MainScene#TheScene` | `invalid` | `MainScene#TheScene` |
| `m.global.findNode("DoesNotExist")` | `invalid` | `invalid` | `invalid` |
| detached custom component, from `init()`: `m.global.findNode("SceneChild")` | `Group#SceneChild` | `invalid` | `Group#SceneChild` |

## Known gaps left open (pre-existing, not introduced here)

- **`m.global.getParent()`** still returns `invalid`; the device returns the Scene. Parenting the global singleton would be the principled fix but has wide ripple effects (render traversal, focus chain, serialization), so this PR reproduces the observable `findNode` result instead.
- **Creation-context scoping.** A device resolves findNode against the *creating component's* scope: a detached plain `Group` built inside a component's script finds that component's nodes (`Group#SceneChild` on device, `invalid` here). This engine has no creation-context link. The third test documents that it checks the fallback's scoping rather than claiming device parity.
- **`m.global`'s own descendants.** A node appended to `m.global` is *not* found by `m.global.findNode()` on a device (its subtree sits outside the Scene's child list); this engine does find it. More permissive, so not a crash source.

## Tests

`test/extensions/scenegraph/GlobalFindNode.test.js` — finds a scene node from the global node, still returns `invalid` for an unknown id, and confirms the fallback stays scoped to the global node.

Full suite green, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)