### PR TITLE
fix: make cross-thread Task field sync and port observers work between threads

### DIFF
--- a/src/api/task.ts
+++ b/src/api/task.ts
@@ -21,10 +21,25 @@ import SharedObject from "../core/SharedObject";
 import { setAppCaptionStyle, setCaptionMode, setDisplayState } from "./display";
 import { SubscribeCallback } from "./util";
 
-const MAX_TASKS = 10;
+/**
+ * Concurrent task workers allowed at once. This is purely a guardrail against a runaway app spawning
+ * workers without end. Apps built around a persistent worker pool park several tasks in permanent loops
+ * and still need headroom for the transient ones, so the ceiling has to sit well above the pool size.
+ * Reaching it no longer drops the task: see `pendingTasks`.
+ */
+const MAX_TASKS = 30;
 
 // Active Tasks
 const tasks: Map<number, Worker> = new Map();
+/**
+ * Launches deferred because `MAX_TASKS` was reached, oldest first, started as slots free.
+ *
+ * The cap used to drop the launch outright, and the task node had already flipped to `started`, so
+ * it never retried — leaving it in `state = "run"` with no thread behind it for the rest of the
+ * session. A cap is a throttle, not a cliff: an app that fans out more sections than there are
+ * slots should load them late, not lose them.
+ */
+const pendingTasks: { taskData: TaskData; payload: AppPayload }[] = [];
 const threadSyncToTask: Map<number, SharedObject> = new Map();
 const threadSyncToMain: Map<number, SharedObject> = new Map();
 let sharedBuffer: ArrayBufferLike;
@@ -115,8 +130,14 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
     if (tasks.has(taskData.id) || !taskData.m?.top?.functionname) {
         notifyAll("debug", `[task:api] Task already running or invalid task data: ${taskData.id}, ${taskData.name}`);
         return;
-    } else if (tasks.size === MAX_TASKS) {
-        notifyAll("warning", `[task:api] Maximum number of tasks reached: ${tasks.size}`);
+    } else if (tasks.size >= MAX_TASKS) {
+        if (!pendingTasks.some((pending) => pending.taskData.id === taskData.id)) {
+            pendingTasks.push({ taskData, payload: currentPayload });
+        }
+        notifyAll(
+            "warning",
+            `[task:api] Maximum number of tasks reached (${tasks.size}), queued: ${taskData.id}, ${taskData.name}`
+        );
         return;
     }
     const taskWorker = new Worker(brsWrkLib);
@@ -153,6 +174,11 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
  * @param taskId ID of the task to terminate
  */
 function endTask(taskId: number) {
+    // A task stopped before its queued launch got a slot must not start afterwards.
+    const queued = pendingTasks.findIndex((pending) => pending.taskData.id === taskId);
+    if (queued >= 0) {
+        pendingTasks.splice(queued, 1);
+    }
     const taskWorker = tasks.get(taskId);
     if (taskWorker) {
         taskWorker.removeEventListener("message", taskCallback);
@@ -165,6 +191,16 @@ function endTask(taskId: number) {
         threadSyncToTask.delete(taskId);
         threadSyncToMain.delete(taskId);
         notifyAll("debug", `[task:api] Task worker stopped: ${taskId}`);
+    }
+    startPendingTasks();
+}
+
+/** Starts queued launches, oldest first, while slots are free. */
+function startPendingTasks() {
+    while (pendingTasks.length > 0 && tasks.size < MAX_TASKS) {
+        const next = pendingTasks.shift()!;
+        notifyAll("debug", `[task:api] Starting queued Task: ${next.taskData.id}, ${next.taskData.name}`);
+        runTask(next.taskData, next.payload);
     }
 }
 
@@ -183,6 +219,9 @@ export function resetTasks() {
         shared.dispose();
     }
     tasks.clear();
+    // Queued launches belong to the app being torn down; starting them against the next one would
+    // spawn workers with a stale payload.
+    pendingTasks.length = 0;
     threadSyncToTask.clear();
     threadSyncToMain.clear();
     directMode = false;

--- a/src/core/brsTypes/components/RoDataGramSocket.ts
+++ b/src/core/brsTypes/components/RoDataGramSocket.ts
@@ -11,7 +11,15 @@ import {
 } from "..";
 import { BrsComponent } from "./BrsComponent";
 import { Interpreter } from "../../interpreter";
-import { BrsSocket, IfSocket, IfSocketAsync, IfSocketOption, IfSocketStatus } from "../interfaces/IfSocket";
+import {
+    attachSocketErrorHandler,
+    GENERIC_SOCKET_ERROR,
+    BrsSocket,
+    IfSocket,
+    IfSocketAsync,
+    IfSocketOption,
+    IfSocketStatus,
+} from "../interfaces/IfSocket";
 import { IfGetMessagePort, IfSetMessagePort } from "../interfaces/IfMessagePort";
 import * as net from "net";
 import { BrsDevice } from "../../device/BrsDevice";
@@ -49,9 +57,10 @@ export class RoDataGramSocket extends BrsComponent implements BrsValue, BrsSocke
         this.recvTimeout = 0;
         try {
             this.socket = new net.Socket();
+            attachSocketErrorHandler(this, this.socket, "roDataGramSocket");
         } catch (err: any) {
             BrsDevice.stderr.write(`warning,[roDataGramSocket] Sockets are not supported in this environment.`);
-            this.errorCode = 3474;
+            this.errorCode = GENERIC_SOCKET_ERROR;
         }
         this.identity = generateUniqueId();
         const ifSocket = new IfSocket(this);

--- a/src/core/brsTypes/components/RoStreamSocket.ts
+++ b/src/core/brsTypes/components/RoStreamSocket.ts
@@ -11,7 +11,15 @@ import {
 } from "..";
 import { BrsComponent } from "./BrsComponent";
 import { Interpreter } from "../../interpreter";
-import { BrsSocket, IfSocket, IfSocketAsync, IfSocketOption, IfSocketStatus } from "../interfaces/IfSocket";
+import {
+    attachSocketErrorHandler,
+    GENERIC_SOCKET_ERROR,
+    BrsSocket,
+    IfSocket,
+    IfSocketAsync,
+    IfSocketOption,
+    IfSocketStatus,
+} from "../interfaces/IfSocket";
 import { IfGetMessagePort, IfSetMessagePort } from "../interfaces/IfMessagePort";
 import * as net from "net";
 import { BrsDevice } from "../../device/BrsDevice";
@@ -43,9 +51,10 @@ export class RoStreamSocket extends BrsComponent implements BrsValue, BrsSocket 
         try {
             this.socket = new net.Socket();
             this.errorCode = 0;
+            attachSocketErrorHandler(this, this.socket, "roStreamSocket");
         } catch (err: any) {
             BrsDevice.stderr.write(`warning,[roStreamSocket] Sockets are not supported in this environment.`);
-            this.errorCode = 3474;
+            this.errorCode = GENERIC_SOCKET_ERROR;
         }
         this.identity = generateUniqueId();
         const ifSocket = new IfSocket(this);

--- a/src/core/brsTypes/interfaces/IfSocket.ts
+++ b/src/core/brsTypes/interfaces/IfSocket.ts
@@ -11,6 +11,7 @@ import {
     ValueKind,
 } from "..";
 import { Interpreter } from "../../interpreter";
+import { BrsDevice } from "../../device/BrsDevice";
 import * as net from "net";
 
 /**
@@ -36,11 +37,18 @@ export class IfSocket {
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter, data: RoByteArray, startIndex: Int32, length: Int32) => {
+            if (!this.component.socket?.writable) {
+                // Writing to a closed/destroyed socket does not throw — it reports asynchronously
+                // through the `error` event. Report "nothing sent" here instead of queueing a write
+                // that can only fail later.
+                this.component.errorCode = GENERIC_SOCKET_ERROR;
+                return new Int32(0);
+            }
             try {
-                const sent = this.component.socket?.write(data.getByteArray());
+                const sent = this.component.socket.write(data.getByteArray());
                 return new Int32(sent ? data.getElements().length : 0);
             } catch (err: any) {
-                this.component.errorCode = err.code;
+                this.component.errorCode = socketErrorCode(err);
                 return new Int32(0);
             }
         },
@@ -53,11 +61,15 @@ export class IfSocket {
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter, data: BrsString) => {
+            if (!this.component.socket?.writable) {
+                this.component.errorCode = GENERIC_SOCKET_ERROR;
+                return new Int32(0);
+            }
             try {
-                const sent = this.component.socket?.write(data.value);
+                const sent = this.component.socket.write(data.value);
                 return new Int32(sent ? data.value.length : 0);
             } catch (err: any) {
-                this.component.errorCode = err.code ?? 3474;
+                this.component.errorCode = socketErrorCode(err);
                 return new Int32(0);
             }
         },
@@ -79,7 +91,7 @@ export class IfSocket {
                 buffer = this.component.socket?.read(length.getValue()) ?? Buffer.alloc(0);
                 return new Int32(buffer.length);
             } catch (err: any) {
-                this.component.errorCode = err.code ?? 3474;
+                this.component.errorCode = socketErrorCode(err);
                 return new Int32(0);
             }
         },
@@ -96,7 +108,7 @@ export class IfSocket {
                 const str = this.component.socket?.read(length.getValue()) ?? "";
                 return new Int32(str.length);
             } catch (err: any) {
-                this.component.errorCode = err.code ?? 3474;
+                this.component.errorCode = socketErrorCode(err);
                 return new Int32(0);
             }
         },
@@ -205,6 +217,67 @@ export class IfSocket {
         impl: (_: Interpreter) => {
             return new Int32(this.component.errorCode);
         },
+    });
+}
+
+/** Generic socket failure, used when a host error maps to nothing `ifSocketStatus` recognizes. */
+export const GENERIC_SOCKET_ERROR = 3474;
+
+/**
+ * Host error names mapped to the numeric codes `ifSocketStatus` compares against.
+ *
+ * Node reports a failure as a *name* (`err.code`, e.g. "EPIPE") plus `err.errno`, whose numeric value
+ * is the host platform's — and those differ (EAGAIN is 11 on Linux, 35 on BSD/macOS). The status
+ * predicates test fixed numbers, so mapping the stable name is what keeps `eAgain()` and friends
+ * answering the same thing regardless of where the simulator runs. Values follow Roku's Linux base,
+ * matching the constants those predicates already assert.
+ */
+const SOCKET_ERROR_CODES: Record<string, number> = {
+    EAGAIN: 11,
+    EWOULDBLOCK: 35,
+    EALREADY: 114,
+    EBADADDR: 14,
+    EBADF: 14,
+    EINVAL: 22,
+    EINPROGRESS: 36,
+    EDESTADDRREQ: 39,
+    EHOSTUNREACH: 65,
+};
+
+/**
+ * Normalizes a host socket error to the numeric code BrightScript reads back.
+ *
+ * `errorCode` is typed `number` and surfaces through `ifSocket.status()` as an `Int32` and through
+ * every `ifSocketStatus` predicate as an equality test. Assigning `err.code` straight through put a
+ * *string* there, so `status()` produced garbage and every predicate answered false.
+ * @param err Error thrown by, or emitted from, a Node socket.
+ * @returns A numeric code, or `GENERIC_SOCKET_ERROR` when the error maps to nothing known.
+ */
+export function socketErrorCode(err: any): number {
+    const name = typeof err?.code === "string" ? SOCKET_ERROR_CODES[err.code.toUpperCase()] : undefined;
+    if (name !== undefined) {
+        return name;
+    }
+    // `errno` is the host's own value, so it is a fallback rather than the primary source.
+    return typeof err?.errno === "number" && err.errno !== 0 ? Math.abs(err.errno) : GENERIC_SOCKET_ERROR;
+}
+
+/**
+ * Records socket failures Node reports asynchronously instead of letting them escape.
+ *
+ * `net.Socket` surfaces a failed `write()`/`connect()` on a destroyed socket through an `error`
+ * event, not as a throw the caller's try/catch can see. An EventEmitter with no `error` listener
+ * rethrows it as an uncaught exception, which took down the whole worker (`ERR_SOCKET_CLOSED`).
+ * Stash it in `errorCode` — the same place the synchronous paths put it — so BrightScript can read
+ * it back through `ifSocketStatus`.
+ * @param component Socket component owning the error state.
+ * @param socket Node socket to listen on.
+ * @param name Component name used in the warning.
+ */
+export function attachSocketErrorHandler(component: BrsSocket, socket: net.Socket, name: string) {
+    socket.on("error", (err: any) => {
+        component.errorCode = socketErrorCode(err);
+        BrsDevice.stderr.write(`warning,[${name}] Socket error: ${err?.code ?? err?.message ?? err}`);
     });
 }
 

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -79,6 +79,13 @@ export class SGRoot {
      * proxy must never hijack the real player instance the app created.
      */
     deserializing: boolean = false;
+    /**
+     * Thread id the data currently being rebuilt came from, or -1 outside a cross-thread rebuild.
+     * `toSGNode` uses it to attribute a node's `_observed_` port observations to the thread whose
+     * real port is waiting on them (see `Field.remotePortObservers`); passing it through every
+     * serializer signature would touch a dozen call sites for one narrow need.
+     */
+    deserializingThread: number = -1;
     /** The render thread's roRenderThreadQueue singleton (holds handlers), drained each frame. */
     private _renderQueue?: RoRenderThreadQueue;
     /**

--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -468,6 +468,28 @@ function walkForFunction(value: any, location: SerializedCallableLocation, seen:
  * @param nodeMap Optional map to track nodes by ID for resolving circular references.
  * @returns A RoSGNode with the converted fields and optionally its children.
  */
+/**
+ * Attributes a rebuilt node's `_observed_` port observations to the thread they came from.
+ *
+ * A node built inside a task and observed there with a port carries those observations across, but
+ * the port itself cannot travel. Recording the originating thread against each field lets the render
+ * thread fan later updates back to where the real port is waiting.
+ * @param obj Serialized node data.
+ * @param node The rebuilt node.
+ */
+function applyRemotePortObservers(obj: any, node: Node) {
+    const observed = obj["_observed_"];
+    const threadId = sgRoot.deserializingThread;
+    if (threadId < 0 || !Array.isArray(observed)) {
+        return;
+    }
+    for (const entry of observed) {
+        if (typeof entry?.name === "string") {
+            node.resolveField(entry.name.toLowerCase())?.addRemotePortObserver(threadId);
+        }
+    }
+}
+
 export function toSGNode(obj: any, type: string, subtype: string, child?: boolean, nodeMap?: Map<string, Node>): Node {
     // Initialize nodeMap on first call
     nodeMap ??= new Map<string, Node>();
@@ -512,6 +534,7 @@ export function toSGNode(obj: any, type: string, subtype: string, child?: boolea
         const kind = FieldKind.fromString(fieldTypes[key] ?? "");
         newNode.setValueSilent(key, brsValueOf(obj[key], undefined, nodeMap), undefined, kind);
     }
+    applyRemotePortObservers(obj, newNode);
     // Recreate fields whose `invalid`/uninitialized value was omitted by JSON serialization, using
     // the preserved declared type so they exist (as `invalid`) on the receiving thread.
     for (const key in fieldTypes) {

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -481,11 +481,62 @@ export class Field {
         );
     }
 
+    /**
+     * Whether `scope` observes this field through a port.
+     *
+     * The `hostNode` match matters: an unscoped observer used to answer true for *every* scope, so
+     * callers picking cross-thread fan-out targets delivered each update to every active task. The
+     * node that registered the observer is recorded on the callback, so attribution is exact — and
+     * for a Task that registered in `init()` (on the render thread, never via rendezvous) this is the
+     * only record that it is waiting.
+     * @param scope Node to test for port observation.
+     */
     isPortObserved(scope: Node) {
         return (
-            (this.unscopedObservers?.some((callback) => callback.observer instanceof RoMessagePort) ?? false) ||
+            (this.unscopedObservers?.some(
+                (callback) => callback.observer instanceof RoMessagePort && callback.hostNode === scope
+            ) ??
+                false) ||
             (this.scopedObservers?.get(scope)?.some((callback) => callback.observer instanceof RoMessagePort) ?? false)
         );
+    }
+
+    /**
+     * Task threads that observe this field through an `roMessagePort`.
+     *
+     * A port cannot cross a thread boundary: `observeField(field, port)` from a task rendezvouses
+     * the call here and the port is rebuilt as a fresh, empty one, while the task's real port is
+     * registered only on its own copy. So the render side cannot tell *which* thread is waiting by
+     * looking at its observer list — and `isPortObserved` answers true for any scope once a single
+     * unscoped port observer exists, which would broadcast every update to every task. Recording
+     * the originating thread id makes the fan-out exact.
+     */
+    private remotePortObservers?: Set<number>;
+
+    /**
+     * Registers a task thread as a port observer of this field.
+     * @param threadId Task thread that called observeField with a port.
+     */
+    addRemotePortObserver(threadId: number) {
+        this.hidden = false;
+        this.remotePortObservers ??= new Set();
+        this.remotePortObservers.add(threadId);
+    }
+
+    /**
+     * Removes a task thread's port observation of this field.
+     * @param threadId Task thread that called unobserveField.
+     */
+    removeRemotePortObserver(threadId: number) {
+        this.remotePortObservers?.delete(threadId);
+    }
+
+    /**
+     * Checks whether a task thread observes this field through a port.
+     * @param threadId Task thread to test.
+     */
+    hasRemotePortObserver(threadId: number) {
+        return this.remotePortObservers?.has(threadId) ?? false;
     }
 
     private convertValue(value: BrsType) {

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -2135,9 +2135,10 @@ export class Node extends RoSGNode implements BrsValue {
      * Used both for the render thread's own field sets and to propagate a set the render applied on
      * behalf of a Task to the *other* observing tasks (cross-task propagation).
      * @param fieldName Field whose current value should be delivered.
-     * @param excludeThreadId Task thread id to skip (e.g. the originating task); -1 skips none.
+     * @param excludeThreadIds Task thread ids to skip — the originating task, plus any thread the
+     *   caller has already delivered to by another route (which would otherwise double-fire).
      */
-    fanOutFieldToObservingTasks(fieldName: string, excludeThreadId: number = -1) {
+    fanOutFieldToObservingTasks(fieldName: string, ...excludeThreadIds: number[]) {
         if (sgRoot.inTaskThread()) {
             return;
         }
@@ -2147,7 +2148,14 @@ export class Node extends RoSGNode implements BrsValue {
         }
         const value = field.getValue(false);
         for (const task of sgRoot.threadTasks) {
-            if (task.active && task.threadId !== excludeThreadId && field.isPortObserved(task)) {
+            // Deliver only to the threads that actually registered a port observer. `isPortObserved`
+            // cannot distinguish them (see `Field.remotePortObservers`) — using it here broadcast
+            // every update to every active task, which swamped the single-slot fan-out buffers.
+            if (
+                task.active &&
+                !excludeThreadIds.includes(task.threadId) &&
+                (field.isPortObserved(task) || field.hasRemotePortObserver(task.threadId))
+            ) {
                 task.syncRemoteField(fieldName, value, this.syncType, this.address);
             }
         }
@@ -2175,7 +2183,11 @@ export class Node extends RoSGNode implements BrsValue {
             const args = callArgs?.map((arg: BrsType) => {
                 if (arg instanceof Node) {
                     arg.setOwner(0); // Node references sent to render thread will be owned by the render thread
-                    return fromSGNode(arg, true);
+                    // Pass the task as host so port-observed fields are flagged `_observed_`. A node
+                    // built *inside* a task and observed there (the request/result node of a worker
+                    // pool) is task-owned at `observeField` time, so that call never rendezvoused and
+                    // the render thread would otherwise have no idea anyone is waiting on it.
+                    return fromSGNode(arg, true, task);
                 }
                 return jsValueOf(arg);
             });

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -3,6 +3,7 @@ import {
     Interpreter,
     BrsDevice,
     BrsEvent,
+    BrsComponent,
     BrsInvalid,
     BrsString,
     BrsType,
@@ -43,6 +44,32 @@ import type { Field, Scene } from "..";
  * activates on another thread instead of running out the clock and throwing a spurious timeout.
  */
 const RENDEZVOUS_POLL_MS = 100;
+
+/**
+ * Renders a field value for a rendezvous trace, but only when it is cheap and safe to print.
+ * Nodes and containers are reported by kind alone — stringifying a content tree inside the render
+ * loop would cost more than the trace is worth.
+ * @param value Value to describe.
+ * @returns A short printable form.
+ */
+function describeSimpleValue(value: BrsType): string {
+    if (value === undefined || value === null) {
+        return "undefined";
+    }
+    if (value.kind === undefined) {
+        return "?";
+    }
+    if (isBrsString(value)) {
+        return `"${value.getValue().slice(0, 24)}"`;
+    }
+    // Never stringify a component: `toString` on an array or AA renders every element (a whole
+    // content tree, worst case) and this runs inside the rendezvous round trip being measured, so
+    // printing the value would distort the very timings the trace exists to expose.
+    if (value instanceof BrsComponent) {
+        return `<${value.getComponentName()}>`;
+    }
+    return String(value.toString()).slice(0, 24);
+}
 
 /**
  * SceneGraph `Task` node implementation responsible for executing BrightScript in a worker thread.
@@ -87,6 +114,18 @@ export class Task extends Node {
     private syncRequestId: number = 1;
     /** Tracks acknowledgements completed by the main thread. */
     private readonly completedAcks: Set<number> = new Set();
+    /**
+     * Request ids of rendezvous field *reads* still awaiting a response.
+     *
+     * The owner answers a `get` with an update whose action is `set`, so the reply travels the same
+     * path as a genuine push and used to be applied with notification — making a read of a field
+     * indistinguishable from a change to it, and firing the reader's own observers. That is never
+     * right (a read fires nothing on a device) and it is actively destructive for a port observer:
+     * an AA- or array-valued field always compares unequal (`RoAssociativeArray.equalTo` is
+     * unconditionally false), so *every* read pushed a phantom event onto the port. An app driving a
+     * dispatch loop off such a port sees completions that never happened.
+     */
+    private readonly pendingReads: Set<number> = new Set();
 
     /**
      * Creates a Task node, registering default and initial fields.
@@ -135,9 +174,23 @@ export class Task extends Node {
             return;
         }
         super.setValue(index, value, alwaysNotify, kind);
+        // Re-resolve: `super.setValue` may have *created* the field (the `alwaysNotify !== undefined`
+        // branch), and the pre-`super` lookup above used `fields.get`, which misses lazily
+        // materialized/aliased fields. Capturing it before the call skipped the sync entirely.
+        const synced = this.resolveField(mapKey);
         // Notify other threads of field changes
-        if (field && sync && this.changed) {
-            this.syncRemoteField(mapKey, field.getValue(false));
+        if (synced && sync && this.changed) {
+            const ownTask = sgRoot.getCurrentThreadTask();
+            if (ownTask && ownTask !== this && this.shouldRendezvous()) {
+                // A *foreign* Task node — another task's node, typically reached through `m.global`.
+                // This copy was never activated on this thread, so it has no thread of its own
+                // (`threadId < 0`) and its own `syncRemoteField` would drop the write silently. Send
+                // it out through the current thread's channel, addressed at the target node, exactly
+                // as `Node.rendezvousSet` does for non-Task nodes.
+                ownTask.syncRemoteField(mapKey, synced.getValue(false), this.syncType, this.address);
+            } else {
+                this.syncRemoteField(mapKey, synced.getValue(false));
+            }
             this.changed = false;
         }
     }
@@ -488,6 +541,9 @@ export class Task extends Node {
             requestId,
         };
         const started = sgRoot.logRendezvous ? Date.now() : 0;
+        // Mark before sending: the reply is applied inside `processThreadUpdate` below, which has to
+        // recognise it as a read and store the value without notifying observers.
+        this.pendingReads.add(requestId);
         this.sendThreadUpdate(request);
         let deadline = Date.now() + timeoutMs;
         const responseBuffer = this.directBuffer ?? this.taskBuffer;
@@ -496,9 +552,11 @@ export class Task extends Node {
             const update = this.processThreadUpdate(responseBuffer);
             if (update?.requestId === requestId) {
                 if (update.action === "set") {
+                    this.pendingReads.delete(requestId);
                     this.logRendezvousTiming("get", type, fieldName, started);
                     return true;
                 } else if (update.action === "nil") {
+                    this.pendingReads.delete(requestId);
                     this.logRendezvousTiming("get", type, fieldName, started);
                     return false;
                 }
@@ -517,6 +575,7 @@ export class Task extends Node {
             // after we entered the wait; the real timeout is enforced by the `remaining` check above.
             responseBuffer.waitVersion(0, Math.min(remaining, RENDEZVOUS_POLL_MS));
         }
+        this.pendingReads.delete(requestId);
         throw this.rendezvousTimeoutError("get", type, fieldName);
     }
 
@@ -758,6 +817,14 @@ export class Task extends Node {
         } else if (update.type === "scene") {
             return sgRoot.scene;
         } else if (update.type === "task") {
+            // A `task`-domain update normally targets the sending task's own node, whose address
+            // matches ours. A worker-pool dispatch (one task writing *another* Task node's field)
+            // carries the target's address instead, so honor it rather than assuming `this` —
+            // otherwise the write lands on the sender's node. Unresolvable falls through to
+            // `handleUnresolvedNode`, which still acks so the sender does not hang.
+            if (update.address && update.address !== this.address) {
+                return this.resolveNode(update.address, true);
+            }
             return this;
         } else if (update.address) {
             return this.resolveNode(update.address, true);
@@ -778,26 +845,69 @@ export class Task extends Node {
         // `update.value` is null when the other thread set the field to `invalid` (jsValueOf maps it
         // to null), which is a legitimate way to clear a node-valued field — reading `_address_` off
         // it threw and killed the whole task-update pass.
-        if (!this.inThread && oldValue instanceof Node && oldValue.getAddress() === update.value?._address_) {
-            // Update existing node to preserve references
-            value = updateSGNode(update.value, oldValue);
-        } else {
-            value = brsValueOf(update.value);
+        // As in `handleMethodCallRequest`: a node arriving as a field value carries its port
+        // observations, which belong to the sending thread.
+        const priorThread = sgRoot.deserializingThread;
+        sgRoot.deserializingThread = this.inThread ? -1 : update.id;
+        try {
+            if (!this.inThread && oldValue instanceof Node && oldValue.getAddress() === update.value?._address_) {
+                // Update existing node to preserve references
+                value = updateSGNode(update.value, oldValue);
+            } else {
+                value = brsValueOf(update.value);
+            }
+        } finally {
+            sgRoot.deserializingThread = priorThread;
         }
         node.markFieldFresh(update.key);
-        node.setValue(update.key, value, false, undefined, false);
+        // An update that lands on a node nobody is watching (a stale duplicate holding the same
+        // address) or whose value already equals what the field held (which suppresses notification)
+        // looks identical to a successful delivery unless the receiving side's state is reported.
+        const observed = sgRoot.logRendezvous
+            ? node.resolveField(update.key.toLowerCase())?.isObserved() ?? false
+            : false;
+        const previous = sgRoot.logRendezvous ? describeSimpleValue(oldValue) : "";
+        // A reply to one of *our* reads only mirrors the owner's value locally — it is not a change,
+        // so it must not fire this thread's observers (see `pendingReads`).
+        const isReadReply = update.requestId !== undefined && this.pendingReads.has(update.requestId);
+        if (isReadReply) {
+            node.setValueSilent(update.key, value);
+        } else {
+            node.setValue(update.key, value, false, undefined, false);
+        }
         if (sgRoot.logRendezvous) {
             BrsDevice.stdout.write(
-                `debug,[rendezvous] thread ${sgRoot.threadId} applied set ${update.type}.${update.key} from thread ${update.id}`
+                `debug,[rendezvous] thread ${sgRoot.threadId} applied set ${update.type}.${update.key} from thread ${
+                    update.id
+                } on ${
+                    node.nodeSubtype
+                }#${node.getAddress()} (observed=${observed} silent=${isReadReply} ${previous}->${describeSimpleValue(
+                    value
+                )})`
             );
         }
         // The render fans a task's applied set out to the other observing tasks itself (targeted to
-        // observers, excluding the originator) rather than relying on the broker to blind-relay. Only
-        // shared domains (global/scene/node) cross between tasks — `task`-type fields are private to a
-        // single task, mirroring the broker's `type !== "task"` guard; fanning them out would deliver
-        // one task's field into another task's identically-named field (and corrupt node ownership).
-        if (this.fanoutBuffer && !this.inThread && update.type !== "task") {
-            node.fanOutFieldToObservingTasks(update.key, update.id);
+        // observers, excluding the originator) rather than relying on the broker to blind-relay.
+        if (this.fanoutBuffer && !this.inThread) {
+            if (update.type === "task") {
+                // A `task`-domain field belongs to one specific Task node. Fanning it out *by type
+                // alone* used to be unsafe — it would land one task's field in another task's
+                // identically-named field — which is why this was skipped wholesale. Updates now
+                // carry the target's address and `getNodeToUpdate` resolves it, so both deliveries
+                // below are unambiguous.
+                //
+                // 1. The node's own thread, when the write came from somewhere else (a worker-pool
+                //    dispatch: one task writing another task's field).
+                const target = node !== this && node instanceof Task ? node : undefined;
+                target?.syncRemoteField(update.key, value);
+                // 2. Any *other* task port-observing the field — e.g. a coordinator watching its
+                //    pool slots' `response`. `observeField(field, port)` from a task rendezvouses
+                //    here and registers on the render copy, so `isPortObserved` sees it; without
+                //    this the observing task's own port never fires and it waits forever.
+                node.fanOutFieldToObservingTasks(update.key, update.id, target?.threadId ?? -1);
+            } else {
+                node.fanOutFieldToObservingTasks(update.key, update.id);
+            }
         }
         // Send acknowledgement back to the other thread if needed
         if (!this.inThread && update.requestId !== undefined) {
@@ -806,6 +916,45 @@ export class Task extends Node {
             this.sendThreadUpdate(update);
         }
         return update;
+    }
+
+    /**
+     * Records (or clears) a task thread's port observation when its `observeField`/`unobserveField`
+     * call arrives here by rendezvous.
+     *
+     * The `roMessagePort` argument does not survive serialization — it is rebuilt as a fresh, empty
+     * port — so the observer this call is about to register on the render copy can never fire.
+     * Remembering *which thread* asked lets `fanOutFieldToObservingTasks` push the value back to
+     * that thread, where the real port lives.
+     * @param target Node the method was called on.
+     * @param update Thread update carrying the originating thread id in `id`.
+     * @param args Serialized argument list from the method-call payload.
+     */
+    private trackRemotePortObserver(target: Node, update: ThreadUpdate, args: any) {
+        const method = update.key.toLowerCase();
+        const observing = method === "observefield" || method === "observefieldscoped";
+        const unobserving = method === "unobservefield" || method === "unobservefieldscoped";
+        if (!observing && !unobserving) {
+            return;
+        }
+        const fieldName = Array.isArray(args) ? args[0] : undefined;
+        if (typeof fieldName !== "string") {
+            return;
+        }
+        const field = target.resolveField(fieldName.toLowerCase());
+        if (!field) {
+            return;
+        }
+        // `observeField` is overloaded on its second argument; only the port form needs tracking,
+        // and a serialized port is the `{_component_: "roMessagePort"}` stub.
+        if (observing && args[1]?._component_?.toLowerCase() !== "romessageport") {
+            return;
+        }
+        if (observing) {
+            field.addRemotePortObserver(update.id);
+        } else {
+            field.removeRemotePortObserver(update.id);
+        }
     }
 
     /**
@@ -826,9 +975,21 @@ export class Task extends Node {
         if (!method || !sgRoot.interpreter) {
             return;
         }
-        const value = brsValueOf(payload.args);
+        // Attribute any `_observed_` carried by node arguments to the calling thread while they are
+        // rebuilt (see `applyRemotePortObservers`); restore so nested rebuilds stay correct.
+        const priorThread = sgRoot.deserializingThread;
+        sgRoot.deserializingThread = this.inThread ? -1 : update.id;
+        let value: BrsType;
+        try {
+            value = brsValueOf(payload.args);
+        } finally {
+            sgRoot.deserializingThread = priorThread;
+        }
         const args: BrsType[] = value instanceof RoArray ? value.getElements() : [];
         const location = payload.location ?? sgRoot.interpreter.location;
+        if (!this.inThread) {
+            this.trackRemotePortObserver(target, update, payload.args);
+        }
         const result = sgRoot.interpreter.call(method, args, hostNode.m, location, hostNode);
         update.action = "resp";
         if (result instanceof Node) {

--- a/src/node/task.ts
+++ b/src/node/task.ts
@@ -24,10 +24,25 @@ import SharedObject from "../core/SharedObject";
 // NOTE: Keep in sync with `src/api/task.ts` (the browser task broker). Both implement the same
 // task-spawn protocol and thread-update relay; only the Worker API and event routing differ.
 
-const MAX_TASKS = 10;
+/**
+ * Concurrent task workers allowed at once. This is purely a guardrail against a runaway app spawning
+ * workers without end. Apps built around a persistent worker pool park several tasks in permanent loops
+ * and still need headroom for the transient ones, so the ceiling has to sit well above the pool size.
+ * Reaching it no longer drops the task: see `pendingTasks`.
+ */
+const MAX_TASKS = 30;
 
 // Active Tasks
 const tasks: Map<number, Worker> = new Map();
+/**
+ * Launches deferred because `MAX_TASKS` was reached, oldest first, started as slots free.
+ *
+ * The cap used to drop the launch outright, and the task node had already flipped to `started`, so
+ * it never retried — leaving it in `state = "run"` with no thread behind it for the rest of the
+ * session. A cap is a throttle, not a cliff: an app that fans out more sections than there are
+ * slots should load them late, not lose them.
+ */
+const pendingTasks: { taskData: TaskData; payload: AppPayload }[] = [];
 const threadSyncToTask: Map<number, SharedObject> = new Map();
 const threadSyncToMain: Map<number, SharedObject> = new Map();
 let sharedBuffer: ArrayBufferLike;
@@ -97,8 +112,14 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
     if (tasks.has(taskData.id) || !taskData.m?.top?.functionname) {
         notifyHost("debug", `[task:host] Task already running or invalid task data: ${taskData.id}, ${taskData.name}`);
         return;
-    } else if (tasks.size === MAX_TASKS) {
-        notifyHost("warning", `[task:host] Maximum number of tasks reached: ${tasks.size}`);
+    } else if (tasks.size >= MAX_TASKS) {
+        if (!pendingTasks.some((pending) => pending.taskData.id === taskData.id)) {
+            pendingTasks.push({ taskData, payload: currentPayload });
+        }
+        notifyHost(
+            "warning",
+            `[task:host] Maximum number of tasks reached (${tasks.size}), queued: ${taskData.id}, ${taskData.name}`
+        );
         return;
     }
     // Pipe stdout/stderr so console output from inside the task worker becomes a host
@@ -144,6 +165,11 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
  * @param taskId ID of the task to terminate
  */
 function endTask(taskId: number) {
+    // A task stopped before its queued launch got a slot must not start afterwards.
+    const queued = pendingTasks.findIndex((pending) => pending.taskData.id === taskId);
+    if (queued >= 0) {
+        pendingTasks.splice(queued, 1);
+    }
     const taskWorker = tasks.get(taskId);
     if (taskWorker) {
         taskWorker.removeAllListeners("message");
@@ -156,6 +182,16 @@ function endTask(taskId: number) {
         threadSyncToTask.delete(taskId);
         threadSyncToMain.delete(taskId);
         notifyHost("debug", `[task:host] Task worker stopped: ${taskId}`);
+    }
+    startPendingTasks();
+}
+
+/** Starts queued launches, oldest first, while slots are free. */
+function startPendingTasks() {
+    while (pendingTasks.length > 0 && tasks.size < MAX_TASKS) {
+        const next = pendingTasks.shift()!;
+        notifyHost("debug", `[task:host] Starting queued Task: ${next.taskData.id}, ${next.taskData.name}`);
+        runTask(next.taskData, next.payload);
     }
 }
 
@@ -174,6 +210,9 @@ export function resetTasks() {
         shared.dispose();
     }
     tasks.clear();
+    // Queued launches belong to the app being torn down; starting them against the next one would
+    // spawn workers with a stale payload.
+    pendingTasks.length = 0;
     threadSyncToTask.clear();
     threadSyncToMain.clear();
     directMode = false;

--- a/test/brsTypes/components/RoStreamSocket.test.js
+++ b/test/brsTypes/components/RoStreamSocket.test.js
@@ -1,0 +1,86 @@
+const brs = require("../../../packages/node/bin/brs.node");
+const { Interpreter } = brs;
+const { RoStreamSocket, BrsString } = brs.types;
+
+/**
+ * `errorCode` is what BrightScript reads back through `ifSocket.status()` (as an Int32) and through
+ * every `ifSocketStatus` predicate (as an equality test against a fixed number), so it has to hold a
+ * number. It used to be assigned Node's `err.code` — a *string* like "EPIPE" — which made `status()`
+ * produce garbage and every predicate answer false.
+ */
+describe("RoStreamSocket", () => {
+    let interpreter;
+    let socket;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        socket = new RoStreamSocket();
+    });
+
+    afterEach(() => {
+        socket.socket?.destroy();
+    });
+
+    /** Invokes one of the component's registered BrightScript methods. */
+    function call(name, ...args) {
+        return socket.getMethod(name).call(interpreter, ...args);
+    }
+
+    describe("asynchronous socket failures", () => {
+        it("records an error event instead of letting it crash the thread", () => {
+            // `net.Socket` reports a failed write on a destroyed socket through an `error` event, not
+            // as a throw. With no listener attached, Node rethrows it as an uncaught exception and
+            // took down the whole worker.
+            expect(() => socket.socket.emit("error", { code: "ERR_SOCKET_CLOSED" })).not.toThrow();
+        });
+
+        it("maps a host error name to the numeric code the status predicates test", () => {
+            socket.socket.emit("error", { code: "EAGAIN", errno: -35 });
+
+            // 11 is asserted by `eAgain()`. The host's own `errno` differs by platform (35 on BSD),
+            // so the stable name has to win over it.
+            expect(call("status").getValue()).toBe(11);
+            expect(call("eAgain").toBoolean()).toBe(true);
+            expect(call("eSuccess").toBoolean()).toBe(false);
+        });
+
+        it("falls back to a generic code for an unrecognized error", () => {
+            socket.socket.emit("error", { code: "ERR_SOCKET_CLOSED" });
+
+            const status = call("status").getValue();
+            expect(typeof status).toBe("number");
+            expect(Number.isNaN(status)).toBe(false);
+            expect(status).toBe(3474);
+        });
+
+        it("starts with no error recorded", () => {
+            expect(call("status").getValue()).toBe(0);
+            expect(call("eSuccess").toBoolean()).toBe(true);
+        });
+    });
+
+    describe("writing to a socket that cannot accept data", () => {
+        beforeEach(() => {
+            // A fresh socket is writable — Node buffers writes made before connect. Closing it is
+            // what makes a write fail, and it fails *asynchronously*, so the caller's try/catch never
+            // sees it.
+            socket.socket.destroy();
+        });
+
+        it("reports nothing sent rather than queueing a write that can only fail", () => {
+            expect(socket.socket.writable).toBe(false);
+
+            expect(call("sendStr", new BrsString("hello")).getValue()).toBe(0);
+            expect(call("status").getValue()).toBe(3474);
+        });
+
+        it("keeps status numeric after a failed send", () => {
+            call("sendStr", new BrsString("hello"));
+
+            // Every ifSocketStatus predicate is an equality test against a number; a string here
+            // makes all of them answer false regardless of what actually happened.
+            expect(typeof call("status").getValue()).toBe("number");
+            expect(call("eSuccess").toBoolean()).toBe(false);
+        });
+    });
+});

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -984,6 +984,67 @@ describe.concurrent("cli", () => {
         expect(lines).toContain("------ Finished 'main.brs' execution [EXIT_USER_NAV] ------");
     }, 30000);
 
+    it("Delivers a field set from one Task thread to another Task's thread", async () => {
+        let command = ["node", brsCliPath, "-r task-pool-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Worker-pool apps park a long-lived Task on a port and dispatch to it from other Task
+        // threads. That write was silently dropped: `Task.setValue` synced through the *target*
+        // Task as transport, but a foreign Task node is only a deserialized copy with no thread
+        // of its own (`threadId < 0`), so `syncRemoteField` returned early and nothing crossed.
+        // The coordinator's notification broke separately: `observeField(field, port)` from a task
+        // thread rendezvouses to the render thread, where the port is rebuilt as a fresh empty
+        // RoMessagePort, so the render side held a dead observer and the task's real port never
+        // fired. `task`-domain fan-out was also skipped wholesale, which is what "WATCHER SAW"
+        // guards — a coordinator watching a pool slot it does not own.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Task Pool Repro ===");
+        expect(lines).toContain("SLOT READY");
+        expect(lines).toContain("WATCHER READY");
+        expect(lines).toContain("DISPATCH: sent");
+        expect(lines).toContain("SLOT RESPONSE: echo:ping");
+        expect(lines).toContain("WATCHER SAW: echo:ping");
+        // The blocking-request pattern: the caller builds a node, port-observes it while it is
+        // still task-owned (so that observeField never rendezvouses), then hands it over. The
+        // render thread only learns a port is waiting from the `_observed_` data carried across.
+        expect(lines).toContain("DISPATCH GOT: echo:ping");
+        expect(lines).toContain("DISPATCHER REPLY: echo:ping");
+        // One dispatch must raise exactly one event. The owner answers a rendezvous *read* with an
+        // update whose action is `set`, and applying it with notification made reading a field
+        // indistinguishable from changing it: the slot's own `req = m.top.request` re-fired its port,
+        // and an assocarray field always compares unequal so it never settled. A continuous-server
+        // loop then re-ran the same work indefinitely, and a coordinator keying completions off such
+        // a port credited responses to the wrong caller.
+        expect(lines).toContain("SLOT EVENT #1");
+        expect(lines).not.toContain("SLOT EVENT #2");
+        expect(lines).not.toContain("WATCHER PHANTOM EVENT");
+        expect(lines).toContain("=== Task Pool Repro Complete ===");
+        expect(lines).toContain("------ Finished 'main.brs' execution [EXIT_USER_NAV] ------");
+    }, 30000);
+
+    it("Delivers a field change to a port a Task registered during init()", async () => {
+        let command = ["node", brsCliPath, "-r task-globalobserve-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // The documented Task pattern (docs/limitations.md): the task registers a port observer in
+        // init() — which runs on the render thread, so it never goes through the rendezvous
+        // observeField path — and consumes events from its own thread. The only record that the task
+        // is waiting is the `hostNode` on the observer callback, so cross-thread fan-out has to
+        // attribute observers by it. Picking fan-out targets any other way either misses this task or
+        // (if it answers "observed" for every scope) broadcasts each update to all of them.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Task Global Observe Repro ===");
+        expect(lines).toContain("TASK READY");
+        expect(lines).toContain("OBSERVER GOT: hello");
+        expect(lines).toContain("SCENE SAW: hello");
+        expect(lines).not.toContain("OBSERVER: timed out");
+        expect(lines).toContain("=== Task Global Observe Repro Complete ===");
+    }, 30000);
+
     it("Clears a node-valued field set to invalid from a Task thread", async () => {
         let command = ["node", brsCliPath, "-r task-clear-node-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/task-globalobserve-app/components/MainScene.xml
+++ b/test/cli/resources/task-globalobserve-app/components/MainScene.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        ' The documented Task pattern: the task registers a port observer in init() (which runs
+        ' on the render thread) and consumes it from its own thread. Here it watches a field on
+        ' m.global that the render thread writes after the task is up.
+        m.global.addFields({ ticket: "" })
+        m.task = createObject("roSGNode", "ObserverTask")
+        m.task.observeField("ready", "onTaskReady")
+        m.task.observeField("seen", "onTaskSeen")
+        m.task.control = "run"
+    end sub
+
+    sub onTaskReady(event as object)
+        if not event.getData() then return
+        print "TASK READY"
+        m.global.ticket = "hello"
+    end sub
+
+    sub onTaskSeen(event as object)
+        print "SCENE SAW: "; event.getData()
+        m.top.done = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-globalobserve-app/components/ObserverTask.xml
+++ b/test/cli/resources/task-globalobserve-app/components/ObserverTask.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ObserverTask" extends="Task">
+    <interface>
+        <field id="ready" type="boolean" value="false" />
+        <field id="seen" type="string" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runObserver"
+        ' Created and registered on the render thread; the task thread receives a copy of `m`
+        ' whose observers are re-registered against this same port.
+        m.port = CreateObject("roMessagePort")
+        m.global.observeField("ticket", m.port)
+    end sub
+
+    sub runObserver()
+        m.top.ready = true
+        for i = 0 to 100
+            msg = wait(100, m.port)
+            if type(msg) = "roSGNodeEvent" and msg.getField() = "ticket"
+                print "OBSERVER GOT: "; msg.getData()
+                m.top.seen = msg.getData()
+                return
+            end if
+        end for
+        print "OBSERVER: timed out"
+        m.top.seen = "timeout"
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-globalobserve-app/manifest
+++ b/test/cli/resources/task-globalobserve-app/manifest
@@ -1,0 +1,4 @@
+title=Task Global Observe Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-globalobserve-app/source/main.brs
+++ b/test/cli/resources/task-globalobserve-app/source/main.brs
@@ -1,0 +1,13 @@
+sub Main()
+    print "=== Task Global Observe Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    for i = 0 to 250
+        msg = wait(20, port)
+        if scene.done then exit for
+    end for
+    print "=== Task Global Observe Repro Complete ==="
+end sub

--- a/test/cli/resources/task-pool-app/components/DispatchTask.xml
+++ b/test/cli/resources/task-pool-app/components/DispatchTask.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="DispatchTask" extends="Task">
+    <interface>
+        <field id="got" type="string" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runDispatch"
+    end sub
+
+    sub runDispatch()
+        ' Runs on its own task thread. `m.global.slot` is another Task node owned by the
+        ' render thread, so writing its field has to rendezvous out through *this* thread's
+        ' channel and then be forwarded to the slot's thread.
+        slot = m.global.slot
+        if slot = invalid
+            print "DISPATCH: slot missing"
+            return
+        end if
+
+        ' The blocking-request pattern: build a result node here, observe it with a port
+        ' *before* handing it over, then park. The node is task-owned at observe time, so
+        ' that observeField never rendezvouses — the render thread only learns a port is
+        ' waiting on it from the `_observed_` data carried by appendChild.
+        result = CreateObject("roSGNode", "ResultNode")
+        port = CreateObject("roMessagePort")
+        result.observeField("isDone", port)
+        slot.appendChild(result)
+
+        slot.request = { text: "ping" }
+        print "DISPATCH: sent"
+
+        msg = wait(5000, port)
+        if type(msg) = "roSGNodeEvent"
+            print "DISPATCH GOT: "; result.payload
+            m.top.got = result.payload
+        else
+            print "DISPATCH: timed out"
+            m.top.got = "timeout"
+        end if
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-pool-app/components/MainScene.xml
+++ b/test/cli/resources/task-pool-app/components/MainScene.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        ' Models a worker-pool app: a long-lived "slot" task parked on a port waiting for
+        ' work, published on m.global so any thread can dispatch to it; a "watcher" task
+        ' that observes the slot's output field with a port from its own thread (the
+        ' coordinator role); and a dispatcher task that hands the slot a request. Both the
+        ' dispatch and the watcher's notification cross a task -> render -> task boundary.
+        m.sawResponse = false
+        m.watcherSaw = false
+        m.dispatcherGot = false
+        m.slot = createObject("roSGNode", "SlotTask")
+        m.global.addFields({ slot: m.slot })
+        m.slot.observeField("isReady", "onSlotReady")
+        m.slot.observeField("response", "onSlotResponse")
+        m.slot.control = "run"
+    end sub
+
+    sub onSlotReady(event as object)
+        if not event.getData() then return
+        print "SLOT READY"
+        ' Start the watcher next; it reports "waiting" once its port observer is registered.
+        m.watcher = createObject("roSGNode", "WatcherTask")
+        m.watcher.observeField("seen", "onWatcherSeen")
+        m.watcher.control = "run"
+    end sub
+
+    sub onWatcherSeen(event as object)
+        seen = event.getData()
+        if seen = "waiting"
+            print "WATCHER READY"
+            ' Only now dispatch, so a missing notification can only mean the update was lost.
+            m.dispatcher = createObject("roSGNode", "DispatchTask")
+            m.dispatcher.observeField("got", "onDispatcherGot")
+            m.dispatcher.control = "run"
+            return
+        end if
+        m.watcherSaw = true
+        checkDone()
+    end sub
+
+    sub onDispatcherGot(event as object)
+        print "DISPATCHER REPLY: "; event.getData()
+        m.dispatcherGot = true
+        checkDone()
+    end sub
+
+    sub onSlotResponse(event as object)
+        print "SLOT RESPONSE: "; event.getData().text
+        m.sawResponse = true
+        checkDone()
+    end sub
+
+    sub checkDone()
+        if m.sawResponse and m.watcherSaw and m.dispatcherGot then m.top.done = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-pool-app/components/ResultNode.xml
+++ b/test/cli/resources/task-pool-app/components/ResultNode.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ResultNode" extends="Node">
+    <interface>
+        <field id="payload" type="string" />
+        <field id="isDone" type="boolean" value="false" />
+    </interface>
+</component>

--- a/test/cli/resources/task-pool-app/components/SlotTask.xml
+++ b/test/cli/resources/task-pool-app/components/SlotTask.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="SlotTask" extends="Task">
+    <interface>
+        <field id="isReady" type="boolean" value="false" />
+        <field id="request" type="assocarray" />
+        <field id="response" type="assocarray" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runSlot"
+    end sub
+
+    sub runSlot()
+        ' Continuous-server loop: park on the port and echo whatever is dispatched to us.
+        port = CreateObject("roMessagePort")
+        m.top.observeField("request", port)
+        ' Announce readiness only after the observer is registered, so the dispatcher
+        ' cannot write before we are listening.
+        m.top.isReady = true
+        events = 0
+        for i = 0 to 100
+            msg = wait(100, port)
+            if type(msg) = "roSGNodeEvent" and msg.getField() = "request"
+                events = events + 1
+                print "SLOT EVENT #"; events.ToStr()
+                ' Reading our own render-owned field rendezvouses. If that reply is applied with
+                ' notification, this read pushes another "request" event onto our own port and the
+                ' loop re-runs the same work forever - an assocarray field always compares unequal,
+                ' so it can never settle.
+                req = m.top.request
+                if events = 1
+                    reply = "echo:" + req.text
+                    ' The caller handed us its result node as a child. Writing to it crosses back
+                    ' through the render thread, which then has to notify the caller's port.
+                    count = m.top.getChildCount()
+                    if count > 0
+                        child = m.top.getChild(count - 1)
+                        child.payload = reply
+                        child.isDone = true
+                    end if
+                    m.top.response = { text: reply }
+                end if
+            end if
+        end for
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-pool-app/components/WatcherTask.xml
+++ b/test/cli/resources/task-pool-app/components/WatcherTask.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="WatcherTask" extends="Task">
+    <interface>
+        <field id="seen" type="string" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runWatcher"
+    end sub
+
+    sub runWatcher()
+        ' A coordinator watching a pool slot it does not own: observe another Task node's
+        ' field with a port from *this* thread, then park. The write happens on the slot's
+        ' own thread, so the value has to travel slot -> render -> here.
+        port = CreateObject("roMessagePort")
+        slot = m.global.slot
+        if slot = invalid
+            print "WATCHER: slot missing"
+            return
+        end if
+        slot.observeField("response", port)
+        m.top.seen = "waiting"
+        for i = 0 to 100
+            ' Reading an observed field must not look like a change to it. Each read rendezvouses to
+            ' the owner and the reply is applied locally; if that apply notifies, this loop sees a
+            ' phantom "response" event carrying whatever the field held, and a dispatch loop driven
+            ' off such a port credits a completion that never happened.
+            probe = slot.response
+            msg = wait(100, port)
+            if type(msg) = "roSGNodeEvent" and msg.getField() = "response"
+                data = msg.getData()
+                ' An assocarray field always compares unequal, so a read applied with notification
+                ' fires here carrying whatever the field held - usually nothing yet.
+                if type(data) <> "roAssociativeArray" or data.text = invalid
+                    print "WATCHER PHANTOM EVENT"
+                    m.top.seen = "phantom"
+                    return
+                end if
+                print "WATCHER SAW: "; data.text
+                m.top.seen = data.text
+                return
+            end if
+        end for
+        print "WATCHER: timed out"
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-pool-app/manifest
+++ b/test/cli/resources/task-pool-app/manifest
@@ -1,0 +1,4 @@
+title=Task Pool Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-pool-app/source/main.brs
+++ b/test/cli/resources/task-pool-app/source/main.brs
@@ -1,0 +1,14 @@
+sub Main()
+    print "=== Task Pool Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Pump the message loop until the slot task echoes back (the scene sets `done`).
+    for i = 0 to 250
+        msg = wait(20, port)
+        if scene.done then exit for
+    end for
+    print "=== Task Pool Repro Complete ==="
+end sub

--- a/test/extensions/scenegraph/TaskPortObservers.test.js
+++ b/test/extensions/scenegraph/TaskPortObservers.test.js
@@ -1,0 +1,145 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, sgRoot, fromSGNode, toSGNode } = scenegraph;
+const { BrsString, RoMessagePort, Interpreter } = core;
+
+/**
+ * Cross-thread fan-out has to answer one question exactly: *which* task thread is waiting on this
+ * field through a port? A port cannot cross a thread boundary — `observeField(field, port)` from a
+ * task rendezvouses to the owner where the port is rebuilt empty, and an observer registered in a
+ * Task's `init()` runs on the render thread and never rendezvouses at all. Getting the answer wrong
+ * in either direction is destructive: too narrow and the waiting task never wakes; too broad and
+ * every update is broadcast to every active task, swamping the single-slot fan-out buffers.
+ */
+describe("task port observer attribution", () => {
+    /**
+     * Registers an unscoped port observer on `target.fieldName`, attributed to `host` the way
+     * `observeField` does (the callback records `interpreter.environment.hostNode`).
+     */
+    function observeWithPort(target, fieldName, host) {
+        const interpreter = new Interpreter();
+        interpreter.environment.hostNode = host;
+        const port = new RoMessagePort();
+        target.addObserver(interpreter, "unscoped", new BrsString(fieldName), port);
+        return port;
+    }
+
+    describe("isPortObserved", () => {
+        test("attributes an unscoped port observer to the node that registered it", () => {
+            const target = new Node([], "Node");
+            target.setValue("payload", new BrsString(""), false);
+            const watcher = new Node([], "WatcherTask");
+            const bystander = new Node([], "OtherTask");
+
+            observeWithPort(target, "payload", watcher);
+            const field = target.resolveField("payload");
+
+            expect(field.isPortObserved(watcher)).toBe(true);
+            // Answering true here is what broadcast every update to every task.
+            expect(field.isPortObserved(bystander)).toBe(false);
+        });
+
+        test("reports no port observation for a field observed by name only", () => {
+            const target = new Node([], "Node");
+            target.setValue("payload", new BrsString(""), false);
+            const host = new Node([], "WatcherTask");
+            const interpreter = new Interpreter();
+            interpreter.environment.hostNode = host;
+
+            target.addObserver(interpreter, "unscoped", new BrsString("payload"), new BrsString("onPayload"));
+
+            expect(target.resolveField("payload").isPortObserved(host)).toBe(false);
+        });
+    });
+
+    describe("remote port observers", () => {
+        test("records and clears the thread waiting on a field", () => {
+            const target = new Node([], "Node");
+            target.setValue("isDone", new BrsString(""), false);
+            const field = target.resolveField("isdone");
+
+            expect(field.hasRemotePortObserver(7)).toBe(false);
+
+            field.addRemotePortObserver(7);
+            expect(field.hasRemotePortObserver(7)).toBe(true);
+            expect(field.hasRemotePortObserver(8)).toBe(false);
+
+            field.removeRemotePortObserver(7);
+            expect(field.hasRemotePortObserver(7)).toBe(false);
+        });
+
+        test("un-hides a field so a hidden default can still be waited on", () => {
+            const target = new Node([], "Node");
+            target.setValue("isDone", new BrsString(""), false);
+            const field = target.resolveField("isdone");
+            field.setHidden(true);
+
+            field.addRemotePortObserver(3);
+
+            expect(field.isHidden()).toBe(false);
+        });
+    });
+
+    describe("carrying observations across a thread boundary", () => {
+        test("serializes only the host's own port-observed fields as _observed_", () => {
+            const target = new Node([], "ApiResultNode");
+            target.setValue("isDone", new BrsString(""), false);
+            target.setValue("other", new BrsString(""), false);
+            const owner = new Node([], "LoadItemsTask");
+
+            observeWithPort(target, "isDone", owner);
+
+            // Serialized field names are lowercased, which is why `applyRemotePortObservers`
+            // lowercases before resolving them on the receiving side.
+            const observedNames = (fromSGNode(target, true, owner)["_observed_"] ?? []).map((entry) => entry.name);
+            expect(observedNames).toContain("isdone");
+            expect(observedNames).not.toContain("other");
+
+            // A different host registered nothing here, so nothing is flagged for it.
+            const bystander = new Node([], "OtherTask");
+            expect(fromSGNode(target, true, bystander)["_observed_"]).toBeUndefined();
+        });
+
+        test("rebuilding a node attributes its _observed_ fields to the sending thread", () => {
+            const target = new Node([], "ApiResultNode");
+            target.setValue("isDone", new BrsString(""), false);
+            const owner = new Node([], "LoadItemsTask");
+            observeWithPort(target, "isDone", owner);
+            const serialized = JSON.parse(JSON.stringify(fromSGNode(target, true, owner)));
+
+            // A node built inside a task and handed over (appendChild) is the only signal the render
+            // thread gets that a port on that thread is waiting on it.
+            const prior = sgRoot.deserializingThread;
+            sgRoot.deserializingThread = 12;
+            let rebuilt;
+            try {
+                rebuilt = toSGNode(serialized, "Node", "ApiResultNode", true);
+            } finally {
+                sgRoot.deserializingThread = prior;
+            }
+
+            expect(rebuilt.resolveField("isdone").hasRemotePortObserver(12)).toBe(true);
+            expect(rebuilt.resolveField("isdone").hasRemotePortObserver(13)).toBe(false);
+        });
+
+        test("records nothing when the rebuild is not attributed to a thread", () => {
+            const target = new Node([], "ApiResultNode");
+            target.setValue("isDone", new BrsString(""), false);
+            const owner = new Node([], "LoadItemsTask");
+            observeWithPort(target, "isDone", owner);
+            const serialized = JSON.parse(JSON.stringify(fromSGNode(target, true, owner)));
+
+            const prior = sgRoot.deserializingThread;
+            sgRoot.deserializingThread = -1;
+            let rebuilt;
+            try {
+                rebuilt = toSGNode(serialized, "Node", "ApiResultNode", true);
+            } finally {
+                sgRoot.deserializingThread = prior;
+            }
+
+            expect(rebuilt.resolveField("isdone").hasRemotePortObserver(0)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Apps built around a **persistent worker pool** — one `Task` parked on a port serving requests, a coordinator dispatching to it, callers blocking on a result node — could not work at all. Four defects on that path, each hiding the next, plus a socket crash and a task-cap truncation found along the way.

All were found by tracing a real SceneGraph app whose content never loaded, and each is covered by a fixture that fails without its fix.

## Cross-thread field sync and port observers

**A Task thread writing a field on a *different* Task node was silently dropped** — no error, no warning. `Task.setValue` synced through the *target* Task as transport, but a foreign Task node is only a deserialized copy that was never activated on this thread, so `threadId` is `-1` and `syncRemoteField` returned early; `Node.setValue` excludes `syncType === "task"` from the generic `rendezvousSet`, so nothing caught it. It now routes through the current thread's own task, addressed at the target, exactly as `rendezvousSet` already does for non-Task nodes. `getNodeToUpdate` also ignored `update.address` for task-domain updates, so even once the write crossed it would have landed on the sender's own node.

**A task observing another Task node's field by port was never notified.** `handleSetFieldRequest` skipped fan-out wholesale for task-domain updates. That guard existed because fanning out *by type alone* could land one task's field in another task's identically-named field — updates now carry the target's address and resolve it, so the ambiguity is gone.

**A rendezvous *read* fired the reader's own observers.** The owner answers a `get` with an update whose action is `set`, so the reply was applied with notification, making a read indistinguishable from a change. An AA- or array-valued field always compares unequal (`RoAssociativeArray.equalTo` is unconditionally false), so *every* read of one pushed a phantom event. Two consequences: a continuous-server loop (`wait` on a field, then read it) re-fired its own port and re-ran the same work indefinitely; and a coordinator keying completion off such a port credited completions that never happened, handing callers **another request's response**. Reads now apply with `setValueSilent`.

**Fan-out could not tell which thread was waiting.** `isPortObserved` answered true for *every* scope once one unscoped port observer existed, so each update went to every active task, swamping the single-slot buffers. `addObserver` already records the registering node, so matching `hostNode` makes attribution exact — and it is the only record for a Task that observed in `init()`, which runs on the render thread and never rendezvouses. A node built inside a task and handed over is covered separately, by carrying its `_observed_` data across.

## Socket crash

An app writing to a closed socket **crashed the whole worker** with an uncaught `ERR_SOCKET_CLOSED`. `net.Socket` reports that asynchronously through an `error` event rather than throwing, so the `try/catch` around `socket.write()` never saw it, and neither socket component registered an `error` listener.

Also keeps `errorCode` numeric: it surfaces through `ifSocket.status()` as an `Int32` and through every `ifSocketStatus` predicate as an equality test against a fixed number, but four sites assigned Node's `err.code` — a *string* — so `status()` returned `NaN` and every predicate answered false. The helper maps the host error *name* rather than `err.errno`, because errno is the host platform's own value and those differ (EAGAIN is 11 on Linux, 35 on BSD) while the predicates test fixed numbers.

## Task concurrency cap

Hitting `MAX_TASKS` dropped the launch, but `checkTaskRun` had already set `started = true`, so the task never retried — it sat in `state = "run"` with no thread behind it for the rest of the session. A cap should throttle, not truncate: refused launches now queue oldest-first and start as slots free. Ceiling raised 10 → 30 (Roku documents no hard limit; a device is memory-bound).

## Testing

**E2E fixtures** (`test/cli/`) — `task-pool-app` covers task→task field writes, cross-task port observation, the observe-then-hand-over blocking-request pattern, and phantom read events; `task-globalobserve-app` covers the documented `init()` port-observer pattern.

**Unit** — `TaskPortObservers.test.js` (observer attribution and the three registration paths), `RoStreamSocket.test.js` (the numeric contract and the crash).

Every test was **mutation-checked** rather than trusted green: reverting each fix fails the test that covers it. This mattered — two earlier versions of the pool fixture *passed against the broken build*, because string-typed fields compare correctly and hide the read-notification bug entirely. The fixture uses assocarrays for that reason.

Full suite green (180 files / 2268 tests); `tsc` and lint clean.

## Notes

Independent of #1104 (rendezvous tracing) — the two branches touch one file in common (`SGRoot.ts`, disjoint hunks) and merge cleanly in either order.

Remaining, not addressed here: cross-thread reads are frame-bound (`docs/scenegraph-rendezvous.md` notes task→render still hops through the main-thread broker and drains one update per pass). `sgRoot.fastFieldReads` exists for exactly that and is still off with no way to enable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
