### PR TITLE
perf(font): memoize text measurement per font

### DIFF
--- a/src/core/brsTypes/components/RoFont.ts
+++ b/src/core/brsTypes/components/RoFont.ts
@@ -7,6 +7,14 @@ import { Int32 } from "../Int32";
 import { FontMetrics, getFontRegistry } from "./RoFontRegistry";
 import { BrsCanvas, BrsCanvasContext2D, MeasuredText } from "../interfaces/IfDraw2D";
 
+/**
+ * Cap on memoized measurements per font. Text is measured per *rendered string*, so an app with a
+ * clock, a counter or a scrolling label would otherwise grow this without bound. Clearing wholesale
+ * on overflow keeps the bookkeeping free — the entries a screen actually uses are re-measured once
+ * and the steady state is small.
+ */
+const MeasureCacheLimit = 4096;
+
 export class RoFont extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
     private readonly family: string;
@@ -15,6 +23,22 @@ export class RoFont extends BrsComponent implements BrsValue {
     private readonly italic: boolean;
     private readonly metrics: FontMetrics;
     private readonly canvas: BrsCanvas;
+    /**
+     * Memoized `measureTextWidth` results, keyed by the text and the constraints (this font's
+     * family/size/bold/italic are immutable, so they need no part in the key).
+     *
+     * Measuring is the single most expensive thing the text path does — a canvas `font` assignment
+     * plus `measureText`, and for an ellipsized string one `measureText` per character removed — and
+     * it is asked the same question over and over: a `LayoutGroup` lays out by running its children
+     * as *measurement* passes (`renderNode` with no draw target), and `Group.isDirty` is only cleared
+     * on a real frame draw, so every such pass re-measured every label underneath it. Appending one
+     * child re-measured the whole subtree, which made the cost of creating a node grow with the size
+     * of the tree (72 custom components: 178 ms each at the start, 386 ms each by the end; a device
+     * is flat at ~10 ms).
+     *
+     * Entries are returned as-is rather than copied, so callers must treat them as read-only.
+     */
+    private readonly measureCache = new Map<string, { width: number; text: string; ellipsized: boolean }>();
 
     // Constructor can only be used by RoFontRegistry()
     constructor(family: BrsString, size: Int32, bold: BrsBoolean, italic: BrsBoolean, metrics: FontMetrics) {
@@ -39,6 +63,13 @@ export class RoFont extends BrsComponent implements BrsValue {
         if (text === "") {
             // node-canvas crashes on empty-string text APIs; measuring "" is always width 0
             return { width: 0, text, ellipsized: false };
+        }
+        // The key separates its parts with an escaped NUL, which cannot appear in a rendered
+        // string, so no combination of width, ellipsis and text can collide with another.
+        const cacheKey = `${maxWidth ?? -1}\u0000${ellipsis ?? ""}\u0000${text}`;
+        const cached = this.measureCache.get(cacheKey);
+        if (cached) {
+            return cached;
         }
         const ctx = this.canvas.getContext("2d", { alpha: false }) as BrsCanvasContext2D;
         ctx.font = this.toFontString();
@@ -67,7 +98,12 @@ export class RoFont extends BrsComponent implements BrsValue {
             ellipsized = true;
         }
 
-        return { width: Math.round(length), text: ellipsizedText, ellipsized };
+        const measured = { width: Math.round(length), text: ellipsizedText, ellipsized };
+        if (this.measureCache.size >= MeasureCacheLimit) {
+            this.measureCache.clear();
+        }
+        this.measureCache.set(cacheKey, measured);
+        return measured;
     }
 
     measureText(text: string, maxWidth?: number, ellipsis?: string): MeasuredText {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -201,6 +201,28 @@ describe.concurrent("cli", () => {
         ]);
     }, 30000);
 
+    it("Keeps memoized text measurements distinct per text, width and font", async () => {
+        // Measuring is memoized per font because a LayoutGroup re-measures its children on every
+        // layout pass (it lays out by rendering them with no draw target), which made the cost of
+        // adding a node grow with the size of the tree. The cache key has to keep every input
+        // apart, or labels would render at another string's width.
+        let command = ["node", brsCliPath, "fontMeasureCache.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "stable: true",
+            "clamped: true",
+            "unclamped: true",
+            "font isolated: true",
+            "text isolated: true",
+            "------ Finished 'fontMeasureCache.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     it("Renders frames as terminal images with --image", async () => {
         let command = ["node", brsCliPath, "emptyTextDraw.brs", "-i", "-c 0"].join(" ");
         let { stdout } = await exec(command, {

--- a/test/cli/resources/fontMeasureCache.brs
+++ b/test/cli/resources/fontMeasureCache.brs
@@ -1,0 +1,23 @@
+sub main()
+    ' Text measurement is memoized per font (see RoFont.measureCache) because a LayoutGroup lays
+    ' out by re-measuring its children on every pass. The cache key must keep every input apart:
+    ' text, maxWidth and the font itself.
+    screen = CreateObject("roScreen", true, 854, 480)
+    reg = CreateObject("roFontRegistry")
+    font = reg.GetDefaultFont(40, false, false)
+    bigFont = reg.GetDefaultFont(80, false, false)
+    text = "measure me twice"
+
+    full = font.GetOneLineWidth(text, 854)
+    print "stable: "; font.GetOneLineWidth(text, 854) = full
+    ' A tighter maxWidth clamps the reported width; the wide measurement must not answer for it.
+    print "clamped: "; font.GetOneLineWidth(text, 20) = 20
+    ' ...and asking again with the original constraint still reports the full width.
+    print "unclamped: "; font.GetOneLineWidth(text, 854) = full
+    ' Each font instance has its own cache, so a larger size is not served the smaller result.
+    print "font isolated: "; bigFont.GetOneLineWidth(text, 2000) > font.GetOneLineWidth(text, 2000)
+    ' Different strings under identical constraints stay distinct.
+    print "text isolated: "; font.GetOneLineWidth("iii", 854) <> font.GetOneLineWidth("WWW", 854)
+    screen.SwapBuffers()
+    end
+end sub


### PR DESCRIPTION
Building a screen of 72 custom components took **23.2 s** in the engine. The same screen on a Roku device takes **1.2 s**. Instrumenting both sides showed two different problems: the engine is ~20x slower per component, and — unlike the device — its per-component cost *grows with the size of the tree*.

Measured with app-level `roTimespan` instrumentation, same app, same screen:

| | device | before | after |
| --- | --- | --- | --- |
| per component, first tab → last tab | 9.8 → 9.6 ms (**flat**) | 178 → 386 ms | **92 → 179 ms** |
| full screen build | 1175 ms | 23187 ms | **11948 ms** |

## Where it goes

`node --cpu-prof` on the app worker, 27.3 s sampled:

```
10.62s  38.9%  measureTextWidth  ← measureText ← drawText ← renderLabel ← renderNode
 4.62s  16.9%  (garbage collector)
```

Every call re-assigned the canvas `font` shorthand and re-ran `measureText`, and for an ellipsized string it runs one `measureText` per character removed.

It is asked the same question over and over. A `LayoutGroup` lays out by running its children as **measurement** passes (`renderNode` with no draw target), and `Group.isDirty` — which gates the per-label line cache in `Group.drawText` — is only cleared on a real frame draw (`nodeRenderingDone`'s `if (draw2D)`). A node under a LayoutGroup is therefore permanently dirty as far as that cache is concerned, so appending one child re-measures every label already in the subtree. That is the growth.

## Change

`RoFont` memoizes `measureTextWidth`, keyed by text + `maxWidth` + `ellipsis`. The font's family/size/bold/italic are immutable per instance, so they need no part in the key. Entries are capped at 4096 per font and the map is cleared wholesale on overflow, so a clock, counter or scrolling label cannot grow it without bound; the entries a screen actually uses are re-measured once and the steady state is small.

Cached entries are returned as-is rather than copied — callers must treat them as read-only, which the existing ones do (`measureText` builds its own object; everyone else reads properties).

## What this does *not* fix

The redundant measurement passes themselves. Per-component cost still grows with tree size, and the remaining profile is GC (29%) plus the field reads those passes perform (`renderLabel` calls `getValueJS` ~10x per label). Against the device's flat ~10 ms there is roughly another 10x to reclaim, but it needs the layout pass to skip subtrees unchanged since their last measurement — a "measured clean" notion distinct from the draw-clean `isDirty`. That is a larger change in an area with several prior fixes it must not regress (`HiddenMeasure`, `MidRenderParentMeasure`, `ListMeasureStability`, the `getBoundingRect` re-entrancy guard), so it belongs in its own PR.

An input-keyed line cache in `Group.drawText`, replacing the `isDirty` gate, was also tried: it measured no further gain once this cache was in place (12.19 s vs 12.11 s) and added a string build per call, so it is not included.

## Tests

`fontMeasureCache.brs` asserts the cache key keeps text, `maxWidth` and font apart, and that repeated measurement is stable — a wrong key would render labels at another string's width. Full suite green (2275 passed); `lint` and `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
