### PR TITLE
fix(scenegraph): resolve findNode against the executing component's scope

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1752,6 +1752,36 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     }
 
     /**
+     * Resolves a findNode miss against the component scope the subject node belongs to.
+     *
+     * A device does not rely on the parent chain alone: a node created inside a component's script
+     * and never attached still reaches that component's tree (device-confirmed — a detached plain
+     * `Group` built in a Scene's script finds the Scene's children). The owning scope is
+     * approximated by the component whose script is currently executing, which the environment
+     * already tracks as `hostNode`; a node is nearly always created and used within one component,
+     * and no per-node creation link has to be stored to get there.
+     *
+     * Only applies to a detached node that is not itself a custom component root — such a node is
+     * its own scope on a device and must never borrow the caller's.
+     * @param interpreter Calling interpreter, carrying the executing component in its environment.
+     * @param id Node id being searched for.
+     * @returns The matching node, or invalid when the subject has no separate component scope.
+     */
+    private findInComponentScope(interpreter: Interpreter, id: string): RoSGNode | BrsInvalid {
+        if (this.getNodeParent() instanceof RoSGNode) {
+            return BrsInvalid.Instance;
+        }
+        if (sgRoot.nodeDefMap.has(this.nodeSubtype.toLowerCase())) {
+            return BrsInvalid.Instance;
+        }
+        const host = interpreter.environment.hostNode;
+        if (!(host instanceof RoSGNode) || host === this) {
+            return BrsInvalid.Instance;
+        }
+        return this.findNodeById(this.findRootNode(host), id);
+    }
+
+    /**
      * Returns the node that is a descendant of the nearest component ancestor of the subject node whose id field matches the given name,
      * otherwise return invalid.
      * Implemented as a DFS from the top of parent hierarchy to match the observed behavior as opposed to the BFS mentioned in the docs.
@@ -1780,6 +1810,9 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 if (node instanceof BrsInvalid) {
                     // if not found, search from root
                     node = this.findNodeById(this.findRootNode(), id);
+                }
+                if (node instanceof BrsInvalid) {
+                    node = this.findInComponentScope(interpreter, id);
                 }
                 return node;
             },

--- a/test/extensions/scenegraph/ComponentScopeFindNode.test.js
+++ b/test/extensions/scenegraph/ComponentScopeFindNode.test.js
@@ -1,0 +1,72 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, sgRoot, SGNodeFactory, ComponentDefinition } = scenegraph;
+const { Interpreter, BrsString, isInvalid } = core;
+
+/**
+ * Device-confirmed: findNode resolves against the component scope a node belongs to, not its
+ * parent chain alone. A detached plain Group built inside a Scene's script finds that Scene's
+ * children; a detached *custom component* root does not, because it is its own scope.
+ *
+ * The executing component is approximated by `environment.hostNode`, which the engine already
+ * tracks for init()/callFunc.
+ */
+describe("findNode falls back to the executing component's scope", () => {
+    function sceneWithScreen() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const screen = new Node([], "Group");
+        screen.setValue("id", new BrsString("HomeScreen"), false);
+        scene.appendChildToParent(screen);
+        sgRoot.setScene(scene);
+        return { scene, screen };
+    }
+
+    function callFindNode(subject, id, hostNode) {
+        const interpreter = new Interpreter();
+        interpreter.environment.hostNode = hostNode;
+        const findNode = subject.getMethod("findnode");
+        return interpreter.call(findNode, [new BrsString(id)], subject.m, interpreter.location);
+    }
+
+    afterEach(() => {
+        sgRoot.setNodeDefMap(new Map());
+    });
+
+    test("a detached plain node reaches the tree of the component running the call", () => {
+        const { scene, screen } = sceneWithScreen();
+        const detached = new Node([], "Group");
+        expect(callFindNode(detached, "HomeScreen", scene)).toBe(screen);
+    });
+
+    test("a detached custom component root is its own scope and does not borrow the caller's", () => {
+        const { scene } = sceneWithScreen();
+        const def = new ComponentDefinition("pkg:/components/DetachedHelper.xml");
+        def.name = "DetachedHelper";
+        def.xmlNode = { attr: { name: "DetachedHelper", extends: "Group" } };
+        sgRoot.setNodeDefMap(new Map([["detachedhelper", def]]));
+
+        const helper = new Node([], "DetachedHelper");
+        expect(isInvalid(callFindNode(helper, "HomeScreen", scene))).toBe(true);
+    });
+
+    test("an attached node keeps using its own tree, not the caller's", () => {
+        const { scene } = sceneWithScreen();
+        // A separate tree that does not contain HomeScreen; the node is attached, so the
+        // component-scope fallback must not apply even though the caller could reach it.
+        const otherRoot = new Node([], "Group");
+        const attached = new Node([], "Group");
+        otherRoot.appendChildToParent(attached);
+
+        expect(isInvalid(callFindNode(attached, "HomeScreen", scene))).toBe(true);
+    });
+
+    test("without an executing component there is no scope to fall back to", () => {
+        const { scene } = sceneWithScreen();
+        const detached = new Node([], "Group");
+        expect(isInvalid(callFindNode(detached, "HomeScreen", undefined))).toBe(true);
+        // The subject itself never counts as its own scope.
+        expect(isInvalid(callFindNode(detached, "HomeScreen", detached))).toBe(true);
+        expect(scene).toBeDefined();
+    });
+});

--- a/test/extensions/scenegraph/GlobalFindNode.test.js
+++ b/test/extensions/scenegraph/GlobalFindNode.test.js
@@ -73,13 +73,10 @@ describe("m.global is parented to the Scene", () => {
         expect(isInvalid(found)).toBe(true);
     });
 
-    // Scoping check, not a fidelity claim: the fallback applies to the global node only.
-    //
-    // A device resolves findNode against the *creating component's* scope, so a detached plain
-    // node built inside a component's script does reach that component's tree — which this engine
-    // does not model (it has no creation-context link). Keeping the fallback narrow avoids
-    // guessing at that scope; broadening it is tracked separately.
-    test("the scene fallback applies to the global node only, not any detached node", () => {
+    // The Scene is reachable because it is the *global node's* parent, not because any detached
+    // node may search it. A detached node reaches a tree only through the component scope running
+    // the call (see ComponentScopeFindNode.test.js), and there is none here.
+    test("a detached node with no component scope does not reach the scene", () => {
         const scene = SGNodeFactory.createNode("Scene");
         const screen = new Node([], "Group");
         screen.setValue("id", new BrsString("HomeScreen"), false);


### PR DESCRIPTION
> **Top of the stack** — #1094 → #1095 → #1096 → this. Merge in order.

## Root cause

Device-confirmed: `findNode` does not rely on the parent chain alone. A node created inside a component's script and never attached still reaches that component's tree — a detached plain `Group` built in a Scene's script finds the Scene's children, where this engine returned `invalid`.

## Fix

Fall back to the tree of the component whose script is executing, which the environment already tracks as `hostNode` for `init()`/`callFunc`.

That approximates the owning scope **without storing a per-node creation link**. A device uses the *creating* component; a node is nearly always created and used within one component, so the executing component matches in practice, and a per-node back-reference would add memory to every node for a rare divergence (passing a detached node between components before searching it).

Applies only to a detached node that is **not itself a custom component root** — such a node is its own scope on a device, confirmed by a detached custom component's `m.top.findNode()` finding nothing.

| probe | device | before | after |
| --- | --- | --- | --- |
| detached `Group` created in a Scene script: `findNode("SceneChild")` | `Group#SceneChild` | `invalid` | `Group#SceneChild` |
| detached custom component, `m.top.findNode("SceneChild")` from `init()` | `invalid` | `invalid` | `invalid` |

## Result: full device parity

With the stack applied, every probe in the instrumented test app matches the device — all 17 lines, including the controls and negatives.

## Tests

New `ComponentScopeFindNode.test.js` — the detached-plain-node fallback, a custom component root not borrowing the caller's scope, an attached node keeping its own tree, and no fallback without an executing component.

Full suite green (2226), lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)