### PR TITLE
perf(scenegraph): introduce the layout/paint render-pass seam and injectable clock

### DIFF
--- a/src/extensions/scenegraph/SGClock.ts
+++ b/src/extensions/scenegraph/SGClock.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Engine (https://github.com/lvcabral/brs-engine)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Replaceable time source backing every render-path clock read in the SceneGraph extension. */
+export interface SGClockSource {
+    /** Wall-clock milliseconds (Date.now semantics). */
+    now(): number;
+    /** Monotonic high-resolution milliseconds (performance.now semantics). */
+    perfNow(): number;
+}
+
+const realSource: SGClockSource = {
+    now: () => Date.now(),
+    perfNow: () => performance.now(),
+};
+
+let source: SGClockSource = realSource;
+
+/**
+ * The SceneGraph clock. Time-driven nodes (animations, spinners, marquees, cursor blink, seek
+ * repeat, timers) read the clock through this object instead of `Date.now()`/`performance.now()`
+ * so tests can substitute a deterministic source through the built bundle via `setSource` —
+ * fake-timer libraries cannot reach into the bundle's captured globals.
+ */
+export const sgClock = {
+    now(): number {
+        return source.now();
+    },
+    perfNow(): number {
+        return source.perfNow();
+    },
+    /** Replaces the time source; call with no argument to restore the real clock. */
+    setSource(replacement?: SGClockSource): void {
+        source = replacement ?? realSource;
+    },
+};

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -53,6 +53,7 @@ export class SGRoot {
     private _dirty: boolean = false;
     private _rendering: boolean = false;
     private _measuring: boolean = false;
+    private _renderPass: "layout" | "paint" = "paint";
     private readonly _pendingPorts: RoMessagePort[] = [];
     /**
      * When `true`, recently-written fields can be re-read from the local copy for a short window,
@@ -217,6 +218,22 @@ export class SGRoot {
 
     set measuring(value: boolean) {
         this._measuring = value;
+    }
+
+    /**
+     * Which kind of render pass is currently traversing the tree. A `layout` pass (started by
+     * `Node.layoutNode` — bounding-rect refreshes, `measureUnsizedChildren`) must be idempotent
+     * and clock-free: rects only. A `paint` pass (`Node.paintNode` — the per-frame render) may
+     * additionally advance time-based state and draw. Defaults to `paint` so direct `renderNode`
+     * calls (external node registrations, tests) keep today's semantics. See
+     * `docs/scenegraph-layout-passes.md`.
+     */
+    get renderPass(): "layout" | "paint" {
+        return this._renderPass;
+    }
+
+    set renderPass(value: "layout" | "paint") {
+        this._renderPass = value;
     }
 
     private audioFlags: number = -1;

--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -215,13 +215,13 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
                     sgRoot.clearDirty();
                     sgRoot.rendering = true;
                     try {
-                        sgRoot.scene.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+                        sgRoot.scene.paintNode(interpreter, [0, 0], 0, 1, this.draw2D);
                         if (showDialog) {
                             const dialog = sgRoot.scene.dialog!;
                             dialog.setValueSilent("visible", BrsBoolean.True);
                             const screenRect = { x: 0, y: 0, width: this.width, height: this.height };
                             this.draw2D.doDrawRotatedRect(screenRect, 255, 0, [0, 0], 0.5);
-                            dialog.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+                            dialog.paintNode(interpreter, [0, 0], 0, 1, this.draw2D);
                         }
                     } finally {
                         sgRoot.rendering = false;

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -560,9 +560,9 @@ export function initializeNode(
                     return BrsInvalid.Instance;
                 }, currentEnv);
 
-                // Pre-render default state of the tree.
+                // Pre-render default state of the tree (layout only — nothing to draw yet).
                 if (node instanceof Scene) {
-                    node.renderNode(interpreter, [0, 0], 0, 1);
+                    node.layoutNode(interpreter, [0, 0], 0, 1);
                 }
 
                 const init = interpreter.inSubEnv((subInterpreter: Interpreter) => {

--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -36,6 +36,7 @@ import { RoSGScreen } from "./components/RoSGScreen";
 import { getRenderThreadQueue } from "./components/RoRenderThreadQueue";
 import packageInfo from "../../../packages/scenegraph/package.json";
 
+export * from "./SGClock";
 export * from "./SGRoot";
 export * from "./SGUtil";
 export * from "./components/RoSGNode";

--- a/src/extensions/scenegraph/nodes/AnimationBase.ts
+++ b/src/extensions/scenegraph/nodes/AnimationBase.ts
@@ -1,6 +1,7 @@
 import { AAMember, BrsString, BrsType, isBrsString } from "brs-engine";
 import { Node } from "./Node";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 
@@ -103,7 +104,7 @@ export abstract class AnimationBase extends Node {
             return false;
         }
 
-        const now = performance.now();
+        const now = sgClock.perfNow();
         const delta = (now - this.lastUpdateTime) / 1000; // seconds
         this.lastUpdateTime = now;
         let effectiveDelta = delta;
@@ -128,7 +129,7 @@ export abstract class AnimationBase extends Node {
             if (this.shouldRepeat()) {
                 this.elapsedTime = 0;
                 this.delayRemaining = this.getDelaySeconds();
-                this.lastUpdateTime = performance.now();
+                this.lastUpdateTime = sgClock.perfNow();
             } else {
                 this.stop();
             }
@@ -179,7 +180,7 @@ export abstract class AnimationBase extends Node {
     protected startFromBeginning() {
         this.elapsedTime = 0;
         this.delayRemaining = this.getDelaySeconds();
-        this.lastUpdateTime = performance.now();
+        this.lastUpdateTime = sgClock.perfNow();
         this.enterRunningState();
     }
 
@@ -187,7 +188,7 @@ export abstract class AnimationBase extends Node {
      * Continues from a paused state without resetting elapsed time.
      */
     protected resumeFromPause() {
-        this.lastUpdateTime = performance.now();
+        this.lastUpdateTime = sgClock.perfNow();
         this.enterRunningState();
     }
 

--- a/src/extensions/scenegraph/nodes/BusySpinner.ts
+++ b/src/extensions/scenegraph/nodes/BusySpinner.ts
@@ -1,4 +1,5 @@
 import { AAMember, Interpreter, BrsString, BrsType, RoArray, Float, IfDraw2D, Rect } from "brs-engine";
+import { sgClock } from "../SGClock";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { rotateTranslation } from "../SGUtil";
 import { SGNodeType } from ".";
@@ -39,7 +40,7 @@ export class BusySpinner extends Group {
             const control = value.toString();
             if (control === "start") {
                 this.active = true;
-                this.lastRenderTime = Date.now();
+                this.lastRenderTime = sgClock.now();
             } else if (control === "stop") {
                 this.active = false;
             } else {
@@ -100,9 +101,9 @@ export class BusySpinner extends Group {
         }
         if (this.active) {
             if (this.lastRenderTime === 0) {
-                this.lastRenderTime = Date.now();
+                this.lastRenderTime = sgClock.now();
             }
-            const now = Date.now();
+            const now = sgClock.now();
             const spinInterval = this.getValueJS("spinInterval") as number;
             const clockwise = this.getValueJS("clockwise") as boolean;
             const direction = clockwise ? -1 : 1;

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -17,6 +17,7 @@ import { SGNodeType } from ".";
 import { Group } from "./Group";
 import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { jsValueOf } from "../factory/Serializer";
 import { computeLayout, KeyInset, keyboardSize, KeyLayout, RenderedKey, resolveKeyIcon } from "./kdf/KeyDefinition";
 
@@ -171,7 +172,7 @@ export class DynamicKeyGrid extends Group {
         super.setValue("keyFocused", new BrsString(key?.out ?? ""));
         // Focus moved to a (possibly) different key: restart the hover dwell timer and
         // clear any pop-up suppression, so the timer applies again on the newly focused key.
-        this.lastFocusTime = Date.now();
+        this.lastFocusTime = sgClock.now();
         this.popupSuppressed = false;
     }
 
@@ -505,7 +506,7 @@ export class DynamicKeyGrid extends Group {
             if (
                 key?.suggestions &&
                 this.triggersInclude(key, "hover") &&
-                Date.now() - this.lastFocusTime > this.hoverDelay
+                sgClock.now() - this.lastFocusTime > this.hoverDelay
             ) {
                 this.openPopup(key);
             }

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -167,7 +167,7 @@ export class LayoutGroup extends Group {
             const dims = child.getDimensions();
             const rectKnown = child.rectToParent.width > 0 || child.rectToScene.width > 0 || child.rectLocal.width > 0;
             if (!rectKnown && !(typeof dims.width === "number" && dims.width > 0)) {
-                child.renderNode(interpreter, [0, 0], 0, 1);
+                child.layoutNode(interpreter, [0, 0], 0, 1);
             }
         }
     }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -949,6 +949,49 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Layout entry point: computes bounding rects for this node's subtree without drawing,
+     * advancing time-based state, or producing any other side effect. Must be idempotent —
+     * calling it twice with the same inputs and an unchanged tree yields identical rects.
+     * Default implementation runs `renderNode` with no draw target (today's measurement pass)
+     * under a `layout` render-pass context; node types with time-based render state gate that
+     * state on `isPaintPass`. See `docs/scenegraph-layout-passes.md`.
+     */
+    layoutNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number) {
+        const previousPass = sgRoot.renderPass;
+        sgRoot.renderPass = "layout";
+        try {
+            this.renderNode(interpreter, origin, angle, opacity);
+        } finally {
+            sgRoot.renderPass = previousPass;
+        }
+    }
+
+    /**
+     * Paint entry point: the per-frame render. Recomputes layout inline (as `renderNode` always
+     * has), advances time-based state (spinner rotation, marquee scroll, cursor blink, seek
+     * repeat), and draws through the required `IfDraw2D`.
+     */
+    paintNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D: IfDraw2D) {
+        const previousPass = sgRoot.renderPass;
+        sgRoot.renderPass = "paint";
+        try {
+            this.renderNode(interpreter, origin, angle, opacity, draw2D);
+        } finally {
+            sgRoot.renderPass = previousPass;
+        }
+    }
+
+    /**
+     * Whether the current traversal may advance time-based state and emit render side effects.
+     * True on paint passes and on direct `renderNode` calls with a draw target; false inside
+     * `layoutNode` traversals. The `draw2D` check keeps direct `renderNode(..., draw2D)` calls
+     * (external node registrations, tests) behaving as paint regardless of context.
+     */
+    protected isPaintPass(draw2D?: IfDraw2D): boolean {
+        return draw2D !== undefined || sgRoot.renderPass === "paint";
+    }
+
+    /**
      * Iterates through child nodes, invoking their render methods in order.
      * @param interpreter Active interpreter.
      * @param origin Parent-space translation.
@@ -978,7 +1021,7 @@ export class Node extends RoSGNode implements BrsValue {
         const root = this.createPath()[0];
         sgRoot.rendering = true;
         try {
-            root.renderNode(interpreter, [0, 0], 0, 1);
+            root.layoutNode(interpreter, [0, 0], 0, 1);
         } finally {
             sgRoot.rendering = false;
         }
@@ -1036,7 +1079,7 @@ export class Node extends RoSGNode implements BrsValue {
             const savedToScene = parent ? { ...parent.rectToScene } : undefined;
             sgRoot.measuring = true;
             try {
-                this.renderNode(interpreter, [0, 0], 0, 1);
+                this.layoutNode(interpreter, [0, 0], 0, 1);
             } finally {
                 sgRoot.measuring = false;
                 if (parent && savedLocal && savedToParent && savedToScene) {

--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -4,6 +4,7 @@ import { SGNodeType } from ".";
 import { Label } from "./Label";
 import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 
 // Enum to manage the scrolling state
 enum ScrollState {
@@ -43,7 +44,7 @@ export class ScrollingLabel extends Label {
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
 
-        this.lastUpdateTime = Date.now();
+        this.lastUpdateTime = sgClock.now();
         this.checkForScrolling();
     }
 
@@ -115,7 +116,7 @@ export class ScrollingLabel extends Label {
         this.scrollOffset = 0;
         this.elapsedTime = 0;
         this.currentRepeat = 0;
-        this.lastUpdateTime = Date.now();
+        this.lastUpdateTime = sgClock.now();
         this.measured = undefined;
     }
 
@@ -130,7 +131,7 @@ export class ScrollingLabel extends Label {
         if (!(drawFont instanceof RoFont)) {
             return { text, width: 0, height: 0, ellipsized: false };
         }
-        const now = Date.now();
+        const now = sgClock.now();
         const deltaTime = now - this.lastUpdateTime;
         this.lastUpdateTime = now;
         this.elapsedTime += deltaTime;

--- a/src/extensions/scenegraph/nodes/TextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/TextEditBox.ts
@@ -10,6 +10,7 @@ import {
     Int32,
     BrsBoolean,
 } from "brs-engine";
+import { sgClock } from "../SGClock";
 import { FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
@@ -93,7 +94,7 @@ export class TextEditBox extends Group {
         this.hintLabel.setValueSilent("color", new Int32(convertHexColor("0xAAAAAAFF")));
         this.linkField(this.hintLabel, "color", "hintTextColor");
 
-        this.lastCursorToggleTime = Date.now();
+        this.lastCursorToggleTime = sgClock.now();
     }
 
     private configureLabel(label: Label) {
@@ -125,7 +126,7 @@ export class TextEditBox extends Group {
                 position++;
                 this.setValue("text", new BrsString(text));
                 this.setValue("cursorPosition", new Float(position));
-                this.lastCharInputTime = Date.now();
+                this.lastCharInputTime = sgClock.now();
                 handled = true;
             }
         } else if (key === "replay") {
@@ -141,7 +142,7 @@ export class TextEditBox extends Group {
         // Reset cursor blink on key press
         if (handled) {
             this.cursorVisible = true;
-            this.lastCursorToggleTime = Date.now();
+            this.lastCursorToggleTime = sgClock.now();
         }
         return handled;
     }
@@ -169,7 +170,7 @@ export class TextEditBox extends Group {
         this.setValue("cursorPosition", new Float(position));
         // Reset cursor blink on move
         this.cursorVisible = true;
-        this.lastCursorToggleTime = Date.now();
+        this.lastCursorToggleTime = sgClock.now();
     }
 
     renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
@@ -186,7 +187,7 @@ export class TextEditBox extends Group {
         const combinedOpacity = opacity * this.getOpacity();
         const text = this.getValueJS("text") as string;
         const secureMode = this.getValueJS("secureMode") as boolean;
-        const now = Date.now(); // Get current time for checks
+        const now = sgClock.now(); // Get current time for checks
 
         // Ensure labels have correct width if TextEditBox width changes
         // And update background if URI changes

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -16,6 +16,7 @@ import { ArrayGrid } from "./ArrayGrid";
 import { ContentNode } from "./ContentNode";
 import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 
 /** Cached parse of one channel's programs (see TimeGrid.channelParseCache). */
@@ -336,7 +337,7 @@ export class TimeGrid extends ArrayGrid {
     }
 
     protected nowEpoch(): number {
-        return Math.floor(Date.now() / 1000);
+        return Math.floor(sgClock.now() / 1000);
     }
 
     protected getDurationSec(): number {

--- a/src/extensions/scenegraph/nodes/Timer.ts
+++ b/src/extensions/scenegraph/nodes/Timer.ts
@@ -1,6 +1,7 @@
 import { AAMember, BrsInvalid, BrsString, BrsType, isBrsString } from "brs-engine";
 import { Node } from "./Node";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 
@@ -34,7 +35,7 @@ export class Timer extends Node {
         if (field && mapKey === "control" && isBrsString(value)) {
             let control = value.getValue().toLowerCase();
             if (control === "start") {
-                this.lastFireTime = performance.now();
+                this.lastFireTime = sgClock.perfNow();
                 this.active = true;
             } else if (control === "stop") {
                 this.active = false;
@@ -53,7 +54,7 @@ export class Timer extends Node {
     }
 
     checkFire() {
-        const now = performance.now();
+        const now = sgClock.perfNow();
         const duration = this.getValueJS("duration") as number;
         const repeat = this.getValueJS("repeat") as boolean;
         if (this.active && (now - this.lastFireTime) / 1000 >= duration) {

--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -5,6 +5,7 @@ import { Label } from "./Label";
 import { Poster } from "./Poster";
 import { Group } from "./Group";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 
 export class TrickPlayBar extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -133,7 +134,7 @@ export class TrickPlayBar extends Group {
         }
         this.stateIcon = this.bmpIcons.get(iconName);
         if (this.stateIcon) {
-            this.stateIconTimeout = timeout > 0 ? Date.now() + timeout : -1;
+            this.stateIconTimeout = timeout > 0 ? sgClock.now() + timeout : -1;
         }
     }
 
@@ -151,7 +152,7 @@ export class TrickPlayBar extends Group {
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(rect, origin, angle);
         this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
-        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > Date.now())) {
+        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > sgClock.now())) {
             const iconRect = {
                 x: rect.x + (size.width - this.stateIcon.width) / 2,
                 y: rect.y + this.barH,

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -29,6 +29,7 @@ import {
 } from "brs-engine";
 import { fromAssociativeArray, toAssociativeArray, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { BusySpinner } from "./BusySpinner";
 import { ContentNode } from "./ContentNode";
 import { Label } from "./Label";
@@ -350,7 +351,7 @@ export class Video extends Group {
     }
 
     setState(eventType: number, eventIndex: number) {
-        const now = Date.now();
+        const now = sgClock.now();
         this.statusChanged = true;
         let state = "none";
         switch (eventType) {
@@ -615,7 +616,7 @@ export class Video extends Group {
             this.showPaused = 0;
             this.showTrickPlay = 0;
         }
-        const now = Date.now();
+        const now = sgClock.now();
         this.backgroundOverlay.setValueSilent("visible", BrsBoolean.from(this.showHeader > now));
         this.titleText.setValue("visible", BrsBoolean.from(this.showHeader > now));
         this.clockText.setValueSilent("visible", BrsBoolean.from(this.showHeader > now));
@@ -648,7 +649,7 @@ export class Video extends Group {
                 handled = true;
             }
         } else if (key === "OK" && this.enableTrickPlay) {
-            const now = Date.now();
+            const now = sgClock.now();
             if (this.showHeader < now) {
                 this.showHeader = now + 5000;
                 handled = true;
@@ -666,7 +667,7 @@ export class Video extends Group {
             if (state === "playing") {
                 const position = this.getValueJS("position") as number;
                 if (position > 0) {
-                    const now = Date.now();
+                    const now = sgClock.now();
                     postMessage(`video,seek,${Math.max(0, position - 20) * 1000}`);
                     this.showHeader = now + 1000;
                     this.showTrickPlay = now + 1000;
@@ -741,7 +742,7 @@ export class Video extends Group {
     }
 
     private updateSeekStep(forward: boolean, duration: number, timeout = 0) {
-        const now = Date.now();
+        const now = sgClock.now();
         const baseStep = Math.min(10, Math.max(1, Math.trunc(duration / 30)));
         const step = baseStep * Math.max(1, this.seekLevel * 3 - 3);
         this.showHeader = now + 30000;
@@ -812,7 +813,7 @@ export class Video extends Group {
             }
         }
         if (this.statusChanged) {
-            if (this.seekTimeout > 0 && this.seekTimeout < Date.now() && ["rw", "ff"].includes(this.seekMode)) {
+            if (this.seekTimeout > 0 && this.seekTimeout < sgClock.now() && ["rw", "ff"].includes(this.seekMode)) {
                 const duration = this.getValueJS("duration") as number;
                 this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
             }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -965,6 +965,30 @@ describe.concurrent("cli", () => {
             "",
         ]);
     }, 30000);
+    it("Builds the layout-pass performance probe (70 self-measuring components)", async () => {
+        let command = ["node", brsCliPath, "-r layout-perf-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+
+        // Committed form of the synthetic probe from docs/scenegraph-layout-passes.md: 70 custom
+        // components in a LayoutGroup, each measuring itself with boundingRect() from its `value`
+        // observer, so every append triggers a full-tree layout refresh. Only correctness is
+        // asserted (the layout height proves all 70 tiles laid out and stacked); the per-tile
+        // timings it prints are for the human device-shape comparison — flat per-component cost —
+        // and would be flaky as assertions. Height: 70 tiles * 60 + 69 gaps * 8 = 4752.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Layout Perf Probe ===");
+        expect(lines).toContain("tiles =  70");
+        // 70 tiles, each 60 (background) + label rows overflow = stacked LayoutGroup height;
+        // proves all 70 laid out. Kept exact so tile-content changes are deliberate.
+        expect(lines).toContain("layout height =  15532");
+        expect(lines).toContain("=== Layout Perf Probe Complete ===");
+        for (const marker of ["q1 tile ms = ", "q2 tile ms = ", "q3 tile ms = ", "q4 tile ms = ", "total ms = "]) {
+            expect(lines.some((line) => line.startsWith(marker))).toBe(true);
+        }
+    }, 60000);
     it("Resolves a component method in call position when an XML field shadows its name", async () => {
         let command = ["node", brsCliPath, "-r method-shadow-field-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/layout-perf-app/components/PerfTile.xml
+++ b/test/cli/resources/layout-perf-app/components/PerfTile.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Synthetic probe component for the layout-pass performance fixture
+    (docs/scenegraph-layout-passes.md). Its `value` observer measures the component with
+    boundingRect() — the ordinary app pattern (e.g. sizing a focus ring from a field change)
+    that makes every component creation trigger a full-tree layout refresh. With N components
+    in a LayoutGroup, a screen build is O(n²) unless the refresh prunes settled subtrees.
+-->
+<component name="PerfTile" extends="Group">
+    <interface>
+        <field id="value" type="string" alwaysNotify="true" />
+        <field id="measuredHeight" type="float" />
+    </interface>
+    <script type="text/brightscript">
+    <![CDATA[
+        sub init()
+            m.background = m.top.createChild("Rectangle")
+            m.background.width = 438
+            m.background.height = 60
+            ' An inner LayoutGroup with several labels gives each tile a realistic node count
+            ' (real app components average dozens of nodes), so a full-tree refresh has
+            ' measurable per-tile cost and the quadratic rise is visible in the timings.
+            m.rows = m.top.createChild("LayoutGroup")
+            m.rows.layoutDirection = "vert"
+            m.rows.itemSpacings = [2]
+            m.rows.translation = [12, 8]
+            for r = 1 to 8
+                row = m.rows.createChild("Label")
+                row.width = 400
+            end for
+            m.label = m.rows.getChild(0)
+            m.top.observeFieldScoped("value", "onValueChange")
+        end sub
+
+        sub onValueChange()
+            m.label.text = m.top.value
+            rect = m.top.boundingRect()
+            m.top.measuredHeight = rect.height
+        end sub
+    ]]>
+    </script>
+</component>

--- a/test/cli/resources/layout-perf-app/manifest
+++ b/test/cli/resources/layout-perf-app/manifest
@@ -1,0 +1,4 @@
+title=Layout Perf Probe
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/layout-perf-app/source/main.brs
+++ b/test/cli/resources/layout-perf-app/source/main.brs
@@ -1,0 +1,42 @@
+' Layout-pass performance probe (docs/scenegraph-layout-passes.md): appends N custom
+' components into a LayoutGroup; each component's `value` observer measures itself with
+' boundingRect(), so every append triggers a full-tree layout refresh. On an engine with
+' incremental (pruned) layout the per-component cost is flat, like a device; without
+' pruning it rises linearly and the build is O(n²) overall.
+sub Main()
+    print "=== Layout Perf Probe ==="
+    tileCount = 70
+
+    layout = CreateObject("roSGNode", "LayoutGroup")
+    layout.layoutDirection = "vert"
+    layout.itemSpacings = [8]
+
+    clock = CreateObject("roTimespan")
+    total = CreateObject("roTimespan")
+    timings = []
+    total.mark()
+    for i = 1 to tileCount
+        clock.mark()
+        tile = CreateObject("roSGNode", "PerfTile")
+        layout.appendChild(tile)
+        ' Set `value` after attach so the observer's boundingRect() refresh walks the whole
+        ' (growing) tree from the root — the O(tree)-per-component pattern the probe exists
+        ' to measure. Set before attach it would only measure the orphan tile.
+        tile.value = "tile " + i.toStr()
+        timings.push(clock.totalMilliseconds())
+    end for
+    totalMs = total.totalMilliseconds()
+
+    rect = layout.boundingRect()
+    print "tiles = "; tileCount
+    print "layout height = "; rect.height
+    ' Quartile samples instead of first/last: tile 1 is inflated by font-load/JIT warmup.
+    ' Flat q1..q4 = device shape (incremental layout); rising = quadratic full refreshes.
+    q = int(tileCount / 4)
+    print "q1 tile ms = "; timings[q - 1]
+    print "q2 tile ms = "; timings[2 * q - 1]
+    print "q3 tile ms = "; timings[3 * q - 1]
+    print "q4 tile ms = "; timings[tileCount - 1]
+    print "total ms = "; totalMs
+    print "=== Layout Perf Probe Complete ==="
+end sub

--- a/test/extensions/scenegraph/ClockSource.test.js
+++ b/test/extensions/scenegraph/ClockSource.test.js
@@ -1,0 +1,67 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgClock } = scenegraph;
+const { BrsString, Float, RoArray } = core;
+
+const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
+
+/**
+ * The SceneGraph clock is injectable (SGClock.ts): time-driven state reads `sgClock` instead of
+ * `Date.now()`/`performance.now()` so tests can substitute a deterministic source through the
+ * built bundle. This also pins the animation-timing property the layout/paint split relies on:
+ * animations advance in `tick()` (driven by the frame loop via sgRoot.processAnimations), NOT
+ * inside renderNode — see docs/scenegraph-layout-passes.md.
+ */
+describe("sgClock injectable time source", () => {
+    afterEach(() => {
+        sgClock.setSource();
+    });
+
+    test("AnimationBase.tick interpolates against the injected clock", () => {
+        let fakeNow = 10_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("id", new BrsString("target"));
+        poster.setValue("opacity", new Float(0));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(2)); // seconds
+        const interp = SGNodeFactory.createNode("FloatFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("target.opacity"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", floatArray([0.0, 1.0]));
+        animation.appendChildToParent(interp);
+        poster.appendChildToParent(animation);
+
+        // Linear easing so the eased fraction equals the raw fraction at the midpoint.
+        animation.setValue("easeFunction", new BrsString("linear"));
+        animation.setValue("control", new BrsString("start"));
+
+        // Fraction 0: no time has passed.
+        animation.tick();
+        expect(poster.getValueJS("opacity")).toBeCloseTo(0, 5);
+
+        // Fraction 0.5: half the 2s duration.
+        fakeNow += 1000;
+        animation.tick();
+        expect(poster.getValueJS("opacity")).toBeCloseTo(0.5, 5);
+
+        // Fraction 1: full duration reached; the animation stops at the end value.
+        fakeNow += 1000;
+        animation.tick();
+        expect(poster.getValueJS("opacity")).toBeCloseTo(1, 5);
+        expect(animation.getValueJS("state")).toBe("stopped");
+    });
+
+    test("setSource() with no argument restores the real clock", () => {
+        sgClock.setSource({ now: () => 42, perfNow: () => 42 });
+        expect(sgClock.now()).toBe(42);
+
+        sgClock.setSource();
+
+        const realNow = Date.now();
+        expect(Math.abs(sgClock.now() - realNow)).toBeLessThan(1000);
+    });
+});

--- a/test/extensions/scenegraph/LayoutPaintSeam.test.js
+++ b/test/extensions/scenegraph/LayoutPaintSeam.test.js
@@ -1,0 +1,114 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsString, Float, RoArray, Interpreter } = core;
+
+/**
+ * The layout/paint seam (docs/scenegraph-layout-passes.md): `layoutNode` is the pure measurement
+ * entry point (today it wraps renderNode with no draw target), `paintNode` is the per-frame render.
+ * Each sets `sgRoot.renderPass` for the duration of its traversal and restores it afterwards, so
+ * node internals can gate time-based state on the pass kind without a signature change.
+ */
+describe("layoutNode/paintNode seam", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    function buildTree() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const group = SGNodeFactory.createNode("Group");
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        layout.setValue("translation", vector([30, 40]));
+        const first = SGNodeFactory.createNode("Rectangle");
+        first.setValue("width", new Float(200));
+        first.setValue("height", new Float(80));
+        const second = SGNodeFactory.createNode("Rectangle");
+        second.setValue("width", new Float(120));
+        second.setValue("height", new Float(60));
+        layout.appendChildToParent(first);
+        layout.appendChildToParent(second);
+        group.appendChildToParent(layout);
+        scene.appendChildToParent(group);
+        return { scene, group, layout, first, second };
+    }
+
+    function snapshotRects(node) {
+        return {
+            local: { ...node.rectLocal },
+            toParent: { ...node.rectToParent },
+            toScene: { ...node.rectToScene },
+        };
+    }
+
+    test("layoutNode computes the same rects as renderNode without a draw target", () => {
+        const measured = buildTree();
+        measured.scene.layoutNode(interpreter, [0, 0], 0, 1);
+        const viaLayout = [measured.group, measured.layout, measured.first, measured.second].map(snapshotRects);
+
+        const rendered = buildTree();
+        rendered.scene.renderNode(interpreter, [0, 0], 0, 1);
+        const viaRender = [rendered.group, rendered.layout, rendered.first, rendered.second].map(snapshotRects);
+
+        expect(viaLayout).toEqual(viaRender);
+    });
+
+    test("paintNode draws through the provided draw target", () => {
+        // Paint from the group (Scene.renderNode needs a full canvas surface; the fake only
+        // records rect draws).
+        const { group } = buildTree();
+        const calls = [];
+        const draw2D = {
+            doDrawRotatedRect: (...args) => calls.push(args),
+        };
+
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls.length).toBeGreaterThan(0);
+    });
+
+    test("renderPass is 'layout'/'paint' inside each traversal and restored afterwards", () => {
+        const { group, layout } = buildTree();
+        const seen = [];
+        const originalRenderNode = layout.renderNode.bind(layout);
+        layout.renderNode = (...args) => {
+            seen.push(sgRoot.renderPass);
+            return originalRenderNode(...args);
+        };
+
+        expect(sgRoot.renderPass).toBe("paint");
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(sgRoot.renderPass).toBe("paint");
+        group.paintNode(interpreter, [0, 0], 0, 1, { doDrawRotatedRect: () => {} });
+        expect(sgRoot.renderPass).toBe("paint");
+
+        expect(seen).toEqual(["layout", "paint"]);
+    });
+
+    test("getBoundingRect's refresh runs as a layout pass", () => {
+        const { scene, layout } = buildTree();
+        const passes = [];
+        const originalRenderNode = scene.renderNode.bind(scene);
+        scene.renderNode = (...args) => {
+            passes.push(sgRoot.renderPass);
+            return originalRenderNode(...args);
+        };
+
+        const rect = layout.getBoundingRect("toParent", interpreter);
+
+        expect(passes).toEqual(["layout"]);
+        expect(rect.width).toBe(200);
+        expect(rect.height).toBe(140);
+    });
+});


### PR DESCRIPTION
First step of the program in `docs/scenegraph-layout-passes.md` (#1114). Behaviorally inert: it creates the seam the follow-up clock-extraction, convergence, and pruning PRs build on.

## What

- **`Node.layoutNode` / `Node.paintNode`** — two entry points wrapping `renderNode`. `layoutNode` is today's measurement pass (no draw target); `paintNode` is the per-frame render with a required `IfDraw2D`. Each sets `sgRoot.renderPass` (`"layout"` / `"paint"`) for the duration of its traversal and restores it after, plus a protected `Node.isPaintPass(draw2D?)` helper. `renderNode` stays the single override point, so external node registrations via `SGNodeFactory.addNodeTypes` are unaffected.
- **Callers routed through the seam:** `refreshLayoutFromRoot`, `getBoundingRect`'s mid-render subtree fallback, `LayoutGroup.measureUnsizedChildren`, and the `NodeFactory` Scene pre-render use `layoutNode`; the `RoSGScreen` frame and dialog renders use `paintNode`.
- **`sgClock` (new `SGClock.ts`)** — injectable time source (`now`/`perfNow`/`setSource`) exported from the bundle. All render-path clock reads (AnimationBase, Timer, BusySpinner, ScrollingLabel, TextEditBox, TrickPlayBar, Video, DynamicKeyGrid, TimeGrid) route through it so tests can drive time-based state deterministically — fake-timer libraries can't reach the built bundle's captured globals.
- **`layout-perf-app` CLI fixture** — the committed form of the proposal doc's synthetic probe: 70 self-measuring components in a LayoutGroup; quartile per-tile timings expose the O(n²) screen-build shape (current run: q1 ≈ 4 ms → q4 ≈ 7 ms rising; a device is flat). The CLI test asserts correctness markers only, never timings.

## Tests

- `LayoutPaintSeam.test.js` — layoutNode ≡ renderNode-without-draw2D (rect equality), paintNode draws, `renderPass` set/restored, boundingRect refresh runs as a layout pass.
- `ClockSource.test.js` — pins the property the split relies on: `AnimationBase.tick()` interpolates against the injected clock (fraction 0 / 0.5 / 1), i.e. animations advance outside `renderNode`.
- Full suite green (184 files, 2288 tests), lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)