### PR TITLE
fix(cli): add 'sfx' to valid message types to ignore in handleStringMessage

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -773,7 +773,7 @@ function handleStringMessage(message: string) {
         writeTerminalText(chalk.gray(msg.trimEnd()) + "\n");
     } else if (mType === "end" && msg.trimEnd() !== AppExitReason.UserNav) {
         process.exitCode = 1;
-    } else if (!["start", "command", "reset", "video", "audio", "syslog", "end"].includes(mType)) {
+    } else if (!["start", "command", "reset", "video", "audio", "sfx", "syslog", "end"].includes(mType)) {
         writeTerminalText(chalk.blueBright(message.trimEnd()) + "\n");
     }
 }


### PR DESCRIPTION
The CLI ignores several message types that are not handled, but are valid messages in the interpreter, mostly related to Video and Audio playback. One message type that was missing in the list to ignore was `sfx` 