### PR TITLE
fix(scenegraph): parent the global node to the Scene

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1775,16 +1775,6 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                     // if not found, search from root
                     node = this.findNodeById(this.findRootNode(), id);
                 }
-                const globalNode: RoSGNode = sgRoot.mGlobal;
-                if (node instanceof BrsInvalid && globalNode === this && sgRoot.scene) {
-                    // On a device the global node is parented to the Scene (`m.global.getParent()`
-                    // returns it), so its nearest component ancestor is the Scene and the ordinary
-                    // ifSGNodeDict search reaches the scene tree — apps rely on this to locate a
-                    // screen from a still-detached component. The global singleton has no parent
-                    // here, so search the scene tree explicitly to get the same result.
-                    // Its own descendants stay out of that search, matching the device.
-                    node = this.findNodeById(sgRoot.scene, id);
-                }
                 return node;
             },
         });

--- a/src/extensions/scenegraph/nodes/Global.ts
+++ b/src/extensions/scenegraph/nodes/Global.ts
@@ -1,5 +1,6 @@
-import { AAMember } from "brs-engine";
+import { AAMember, BrsInvalid } from "brs-engine";
 import { Node } from "./Node";
+import { sgRoot } from "../SGRoot";
 import { SGNodeType } from ".";
 
 export class Global extends Node {
@@ -13,5 +14,20 @@ export class Global extends Node {
     public setOwner(_threadId: number): void {
         // Global node owner cannot be changed
         return;
+    }
+
+    /**
+     * On a device the global node is parented to the Scene — `m.global.getParent()` returns it —
+     * which is what puts the Scene in reach of `m.global.findNode()`: the Scene becomes the global
+     * node's nearest component ancestor, so the ordinary `ifSGNodeDict` search covers the scene
+     * tree. The link is resolved on demand rather than stored, so it follows the current Scene and
+     * leaves no stale pointer when the app swaps screens.
+     *
+     * The global node deliberately stays out of the Scene's *children*, matching the device: a node
+     * appended to `m.global` is not reachable from `m.top.findNode()` (nor from `m.global`'s own
+     * search, which runs against the Scene), and the render pass never walks into it.
+     */
+    getNodeParent(): Node | BrsInvalid {
+        return sgRoot.scene ?? BrsInvalid.Instance;
     }
 }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1812,8 +1812,12 @@ export class Node extends RoSGNode implements BrsValue {
      */
     protected findRootNode(start?: Node): Node {
         let root: Node = start ?? this;
-        while (root.parent instanceof Node) {
-            root = root.parent;
+        // Walk through getNodeParent() rather than the raw field so a node whose parent link is
+        // resolved on demand participates — the global node reports the Scene as its parent.
+        let parent = root.getNodeParent();
+        while (parent instanceof Node) {
+            root = parent;
+            parent = root.getNodeParent();
         }
         return root;
     }

--- a/test/extensions/scenegraph/GlobalFindNode.test.js
+++ b/test/extensions/scenegraph/GlobalFindNode.test.js
@@ -8,10 +8,30 @@ const { Interpreter, BrsString, BrsInvalid, isInvalid } = core;
  * Device-confirmed: `m.global.getParent()` returns the Scene, so the global node's nearest
  * component ancestor is the Scene and the ordinary ifSGNodeDict search reaches the scene tree.
  * Apps rely on this to find a screen from a still-detached component (e.g. a module whose setup
- * runs before it is inserted). The global singleton is parentless here, so findNode searches the
- * scene explicitly to reach the same result.
+ * runs before it is inserted).
  */
-describe("m.global.findNode scene fallback", () => {
+describe("m.global is parented to the Scene", () => {
+    test("getParent() reports the current Scene, and follows a Scene swap", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        sgRoot.setScene(scene);
+
+        const interpreter = new Interpreter();
+        const getParent = sgRoot.mGlobal.getMethod("getparent");
+        expect(interpreter.call(getParent, [], sgRoot.mGlobal.m, interpreter.location)).toBe(scene);
+
+        // Resolved on demand, so swapping the Scene never leaves a stale parent pointer.
+        const nextScene = SGNodeFactory.createNode("Scene");
+        sgRoot.setScene(nextScene);
+        expect(interpreter.call(getParent, [], sgRoot.mGlobal.m, interpreter.location)).toBe(nextScene);
+    });
+
+    test("the global node stays out of the Scene's children", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        sgRoot.setScene(scene);
+        // A device never renders or traverses into m.global from the Scene.
+        expect(scene.getNodeChildren()).not.toContain(sgRoot.mGlobal);
+    });
+
     test("finds a scene node by id from the global node", () => {
         const scene = SGNodeFactory.createNode("Scene");
         const screen = new Node([], "Group");


### PR DESCRIPTION
> **Stacked on #1094** — review/merge that first. Base is `fix/global-findnode-scene`, so this PR's diff shows only its own change.

## Root cause

Device-confirmed with an instrumented app: `m.global.getParent()` returns the **Scene**. Here it returned `invalid` — the global node was a fully detached singleton, which is why #1094 needed a special case in `findNode` to reach the scene tree at all.

## Fix

Resolve the global node's parent on demand as the current Scene, and walk `findRootNode()` through `getNodeParent()` so a node whose parent link is computed participates. The Scene then *is* the global node's nearest component ancestor, so the ordinary `ifSGNodeDict` search covers the scene tree — which makes #1094's special case redundant, and it is removed here.

Resolving on demand rather than storing a pointer means the link follows the current Scene and leaves nothing stale when the app swaps screens.

The global node deliberately stays **out of the Scene's children**, matching the device: a node appended to `m.global` is not reachable from `m.top.findNode()`, and the render pass never walks into it.

| probe | device | before | after |
| --- | --- | --- | --- |
| `m.global.getParent()` | `MainScene#TheScene` | `invalid` | `MainScene#TheScene` |
| same, from a detached component's `init()` | `MainScene#TheScene` | `invalid` | `MainScene#TheScene` |
| `m.global.findNode(...)` (all cases) | finds | finds (via special case) | finds (via ordinary path) |

## Tests

`GlobalFindNode.test.js` — `getParent()` reports the current Scene and follows a Scene swap; the global node stays out of the Scene's children.

Full suite green (2221), lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)