### PR TITLE
fix(cli): let the ECP server bind a port other than 8060

### DIFF
--- a/docs/run-as-cli.md
+++ b/docs/run-as-cli.md
@@ -216,6 +216,14 @@ The app runs on a dedicated worker thread, leaving the terminal free for interac
 
 If you need remote control simulation from other devices, enable the option `--ecp` that will launch the ECP Server in port 8060 (same as a Roku device). With this option enabled, you can connect to your computer using any remote control app that uses ECP, including the [Roku Remote Tool](https://devtools.web.roku.com/#remote-tool), the [Roku GamePad Gateway](http://github.com/lvcabral/roku-gpg) or the Roku mobile apps. This option also enables an SSDP service to allow it to be discovered in your local network.
 
+If port 8060 is already taken — by another instance of the engine, a desktop build, or a remote control tool — set the `BRS_ECP_PORT` environment variable to bind elsewhere:
+
+```console
+$ BRS_ECP_PORT=8160 brs-cli --ecp app.zip
+```
+
+SSDP discovery is skipped on a non-default port: remote control apps only look for ECP on 8060, so advertising a relocated server would publish an endpoint nothing can use.
+
 ### Production vs Developer mode
 
 By default the engine runs in **production mode**, which keeps it lean by skipping all debug

--- a/src/cli/ecp.ts
+++ b/src/cli/ecp.ts
@@ -28,8 +28,27 @@ import WebSocket, { WebSocketServer, RawData } from "ws";
 import packageInfo from "../../packages/node/package.json";
 
 const DEBUG = false;
-const ECPPORT = 8060;
+/** The port a Roku serves ECP on. Remote-control apps look for it here, so it stays the default. */
+const DEFAULT_ECPPORT = 8060;
+const ECPPORT = resolveEcpPort();
 const SSDPPORT = 1900;
+
+/**
+ * Resolves the ECP listen port, honoring `BRS_ECP_PORT`.
+ *
+ * The port is fixed on a real device, so it is fixed here too — but that makes the server
+ * unstartable whenever anything else already holds 8060 (another engine instance, a desktop build,
+ * a real remote-control tool). The override exists so those cases can bind elsewhere instead of
+ * failing; an unset or unusable value keeps the Roku default.
+ * @returns The port to listen on.
+ */
+function resolveEcpPort(): number {
+    const configured = Number(process.env.BRS_ECP_PORT);
+    if (Number.isInteger(configured) && configured > 0 && configured < 65536) {
+        return configured;
+    }
+    return DEFAULT_ECPPORT;
+}
 const MAC = getMacAddress();
 const UDN = "138aedd0-d6ad-11eb-b8bc-" + MAC.replaceAll(/:\s*/g, "");
 let ecp: restana.Service<restana.Protocol.HTTP>;
@@ -103,43 +122,52 @@ function enableECP() {
     }
     ecp.start(ECPPORT)
         .then((server) => {
-            // Create SSDP Server
-            ssdp = new SSDP({
-                location: {
-                    port: ECPPORT,
-                    path: "/",
-                },
-                adInterval: 120000,
-                ttl: 3600,
-                udn: `uuid:roku:ecp:${device.serialNumber}`,
-                ssdpSig: "Roku UPnP/1.0 Roku/9.1.0",
-                ssdpPort: SSDPPORT,
-                suppressRootDeviceAdvertisements: true,
-                headers: { "device-group.roku.com": "46F5CCE2472F2B14D77" },
-            });
-            ssdp.addUSN("roku:ecp");
-            ssdp._usns["roku:ecp"] = `uuid:roku:ecp:${device.serialNumber}`;
-            // Start server on all interfaces
-            ssdp.start()
-                .catch((e: Error) => {
-                    parentPort?.postMessage({
-                        ready: false,
-                        msg: `Failed to start SSDP server:${e.message}\n`,
-                    });
-                })
-                .then(() => {
-                    subscribeControl("ecp", (event: string) => {
-                        if (event === "home" || event === "poweroff") {
-                            Atomics.store(sharedArray, DataType.DBG, DebugCommand.EXIT);
-                        }
-                    });
-                    enableSendKeys(true);
-                    isECPEnabled = true;
-                    parentPort?.postMessage({
-                        ready: true,
-                        msg: "ECP and SSDP servers initialized!\n",
-                    });
+            /** Wires up control handling and reports the server as ready. */
+            const finishStartup = (msg: string) => {
+                subscribeControl("ecp", (event: string) => {
+                    if (event === "home" || event === "poweroff") {
+                        Atomics.store(sharedArray, DataType.DBG, DebugCommand.EXIT);
+                    }
                 });
+                enableSendKeys(true);
+                isECPEnabled = true;
+                parentPort?.postMessage({ ready: true, msg });
+            };
+            if (ECPPORT === DEFAULT_ECPPORT) {
+                // Create SSDP Server
+                ssdp = new SSDP({
+                    location: {
+                        port: ECPPORT,
+                        path: "/",
+                    },
+                    adInterval: 120000,
+                    ttl: 3600,
+                    udn: `uuid:roku:ecp:${device.serialNumber}`,
+                    ssdpSig: "Roku UPnP/1.0 Roku/9.1.0",
+                    ssdpPort: SSDPPORT,
+                    suppressRootDeviceAdvertisements: true,
+                    headers: { "device-group.roku.com": "46F5CCE2472F2B14D77" },
+                });
+                ssdp.addUSN("roku:ecp");
+                ssdp._usns["roku:ecp"] = `uuid:roku:ecp:${device.serialNumber}`;
+                // Start server on all interfaces
+                ssdp.start()
+                    .catch((e: Error) => {
+                        parentPort?.postMessage({
+                            ready: false,
+                            msg: `Failed to start SSDP server:${e.message}\n`,
+                        });
+                    })
+                    .then(() => {
+                        finishStartup("ECP and SSDP servers initialized!\n");
+                    });
+            } else {
+                // Discovery announces "a Roku serves ECP at this location", but a remote-control app
+                // only looks on the standard port, so advertising a relocated server publishes an
+                // endpoint nothing will use. SSDP also binds its own fixed port (1900), which is as
+                // likely to be held as the one we moved off — the reason for moving in the first place.
+                finishStartup(`ECP server initialized on port ${ECPPORT}, SSDP discovery disabled!\n`);
+            }
             // Create ECP-2 WebSocket Server
             const wss = new WebSocketServer({ noServer: true });
             wss.on("connection", function connection(ws) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1400,11 +1400,33 @@ describe.concurrent("cli", () => {
         }, 30000);
     });
 
-    // Binds a fixed port (8060) and shares a `server` handle across tests, so these must not
-    // overlap with each other.
+    // Shares a `server` handle across tests, so these must not overlap with each other.
     describe.sequential("ECP query/r2d2-bitmaps", () => {
         const http = require("http");
+        const net = require("net");
         let server;
+        let ecpPort;
+        let url;
+
+        /**
+         * Reserves a free port by binding to 0 and releasing it.
+         *
+         * The ECP server defaults to Roku's fixed 8060, which anything else on the machine may
+         * already hold — a desktop build of the engine, another instance, a remote-control tool.
+         * These tests then fail for a reason that has nothing to do with the code, so they bind
+         * somewhere unoccupied via BRS_ECP_PORT instead.
+         */
+        function reserveFreePort() {
+            return new Promise((resolve, reject) => {
+                const probe = net.createServer();
+                probe.unref();
+                probe.on("error", reject);
+                probe.listen(0, "127.0.0.1", () => {
+                    const { port } = probe.address();
+                    probe.close(() => resolve(port));
+                });
+            });
+        }
 
         /** Performs an HTTP GET, resolving with the body once the server responds. */
         function httpGet(url) {
@@ -1451,19 +1473,26 @@ describe.concurrent("cli", () => {
             });
         }
 
-        const url = "http://localhost:8060/query/r2d2-bitmaps";
+        beforeEach(async () => {
+            ecpPort = await reserveFreePort();
+            url = `http://localhost:${ecpPort}/query/r2d2-bitmaps`;
+        });
 
         afterEach(() => {
             server?.kill("SIGKILL");
             server = undefined;
         });
 
+        /** Spawns the CLI with the ECP server bound to this test's reserved port. */
+        function spawnEcp(args) {
+            return child_process.spawn("node", [brsCliPath, ...args], {
+                cwd: path.join(__dirname, "resources"),
+                env: { ...process.env, BRS_ECP_PORT: String(ecpPort) },
+            });
+        }
+
         it("returns texture-memory data for the running app's bitmaps and fonts in debug mode", async () => {
-            server = child_process.spawn(
-                "node",
-                [brsCliPath, "-r", "r2d2-bitmaps-app", "source/main.brs", "--ecp", "--debug"],
-                { cwd: path.join(__dirname, "resources") }
-            );
+            server = spawnEcp(["-r", "r2d2-bitmaps-app", "source/main.brs", "--ecp", "--debug"]);
             const xml = await waitForEndpoint(url, (body) => body.includes("pkg:/images/alpha.png"));
 
             expect(xml).toContain("<r2d2-bitmaps>");
@@ -1485,9 +1514,7 @@ describe.concurrent("cli", () => {
         }, 30000);
 
         it("returns no bitmaps in production mode (no --debug)", async () => {
-            server = child_process.spawn("node", [brsCliPath, "-r", "r2d2-bitmaps-app", "source/main.brs", "--ecp"], {
-                cwd: path.join(__dirname, "resources"),
-            });
+            server = spawnEcp(["-r", "r2d2-bitmaps-app", "source/main.brs", "--ecp"]);
             // Wait until the app has created its bitmaps, then confirm the registry stayed empty.
             await waitForStdout(server, "R2D2 ready");
             const xml = await waitForEndpoint(url, (body) => body.includes("<status>OK</status>"));


### PR DESCRIPTION
## Summary

The ECP server's port was fixed at Roku's 8060, so it could not start at all whenever something else on the machine already held it — another instance of the engine, a desktop build, a remote-control tool. The two `query/r2d2-bitmaps` tests then failed for a reason unrelated to the code under test, which is exactly what happened while verifying #1104:

```
× ECP query/r2d2-bitmaps > returns texture-memory data ...  → ECP endpoint not ready
× ECP query/r2d2-bitmaps > returns no bitmaps in production mode  → stdout did not contain "R2D2 ready"
```

## Changes

`BRS_ECP_PORT` overrides the port. Unset or unusable values keep the Roku default, so a normal run is unchanged:

```console
$ BRS_ECP_PORT=8160 brs-cli --ecp app.zip
```

The tests **reserve a free port** (bind to 0, read it back, release) and pass it through, rather than moving to a different fixed number — that removes the shared-resource dependency instead of relocating it, and keeps parallel runs safe.

**SSDP is skipped on a non-default port.** Discovery announces "a Roku serves ECP at this location", but remote-control apps only look on 8060, so advertising a relocated server publishes an endpoint nothing can use. SSDP also binds its own fixed port (1900), which is as likely to be held as the one being moved off.

## Testing

Verified against the actual failure condition — with a desktop build still holding 8060:

- Both ECP tests pass (and complete in ~2s each instead of timing out after 20s).
- Without `BRS_ECP_PORT`, the CLI still targets 8060 and reports `EADDRINUSE`, confirming the default path is untouched.
- With `BRS_ECP_PORT=8161`, `GET /query/device-info` on 8161 returns 200.
- Full suite green (178 files); `tsc` and lint clean.

## Notes

Independent of #1104 and #1105, and worth landing first — CI for both stays vulnerable to this until it does.

Only the environment variable is exposed, not a CLI flag, since the fixed port is correct for every normal use and this is an escape hatch. Happy to add `--ecp-port` instead if you'd rather have it discoverable in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
