### PR TITLE
perf(scenegraph): make layout passes pure — clock and side effects paint-only

### DIFF
--- a/src/extensions/scenegraph/nodes/BusySpinner.ts
+++ b/src/extensions/scenegraph/nodes/BusySpinner.ts
@@ -1,5 +1,6 @@
 import { AAMember, Interpreter, BrsString, BrsType, RoArray, Float, IfDraw2D, Rect } from "brs-engine";
 import { sgClock } from "../SGClock";
+import { sgRoot } from "../SGRoot";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { rotateTranslation } from "../SGUtil";
 import { SGNodeType } from ".";
@@ -99,7 +100,10 @@ export class BusySpinner extends Group {
         if (this.isDirty) {
             this.updateChildren();
         }
-        if (this.active) {
+        // Advance the spin only on a paint pass: a layout pass (a bounding-rect refresh) must be
+        // pure and clock-free — it renders the poster at its stored rotation. Consuming the time
+        // delta here would also make measurement frequency change the spin speed.
+        if (this.active && this.isPaintPass(draw2D)) {
             if (this.lastRenderTime === 0) {
                 this.lastRenderTime = sgClock.now();
             }
@@ -112,7 +116,10 @@ export class BusySpinner extends Group {
             if (rotationChange !== 0) {
                 this.currentRotation += direction * rotationChange;
                 const spin = this.currentRotation + rotation;
-                this.poster.setValue("rotation", new Float(spin));
+                // Silent write + explicit dirty: the internal poster's rotation has no app
+                // observers to notify, but the spinner still needs the next frame drawn.
+                this.poster.setValueSilent("rotation", new Float(spin));
+                sgRoot.makeDirty();
                 this.lastRenderTime = now;
             }
         }

--- a/src/extensions/scenegraph/nodes/Dialog.ts
+++ b/src/extensions/scenegraph/nodes/Dialog.ts
@@ -210,7 +210,11 @@ export class Dialog extends Group {
         if (this.isDirty) {
             this.updateChildren();
         }
-        this.setNodeFocus(true);
+        // Claiming focus is a paint-side effect: a layout pass (a bounding-rect refresh that
+        // reaches the dialog) must not move focus.
+        if (this.isPaintPass(draw2D)) {
+            this.setNodeFocus(true);
+        }
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(boundingRect, origin, rotation);

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -501,7 +501,8 @@ export class DynamicKeyGrid extends Group {
 
         // Auto-open a "hover" suggestion pop-up once the focus has dwelled on the key, unless it
         // was suppressed by a previous selection (until focus leaves and returns to the key).
-        if (showFocus && !this.popup && !this.popupSuppressed) {
+        // Paint-only: opening a popup mutates the tree, which a layout pass must never do.
+        if (showFocus && !this.popup && !this.popupSuppressed && this.isPaintPass(draw2D)) {
             const key = this.renderedKeys[this.focusIndex];
             if (
                 key?.suggestions &&

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -776,6 +776,13 @@ export class Group extends Node {
         return true;
     }
 
+    /**
+     * Runs on layout passes too (not gated on `isPaintPass`): tracking is a deterministic
+     * function of layout state (rects + visibility), the write only fires on a genuine change,
+     * and HiddenMeasure pins that a bounding-rect refresh reports "none" for UI measured under a
+     * hidden ancestor. That keeps layout passes idempotent without freezing tracking between
+     * frames.
+     */
     protected updateRenderTracking(invisible: boolean) {
         const enableRenderTracking = this.getValueJS("enableRenderTracking") as boolean;
         const renderTracking = this.getValueJS("renderTracking") as string;

--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -110,6 +110,50 @@ export class ScrollingLabel extends Label {
         }
     }
 
+    /**
+     * Advances the marquee state machine by the wall-clock time since the last paint. Called only
+     * from paint passes — layout renders the stored state without touching the clock.
+     */
+    private advanceScroll(scrollDistance: number, scrollDuration: number, repeatCount: number) {
+        const now = sgClock.now();
+        const deltaTime = now - this.lastUpdateTime;
+        this.lastUpdateTime = now;
+        this.elapsedTime += deltaTime;
+
+        switch (this.scrollState) {
+            case ScrollState.INITIAL_PAUSE:
+                if (this.elapsedTime >= INITIAL_PAUSE_MS) {
+                    this.scrollState = ScrollState.SCROLLING;
+                    this.elapsedTime = 0;
+                    this.scrollOffset = 0;
+                }
+                break;
+
+            case ScrollState.SCROLLING:
+                this.scrollOffset = Math.min(scrollDistance, (this.elapsedTime / scrollDuration) * scrollDistance);
+                if (this.elapsedTime >= scrollDuration) {
+                    this.scrollState = ScrollState.END_PAUSE;
+                    this.elapsedTime = 0;
+                    this.scrollOffset = scrollDistance; // Ensure it's exactly at the end
+                }
+                break;
+
+            case ScrollState.END_PAUSE:
+                if (this.elapsedTime >= END_PAUSE_MS) {
+                    this.currentRepeat++;
+                    if (repeatCount !== -1 && this.currentRepeat >= repeatCount) {
+                        this.scrollState = ScrollState.FINISHED;
+                    } else {
+                        // Repeat the cycle
+                        this.scrollState = ScrollState.INITIAL_PAUSE;
+                        this.elapsedTime = 0;
+                    }
+                    this.scrollOffset = 0;
+                }
+                break;
+        }
+    }
+
     // Reset scrolling state variables
     private resetScrollingState() {
         this.scrollState = this.needsScrolling ? ScrollState.INITIAL_PAUSE : ScrollState.STATIC;
@@ -131,11 +175,6 @@ export class ScrollingLabel extends Label {
         if (!(drawFont instanceof RoFont)) {
             return { text, width: 0, height: 0, ellipsized: false };
         }
-        const now = sgClock.now();
-        const deltaTime = now - this.lastUpdateTime;
-        this.lastUpdateTime = now;
-        this.elapsedTime += deltaTime;
-
         const scrollSpeed = this.getValueJS("scrollSpeed") as number;
         const repeatCount = this.getValueJS("repeatCount") as number;
         const maxWidth = this.getValueJS("maxWidth") as number;
@@ -148,68 +187,36 @@ export class ScrollingLabel extends Label {
         const color = this.getValueJS("color") as number;
         const vertAlign = this.getValueJS("vertAlign") || "top";
 
+        const scrollDistance = this.fullTextWidth - maxWidth; // How much the text needs to move
+        const scrollDuration = scrollDistance > 0 && scrollSpeed > 0 ? (scrollDistance / scrollSpeed) * 1000 : 0; // ms
+
+        // Advance the marquee only on a paint pass: a layout pass (a bounding-rect refresh) must
+        // be pure and clock-free — it renders the stored scroll position. Consuming the time delta
+        // here used to make measurement frequency change the scroll speed, and the makeDirty from
+        // inside a refresh re-dirtied the scene from a boundingRect() query.
+        if (this.needsScrolling && this.scrollState !== ScrollState.FINISHED && this.isPaintPass(draw2D)) {
+            sgRoot.makeDirty(); // Ensure continuous updates during scrolling
+            this.advanceScroll(scrollDistance, scrollDuration, repeatCount);
+        }
+
+        // Derive what to draw purely from the stored scroll state.
         let textToDraw = text;
         let drawOffset = 0;
         let isEllipsized = false;
-
-        if (this.needsScrolling && this.scrollState !== ScrollState.FINISHED) {
-            sgRoot.makeDirty(); // Ensure continuous updates during scrolling
-            const scrollDistance = this.fullTextWidth - maxWidth; // How much the text needs to move
-            const scrollDuration = scrollDistance > 0 && scrollSpeed > 0 ? (scrollDistance / scrollSpeed) * 1000 : 0; // ms
-
+        if (this.needsScrolling) {
             switch (this.scrollState) {
-                case ScrollState.INITIAL_PAUSE:
+                case ScrollState.SCROLLING:
+                    drawOffset = -this.scrollOffset;
+                    break;
+                case ScrollState.END_PAUSE:
+                    drawOffset = -scrollDistance;
+                    break;
+                default:
+                    // INITIAL_PAUSE and FINISHED show the truncated text at rest.
                     textToDraw = this.truncatedText;
                     isEllipsized = true;
-                    if (this.elapsedTime >= INITIAL_PAUSE_MS) {
-                        this.scrollState = ScrollState.SCROLLING;
-                        this.elapsedTime = 0;
-                    }
-                    break;
-
-                case ScrollState.SCROLLING:
-                    textToDraw = text; // Draw the full text
-                    // Calculate current offset based on elapsed time in this state
-                    this.scrollOffset = Math.min(scrollDistance, (this.elapsedTime / scrollDuration) * scrollDistance);
-                    drawOffset = -this.scrollOffset;
-
-                    if (this.elapsedTime >= scrollDuration) {
-                        this.scrollState = ScrollState.END_PAUSE;
-                        this.elapsedTime = 0;
-                        this.scrollOffset = scrollDistance; // Ensure it's exactly at the end
-                        drawOffset = -this.scrollOffset;
-                    }
-                    break;
-
-                case ScrollState.END_PAUSE:
-                    textToDraw = text; // Keep drawing full text, but fully scrolled
-                    drawOffset = -scrollDistance;
-                    if (this.elapsedTime >= END_PAUSE_MS) {
-                        this.currentRepeat++;
-                        if (repeatCount !== -1 && this.currentRepeat >= repeatCount) {
-                            this.scrollState = ScrollState.FINISHED;
-                            textToDraw = this.truncatedText; // Show truncated at the end
-                            drawOffset = 0;
-                            isEllipsized = true;
-                        } else {
-                            // Repeat the cycle
-                            this.scrollState = ScrollState.INITIAL_PAUSE;
-                            this.elapsedTime = 0;
-                            this.scrollOffset = 0;
-                            textToDraw = this.truncatedText;
-                            drawOffset = 0;
-                            isEllipsized = true;
-                        }
-                    }
                     break;
             }
-        } else if (this.scrollState === ScrollState.FINISHED) {
-            // If finished, just draw the truncated text statically
-            textToDraw = this.truncatedText;
-            isEllipsized = true;
-        } else {
-            // Static case: Text fits or scrolling is disabled/not needed
-            textToDraw = text;
         }
         const clipRect: Rect = { ...rect, height: Math.max(boxHeight, textHeight) };
         let drawX = rect.x + drawOffset;
@@ -234,6 +241,9 @@ export class ScrollingLabel extends Label {
         draw2D?.pushClip(clipRect);
         draw2D?.doDrawRotatedText(textToDraw, drawX, drawY, color, opacity, drawFont, rotation);
         draw2D?.popClip();
+        // Safe on layout passes too (matching the base Label): with the scroll state frozen
+        // during layout, the value derives purely from stored state, and setValue only notifies
+        // on a genuine change — idempotent.
         this.setEllipsized(isEllipsized);
         const measuredWidth = this.needsScrolling ? maxWidth : this.fullTextWidth;
         return {

--- a/src/extensions/scenegraph/nodes/StandardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardDialog.ts
@@ -488,7 +488,11 @@ export class StandardDialog extends Group {
             this.pendingRelayout = false;
             this.layoutStandardDialog();
         }
-        this.setNodeFocus(true);
+        // Claiming focus is a paint-side effect: a layout pass (a bounding-rect refresh that
+        // reaches the dialog) must not move focus.
+        if (this.isPaintPass(draw2D)) {
+            this.setNodeFocus(true);
+        }
         const nodeTrans = this.getTranslation();
         const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
         drawTrans[0] += origin[0];

--- a/src/extensions/scenegraph/nodes/TextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/TextEditBox.ts
@@ -39,6 +39,8 @@ export class TextEditBox extends Group {
     private cursorVisible: boolean = true;
     private lastCursorToggleTime: number = 0;
     private lastCharInputTime: number = 0;
+    /** Clock captured on the last paint pass; layout passes reuse it instead of reading the clock. */
+    private lastPaintNow: number = 0;
     private readonly cursor?: RoBitmap;
     private readonly textLabel: Label;
     private readonly secureLabel: Label;
@@ -187,7 +189,13 @@ export class TextEditBox extends Group {
         const combinedOpacity = opacity * this.getOpacity();
         const text = this.getValueJS("text") as string;
         const secureMode = this.getValueJS("secureMode") as boolean;
-        const now = sgClock.now(); // Get current time for checks
+        // Read the clock only on a paint pass; a layout pass reuses the last paint's timestamp so
+        // its output (secure-char reveal, cursor phase) is identical between frames — layout must
+        // be pure and clock-free.
+        if (this.isPaintPass(draw2D)) {
+            this.lastPaintNow = sgClock.now();
+        }
+        const now = this.lastPaintNow;
 
         // Ensure labels have correct width if TextEditBox width changes
         // And update background if URI changes
@@ -259,7 +267,8 @@ export class TextEditBox extends Group {
         if (!isActive || !this.cursor?.isValid()) {
             return;
         }
-        if (now - this.lastCursorToggleTime > this.cursorBlinkInterval) {
+        // Flip the blink phase only on a paint pass — layout renders the stored phase.
+        if (this.isPaintPass(draw2D) && now - this.lastCursorToggleTime > this.cursorBlinkInterval) {
             this.cursorVisible = !this.cursorVisible;
             this.lastCursorToggleTime = now;
         }

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -155,6 +155,8 @@ export class TimeGrid extends ArrayGrid {
     protected gridX: number = 0;
     protected gridWidth: number = 0;
     protected rowHeight: number = 0;
+    /** "Now" epoch captured on the last paint pass; layout passes reuse it (clock-free layout). */
+    private cachedNowEpoch: number = 0;
     protected visibleChannels: number = 0;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TimeGrid) {
@@ -720,7 +722,13 @@ export class TimeGrid extends ArrayGrid {
         const secToPx = this.gridWidth / duration;
         this.updateTopRow();
         const topCh = this.topRow;
-        const now = this.nowEpoch();
+        // The "now" marker position is refreshed only on paint passes (or the first layout before
+        // any paint); a layout pass reuses the cached epoch so repeated bounding-rect refreshes
+        // are idempotent — layout must be clock-free.
+        if (this.isPaintPass(draw2D) || this.cachedNowEpoch === 0) {
+            this.cachedNowEpoch = this.nowEpoch();
+        }
+        const now = this.cachedNowEpoch;
         const center = this.getScaleRotateCenter();
         const nodeFocus = sgRoot.focused === this;
         let textIndex = 0;

--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -28,6 +28,8 @@ export class TrickPlayBar extends Group {
     private readonly bmpIcons: Map<string, RoBitmap>;
     private stateIcon: RoBitmap | undefined;
     private stateIconTimeout: number = -1;
+    /** Clock captured on the last paint pass; layout passes reuse it instead of reading the clock. */
+    private lastPaintNow: number = 0;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TrickPlayBar) {
         super([], name);
@@ -152,7 +154,12 @@ export class TrickPlayBar extends Group {
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(rect, origin, angle);
         this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
-        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > sgClock.now())) {
+        // Check the icon expiry against the clock only on a paint pass; a layout pass reuses the
+        // last paint's timestamp so the icon cannot flip mid-refresh (layout must be clock-free).
+        if (this.isPaintPass(draw2D)) {
+            this.lastPaintNow = sgClock.now();
+        }
+        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > this.lastPaintNow)) {
             const iconRect = {
                 x: rect.x + (size.width - this.stateIcon.width) / 2,
                 y: rect.y + this.barH,

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -801,8 +801,20 @@ export class Video extends Group {
         const presenting =
             owner && (state === "playing" || state === "paused" || (state === "buffering" && this.hasPresented));
         const buffering = owner && state === "buffering" && !this.hasPresented && this.uiVisible();
-        if (this.isDirty && presenting) {
-            postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
+        // The video-plane rect postMessage, the ff/rw seek auto-repeat, and showUI's child field
+        // writes are paint-only: a layout pass (a bounding-rect refresh) must be pure — it would
+        // otherwise spam the host with rect messages and advance seek state per measurement.
+        if (this.isPaintPass(draw2D)) {
+            if (this.isDirty && presenting) {
+                postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
+            }
+            if (this.statusChanged) {
+                if (this.seekTimeout > 0 && this.seekTimeout < sgClock.now() && ["rw", "ff"].includes(this.seekMode)) {
+                    const duration = this.getValueJS("duration") as number;
+                    this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
+                }
+                this.showUI(this.uiVisible());
+            }
         }
         if (draw2D) {
             this.isDirty = false;
@@ -811,13 +823,6 @@ export class Video extends Group {
             } else if (buffering) {
                 draw2D.doDrawRotatedRect(rect, 0x000000ff, 0, [0, 0], opacity);
             }
-        }
-        if (this.statusChanged) {
-            if (this.seekTimeout > 0 && this.seekTimeout < sgClock.now() && ["rw", "ff"].includes(this.seekMode)) {
-                const duration = this.getValueJS("duration") as number;
-                this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
-            }
-            this.showUI(this.uiVisible());
         }
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);

--- a/test/extensions/scenegraph/BusySpinnerClock.test.js
+++ b/test/extensions/scenegraph/BusySpinnerClock.test.js
@@ -1,0 +1,67 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsString, Interpreter } = core;
+
+/**
+ * BusySpinner advances its rotation only on paint passes, by the paint-to-paint time delta —
+ * layout passes (bounding-rect refreshes) render the stored rotation without consuming time.
+ * Before the layout/paint split a measurement pass both advanced the spin (making measurement
+ * frequency change the spin speed) and re-dirtied the scene via the poster field write.
+ */
+describe("BusySpinner clock behavior across pass kinds", () => {
+    let interpreter;
+    let fakeNow;
+    const draw2D = { doDrawRotatedBitmap: () => {}, doDrawRotatedRect: () => {} };
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        fakeNow = 50_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+    });
+
+    function buildSpinner() {
+        const group = SGNodeFactory.createNode("Group");
+        const spinner = SGNodeFactory.createNode("BusySpinner");
+        group.appendChildToParent(spinner);
+        spinner.setValue("control", new BrsString("start"));
+        return { group, spinner, poster: spinner.getValue("poster") };
+    }
+
+    test("rotation advances only on paint, by the paint-to-paint delta", () => {
+        const { group, poster } = buildSpinner();
+
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        const start = poster.getValueJS("rotation");
+
+        // Interleave layout passes across 1s of clock: no advancement.
+        fakeNow += 400;
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+        fakeNow += 600;
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(poster.getValueJS("rotation")).toBe(start);
+
+        // The next paint advances by the FULL elapsed second (spinInterval default 2s =>
+        // half a revolution) — the interleaved layouts did not eat the delta.
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        const advanced = poster.getValueJS("rotation");
+        expect(Math.abs(advanced - start)).toBeCloseTo(Math.PI, 5);
+    });
+
+    test("layout passes do not re-dirty the scene from the spin", () => {
+        const { group } = buildSpinner();
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        sgRoot.clearDirty();
+        fakeNow += 300;
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.isDirty).toBe(false);
+    });
+});

--- a/test/extensions/scenegraph/LayoutPurity.test.js
+++ b/test/extensions/scenegraph/LayoutPurity.test.js
@@ -1,0 +1,149 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsDevice, BrsString, Float, Int32, Interpreter } = core;
+
+/**
+ * The central invariant of the layout/paint split (docs/scenegraph-layout-passes.md): a layout
+ * pass is pure — idempotent and clock-free. Running layoutNode twice while the clock ADVANCES
+ * between calls must produce identical rects and must not advance any node's time-based state,
+ * for every node type that reads the clock during render.
+ */
+describe("layout passes are pure (idempotent, clock-free)", () => {
+    let interpreter;
+    let fakeNow;
+
+    beforeAll(() => {
+        // Label/keyboard nodes resolve fonts from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        fakeNow = 100_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+    });
+
+    function snapshot(node) {
+        return {
+            local: { ...node.rectLocal },
+            toParent: { ...node.rectToParent },
+            toScene: { ...node.rectToScene },
+        };
+    }
+
+    /** Two layout passes with 5s of clock between them must agree exactly. */
+    function expectIdempotentLayout(root, node) {
+        root.layoutNode(interpreter, [0, 0], 0, 1);
+        const first = snapshot(node);
+        fakeNow += 5000;
+        root.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(snapshot(node)).toEqual(first);
+    }
+
+    test("BusySpinner: layout does not advance the spin nor write the poster rotation", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const spinner = SGNodeFactory.createNode("BusySpinner");
+        group.appendChildToParent(spinner);
+        spinner.setValue("control", new BrsString("start"));
+        const poster = spinner.getValue("poster");
+        const before = poster.getValueJS("rotation");
+
+        expectIdempotentLayout(group, spinner);
+
+        expect(poster.getValueJS("rotation")).toBe(before);
+
+        // A paint pass advances it.
+        fakeNow += 500;
+        group.paintNode(interpreter, [0, 0], 0, 1, { doDrawRotatedBitmap: () => {}, doDrawRotatedRect: () => {} });
+        expect(poster.getValueJS("rotation")).not.toBe(before);
+    });
+
+    test("ScrollingLabel: layout does not consume the marquee time delta nor re-dirty the scene", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const label = SGNodeFactory.createNode("ScrollingLabel");
+        label.setValue("text", new BrsString("A very long text that certainly does not fit the maximum width"));
+        label.setValue("maxWidth", new Int32(120));
+        group.appendChildToParent(label);
+
+        sgRoot.clearDirty();
+        expectIdempotentLayout(group, label);
+        // The makeDirty that keeps the marquee animating is paint-only; a bounding-rect
+        // refresh must not re-dirty the scene (that made every measurement force a frame).
+        expect(sgRoot.isDirty).toBe(false);
+    });
+
+    test("TextEditBox: layout does not flip the cursor blink phase", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const editBox = SGNodeFactory.createNode("TextEditBox");
+        editBox.setValue("text", new BrsString("hello"));
+        editBox.setValue("active", core.BrsBoolean.True);
+        group.appendChildToParent(editBox);
+
+        // Paint once to seed lastPaintNow, then layout repeatedly across several blink
+        // intervals — the phase must not change (each flip would mutate state).
+        const draw2D = {
+            doDrawRotatedBitmap: () => {},
+            doDrawRotatedRect: () => {},
+            doDrawRotatedText: () => {},
+            doDrawScaledObject: () => {},
+            drawNinePatch: () => {},
+            drawImage: () => {},
+        };
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        expectIdempotentLayout(group, editBox);
+    });
+
+    test("Video: layout does not advance seek state", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const video = SGNodeFactory.createNode("Video");
+        group.appendChildToParent(video);
+
+        expectIdempotentLayout(group, video);
+    });
+
+    test("DynamicKeyGrid: a layout pass after the hover dwell does not open the popup", () => {
+        const grid = SGNodeFactory.createNode("DynamicKeyGrid");
+        const kdfUri = "common:/keyboards/kdf/qwerty_suggestions.json";
+        if (grid.getValueJS("keyDefinitionUri") !== undefined) {
+            grid.setValue("keyDefinitionUri", new BrsString(kdfUri));
+        }
+        sgRoot.setFocused(grid);
+        const childCountBefore = grid.getNodeChildren().length;
+
+        fakeNow += 10_000; // way past any hover delay
+        grid.layoutNode(interpreter, [0, 0], 0, 1);
+
+        // No popup node was appended by the layout pass.
+        expect(grid.getNodeChildren().length).toBe(childCountBefore);
+    });
+
+    test("a LayoutGroup subtree with mixed content lays out identically across advancing clock", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(100));
+        const marquee = SGNodeFactory.createNode("ScrollingLabel");
+        marquee.setValue("text", new BrsString("Another long scrolling text that overflows its container"));
+        marquee.setValue("maxWidth", new Int32(200));
+        const spinner = SGNodeFactory.createNode("BusySpinner");
+        spinner.setValue("control", new BrsString("start"));
+        layout.appendChildToParent(rect);
+        layout.appendChildToParent(marquee);
+        layout.appendChildToParent(spinner);
+        scene.appendChildToParent(layout);
+
+        expectIdempotentLayout(scene, layout);
+    });
+});

--- a/test/extensions/scenegraph/ScrollingLabelClock.test.js
+++ b/test/extensions/scenegraph/ScrollingLabelClock.test.js
@@ -1,0 +1,114 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsDevice, BrsString, Int32, Interpreter } = core;
+
+/**
+ * ScrollingLabel's marquee advances only on paint passes; a layout pass (bounding-rect refresh)
+ * renders the stored scroll position without consuming the time delta. Before the layout/paint
+ * split, a measurement between two frames ate part of the elapsed time (stuttering the marquee
+ * under boundingRect polling) and the mid-render makeDirty re-dirtied the scene from inside a
+ * refresh.
+ */
+describe("ScrollingLabel marquee across pass kinds", () => {
+    let interpreter;
+    let fakeNow;
+
+    /** Captures the x offset the marquee text is drawn at. */
+    function paintAndCaptureX(label) {
+        let capturedX;
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            doDrawRotatedText(text, x) {
+                capturedX = x;
+            },
+        };
+        label.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        return capturedX;
+    }
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        fakeNow = 200_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+    });
+
+    function buildMarquee() {
+        const label = SGNodeFactory.createNode("ScrollingLabel");
+        label.setValue("maxWidth", new Int32(150));
+        label.setValue("text", new BrsString("A very long text that certainly does not fit into 150 pixels"));
+        return label;
+    }
+
+    test("interleaved layout passes do not eat the scroll delta", () => {
+        // Two identical marquees; one gets layout passes interleaved between its paints.
+        // Both must land on the same scroll offset at the same wall-clock time.
+        const plain = buildMarquee();
+        const measured = buildMarquee();
+
+        paintAndCaptureX(plain);
+        paintAndCaptureX(measured);
+
+        // Get both past the initial pause (2500ms) into SCROLLING.
+        fakeNow += 3000;
+        paintAndCaptureX(plain);
+        paintAndCaptureX(measured);
+
+        // Advance 1s of scrolling; hammer one with layout passes mid-interval.
+        fakeNow += 500;
+        measured.layoutNode(interpreter, [0, 0], 0, 1);
+        measured.layoutNode(interpreter, [0, 0], 0, 1);
+        fakeNow += 500;
+        const plainX = paintAndCaptureX(plain);
+        const measuredX = paintAndCaptureX(measured);
+
+        expect(measuredX).toBe(plainX);
+        // And it actually scrolled (offset went negative).
+        expect(plainX).toBeLessThan(0);
+    });
+
+    test("a layout pass during scrolling does not move the drawn offset", () => {
+        const label = buildMarquee();
+        paintAndCaptureX(label);
+        fakeNow += 3000; // into SCROLLING
+        const x1 = paintAndCaptureX(label);
+
+        fakeNow += 1000;
+        label.layoutNode(interpreter, [0, 0], 0, 1);
+        // Paint with a zero-delta clock read (no time passed since the layout): the offset
+        // moved only by the paint-to-paint delta, unaffected by the layout in between.
+        const x2 = paintAndCaptureX(label);
+        expect(x2).toBeLessThan(x1); // scrolled by the 1000ms between paints
+
+        // Now verify layout alone never moves it: two layouts with clock advancing.
+        const rectBefore = { ...label.rectToParent };
+        fakeNow += 700;
+        label.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(label.rectToParent).toEqual(rectBefore);
+    });
+
+    test("layout passes do not re-dirty the scene while the marquee is active", () => {
+        const label = buildMarquee();
+        paintAndCaptureX(label);
+        fakeNow += 3000;
+
+        sgRoot.clearDirty();
+        label.layoutNode(interpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.isDirty).toBe(false);
+    });
+});


### PR DESCRIPTION
Stacked on #1117. Second step of `docs/scenegraph-layout-passes.md`: every node that read the clock or produced side effects inside `renderNode` now gates that work on `isPaintPass`, making layout passes (bounding-rect refreshes) **idempotent and clock-free** — the soundness precondition for pruning the refresh traversal (next PRs).

## Per node

| Node | Was (on every pass, incl. measurement) | Now |
|---|---|---|
| BusySpinner | advanced rotation + non-silent poster `rotation` write (re-dirtied the scene) | paint-only; silent write + explicit `makeDirty` |
| ScrollingLabel | marquee state machine consumed the time delta; `sgRoot.makeDirty()` from inside a refresh | `advanceScroll()` on paint only; layout renders the stored offset |
| TextEditBox | cursor blink flipped per render | blink + clock sample on paint; layout reuses last paint's timestamp |
| TrickPlayBar | icon expiry read the live clock | compares against last paint's clock |
| Video | plane-rect `postMessage`, ff/rw seek auto-repeat, `showUI` field writes | all paint-only |
| DynamicKeyGrid | hover dwell could open the popup mid-measure | paint-only |
| TimeGrid | "now" marker read the clock per render | epoch cached on paint |
| Dialog / StandardDialog | `setNodeFocus(true)` during any render | paint-only — measuring must not move focus |

`updateRenderTracking` intentionally stays active on layout passes: it's a deterministic function of layout state, writes only on genuine change, and `HiddenMeasure` pins the `"none"` report for UI measured under a hidden ancestor.

## Behavior changes (deliberate, closer to Roku)

- Marquees no longer stutter when apps poll `boundingRect()` (measurement used to eat the scroll delta).
- Spinners advance only on frames; measurement frequency no longer changes spin speed.
- A bounding-rect refresh no longer re-dirties the scene or spams the host with video-rect messages.

## Tests

- `LayoutPurity.test.js` — the program's central invariant: `layoutNode` twice with the clock advancing between calls → identical rects, no state advanced, `sgRoot.isDirty` untouched; per clock-carrying node type.
- `BusySpinnerClock.test.js` — rotation advances only on paint, by the full paint-to-paint delta across interleaved layouts.
- `ScrollingLabelClock.test.js` — two identical marquees, one hammered with layout passes, land on the same offset at the same wall-clock time.
- Full suite green (187 files, 2299 tests), lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)