### PR TITLE
fix(scenegraph): keep m.global's own descendants out of its findNode search

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1769,8 +1769,14 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 }
                 const id = name.getValue();
                 if (id.trim() === "") return BrsInvalid.Instance;
-                // perform search to child nodes
-                let node = this.findNodeById(this, id);
+                // The search space is the subject node's nearest component ancestor. The global
+                // node's is the Scene, and the global node itself sits *outside* the Scene's
+                // children, so its own descendants are not in that space: a device does not find a
+                // node appended to m.global via m.global.findNode(). Skipping the self-search keeps
+                // that boundary — every other node's subtree is part of its ancestor's anyway, so
+                // searching it first is only a shortcut.
+                const searchSelf: boolean = sgRoot.mGlobal !== this;
+                let node: RoSGNode | BrsInvalid = searchSelf ? this.findNodeById(this, id) : BrsInvalid.Instance;
                 if (node instanceof BrsInvalid) {
                     // if not found, search from root
                     node = this.findNodeById(this.findRootNode(), id);

--- a/test/extensions/scenegraph/GlobalFindNode.test.js
+++ b/test/extensions/scenegraph/GlobalFindNode.test.js
@@ -32,6 +32,24 @@ describe("m.global is parented to the Scene", () => {
         expect(scene.getNodeChildren()).not.toContain(sgRoot.mGlobal);
     });
 
+    test("does not find its own descendants — the search space is the Scene", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        sgRoot.setScene(scene);
+        const ownChild = new Node([], "Node");
+        ownChild.setValue("id", new BrsString("GlobalOwnChild"), false);
+        sgRoot.mGlobal.appendChildToParent(ownChild);
+
+        const interpreter = new Interpreter();
+        // Device-confirmed: a node appended to m.global is reachable from neither search, because
+        // the global node sits outside the Scene's children.
+        const globalFind = sgRoot.mGlobal.getMethod("findnode");
+        const args = [new BrsString("GlobalOwnChild")];
+        expect(isInvalid(interpreter.call(globalFind, args, sgRoot.mGlobal.m, interpreter.location))).toBe(true);
+
+        const sceneFind = scene.getMethod("findnode");
+        expect(isInvalid(interpreter.call(sceneFind, args, scene.m, interpreter.location))).toBe(true);
+    });
+
     test("finds a scene node by id from the global node", () => {
         const scene = SGNodeFactory.createNode("Scene");
         const screen = new Node([], "Group");


### PR DESCRIPTION
> **Stacked on the global-node-parent PR** (which is itself stacked on #1094). Merge in order.

## Root cause

Device-confirmed: a node appended to `m.global` is found by **neither** `m.global.findNode()` nor `m.top.findNode()`.

`findNode`'s search space is the subject node's nearest component ancestor. For the global node that is the Scene, and the global node itself sits outside the Scene's children — so its own subtree is not in that space. This engine searched the subject's own subtree *first* and found it.

## Fix

Skip that self-search for the global node. Every other node's subtree is part of its component ancestor's subtree anyway, so searching it first is only a shortcut; their behavior is unchanged.

| probe | device | before | after |
| --- | --- | --- | --- |
| `m.global.findNode("GlobalOwnChild")` | `invalid` | `Node#GlobalOwnChild` | `invalid` |
| `m.top.findNode("GlobalOwnChild")` | `invalid` | `invalid` | `invalid` |

Note this is a *narrowing* — an app that appended to `m.global` and relied on finding it would have been broken on a device already.

## Tests

`GlobalFindNode.test.js` — a node appended to `m.global` is reachable from neither search.

Full suite green (2222), lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)