### PR TITLE
fix(rsg): repair the release build broken by the findNode global check

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1805,7 +1805,10 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 // node appended to m.global via m.global.findNode(). Skipping the self-search keeps
                 // that boundary — every other node's subtree is part of its ancestor's anyway, so
                 // searching it first is only a shortcut.
-                const searchSelf: boolean = sgRoot.mGlobal !== this;
+                // Widened to RoSGNode so the comparison type-checks: `sgRoot.mGlobal` is a `Global`,
+                // which TypeScript sees as having no overlap with the polymorphic `this`.
+                const globalNode: RoSGNode = sgRoot.mGlobal;
+                const searchSelf: boolean = globalNode !== this;
                 let node: RoSGNode | BrsInvalid = searchSelf ? this.findNodeById(this, id) : BrsInvalid.Instance;
                 if (node instanceof BrsInvalid) {
                     // if not found, search from root


### PR DESCRIPTION
## Master is red

`sgRoot.mGlobal !== this` (introduced in #1096) does not compile:

```
RoSGNode.ts(1808,45) TS2367: This comparison appears to be unintentional
because the types 'Global' and 'this' have no overlap.
```

`brs-scenegraph`'s webpack/ts-loader and `tsc` both reject it, so `npm run build` fails.

## Fix

Widen to `RoSGNode` before comparing — the same thing the earlier global-node check in #1094 did for exactly this reason. Behavior is unchanged.

## Why it got through

**Only a clean build surfaces it.** An incremental rebuild reuses the cached module and reports success, and the test suite then runs against the previously-built bundles. Verified: `npm run clean && npm run build` reproduces it on master, and passes with this change (0 TypeScript errors, both bundles emitted).

Full suite green (2240), lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)