### PR TITLE
perf(scenegraph): converge LayoutGroup layout passes to a fixed point

### DIFF
--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -32,6 +32,10 @@ export class LayoutGroup extends Group {
         { name: "addItemSpacingAfterChild", type: "boolean", value: "true" },
     ];
 
+    /** Divergence backstop for the layout-pass convergence loop; never reached by settling layouts. */
+    private static readonly MAX_LAYOUT_PASSES = 8;
+    /** @internal Passes the last layout call ran; exposed for convergence tests. */
+    lastPassCount = 0;
     private layoutDirty = true;
     private metricsUsedThisPass?: WeakMap<Node, LayoutMetrics>;
     private readonly childSizes = new WeakMap<Node, NodeSize>();
@@ -123,15 +127,21 @@ export class LayoutGroup extends Group {
 
         const addAfter = this.shouldAddSpacingAfterChild();
 
-        // On a measurement pass (no draw target — getBoundingRect's full-tree refresh and its
-        // single-subtree fallback both render with draw2D undefined), converge the layout in this one
-        // pass instead of deferring to the next frame. When a child's settled size differs from what
-        // applyLayout used (a wrapped Label laid out at a shorter height then rendered taller shifts
-        // its siblings), synchronizeChildMetrics re-dirties the layout; a one-shot boundingRect() query
-        // would otherwise read the pre-convergence size. A real frame draw (draw2D present) keeps
-        // maxPasses = 1, preserving its next-frame correction. Capped at 2 to terminate.
-        const maxPasses = draw2D === undefined && layoutChildren.length ? 2 : 1;
+        // On a layout/measurement pass (no draw target — getBoundingRect's full-tree refresh and
+        // its single-subtree fallback both render with draw2D undefined), converge the layout to a
+        // FIXED POINT in this one call instead of deferring to the next frame. When a child's
+        // settled size differs from what applyLayout used (a wrapped Label laid out at a shorter
+        // height then rendered taller shifts its siblings), synchronizeChildMetrics re-dirties the
+        // layout and the loop runs another pass; it exits only once a pass leaves the layout clean,
+        // so a one-shot boundingRect() query never reads a pre-convergence size. The former cap of
+        // 2 could exit while still dirty, returning rects that kept creeping on later refreshes.
+        // MAX_LAYOUT_PASSES is a divergence backstop, not the terminator — hitting it means child
+        // metrics oscillate (a bug to fix, not a state to paper over). A real frame draw (draw2D
+        // present) keeps a single pass, preserving its next-frame correction.
+        const maxPasses = draw2D === undefined && layoutChildren.length ? LayoutGroup.MAX_LAYOUT_PASSES : 1;
+        this.lastPassCount = 0;
         for (let pass = 0; pass < maxPasses; pass++) {
+            this.lastPassCount = pass + 1;
             this.metricsUsedThisPass = undefined;
             if (layoutChildren.length && this.layoutDirty) {
                 this.measureUnsizedChildren(layoutChildren, interpreter);

--- a/test/extensions/scenegraph/LayoutConvergence.test.js
+++ b/test/extensions/scenegraph/LayoutConvergence.test.js
@@ -1,0 +1,141 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, BrsBoolean, Float, RoArray, Interpreter } = core;
+
+/**
+ * LayoutGroup converges to a fixed point within a single layout pass
+ * (docs/scenegraph-layout-passes.md, "Make container convergence explicit"): after one
+ * layoutNode call, further calls must change NOTHING — exact equality, not epsilon. The former
+ * hard cap of 2 inner passes could exit while the layout was still dirty, so rects kept creeping
+ * asymptotically across refreshes (observed 659 → 631 → 629 in a real app).
+ */
+describe("LayoutGroup layout-pass convergence", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    const vector = (vals) => new RoArray(vals.map((v) => new Float(v)));
+
+    function snapshotTree(node, out = []) {
+        out.push({ ...node.rectLocal }, { ...node.rectToParent }, { ...node.rectToScene });
+        for (const child of node.getNodeChildren()) {
+            snapshotTree(child, out);
+        }
+        return out;
+    }
+
+    /** 4-level LayoutGroup nest, each level with a sibling Rectangle, deepest holds a wrapped Label. */
+    function buildDeepNest() {
+        const scene = SGNodeFactory.createNode("Scene");
+        let parent = scene;
+        const groups = [];
+        for (let d = 0; d < 4; d++) {
+            const g = SGNodeFactory.createNode("LayoutGroup");
+            g.setValue("layoutDirection", new BrsString("vert"));
+            g.setValue("itemSpacings", vector([4]));
+            const sib = SGNodeFactory.createNode("Rectangle");
+            sib.setValue("width", new Float(100));
+            sib.setValue("height", new Float(20));
+            g.appendChildToParent(sib);
+            parent.appendChildToParent(g);
+            groups.push(g);
+            parent = g;
+        }
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("wrap", BrsBoolean.True);
+        label.setValue("width", new Float(200));
+        label.setValue("text", new BrsString("short"));
+        parent.appendChildToParent(label);
+        return { scene, groups, label };
+    }
+
+    test("a second and third layout pass are exact no-ops", () => {
+        const { scene, label } = buildDeepNest();
+        label.setValue(
+            "text",
+            new BrsString(
+                "a much longer text that wraps to several lines when constrained to two hundred pixels of width"
+            )
+        );
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        const first = snapshotTree(scene);
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(snapshotTree(scene)).toEqual(first);
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(snapshotTree(scene)).toEqual(first);
+    });
+
+    test("convergence does not hit the divergence backstop", () => {
+        const { scene, groups, label } = buildDeepNest();
+        label.setValue(
+            "text",
+            new BrsString("another wrapped text long enough to grow the innermost group by a few line heights")
+        );
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+
+        for (const group of groups) {
+            expect(group.lastPassCount).toBeGreaterThan(0);
+            expect(group.lastPassCount).toBeLessThan(8);
+        }
+    });
+
+    test("a deep perturbation settles every ancestor in one layout pass", () => {
+        const { scene, groups, label } = buildDeepNest();
+        for (let p = 0; p < 3; p++) {
+            scene.layoutNode(interpreter, [0, 0], 0, 1);
+        }
+        const settled = groups.map((g) => g.rectToParent.height);
+
+        label.setValue(
+            "text",
+            new BrsString(
+                "now a much longer text that wraps to many lines when constrained to two hundred pixels wide, growing the innermost group by several line heights"
+            )
+        );
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        const afterOne = groups.map((g) => g.rectToParent.height);
+        // Every level grew (the innermost change propagated all the way up in ONE call)...
+        for (let i = 0; i < groups.length; i++) {
+            expect(afterOne[i]).toBeGreaterThan(settled[i]);
+        }
+        // ...and a second call confirms it was already the fixed point.
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(groups.map((g) => g.rectToParent.height)).toEqual(afterOne);
+    });
+
+    test("a paint pass keeps single-pass next-frame correction semantics", () => {
+        const { scene, label } = buildDeepNest();
+        label.setValue("text", new BrsString("wrapped text that is long enough to span at least a couple of lines"));
+        const draw2D = {
+            doDrawRotatedRect: () => {},
+            doDrawRotatedText: () => {},
+            doDrawRotatedBitmap: () => {},
+            pushClip: () => {},
+            popClip: () => {},
+        };
+
+        // Paint from the outer LayoutGroup (Scene.renderNode needs a full canvas surface).
+        const outer = scene.getNodeChildren()[0];
+        outer.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        expect(outer.lastPassCount).toBe(1);
+    });
+});


### PR DESCRIPTION
Stacked on #1118. Third step of `docs/scenegraph-layout-passes.md`: layout passes iterate to a **fixed point** instead of stopping at a hard cap of 2.

## What

- The layout-pass convergence loop in `LayoutGroup.renderNode` runs until a pass leaves `layoutDirty` false (the `synchronizeChildMetrics` predicate, unchanged). The former `maxPasses = 2` could exit mid-convergence, so a `boundingRect()` query read a pre-convergence size and rects crept asymptotically across refreshes (the doc's observed 659 → 631 → 629).
- `MAX_LAYOUT_PASSES = 8` remains as a **divergence backstop only** — hitting it means child metrics oscillate, a bug to surface rather than paper over. `lastPassCount` (internal) lets tests assert it's never reached.
- Frame draws keep single-pass next-frame-correction semantics.

## Diagnosis (per the doc's "surface and fix, don't guess" instruction)

Synthetic repros — nested LayoutGroups with wrapped Labels, children with negative intrinsic offsets, cross-axis app-written translations, horizontal alignment — all converge in **one** outer `layoutNode` call on top of #1118. The historical creep was the combination of measurement passes that advanced clock-driven state (fixed in #1118) and the cap-of-2 exit while still dirty (fixed here). A deep perturbation (innermost label of a 4-level nest growing several line heights) now settles every ancestor in a single call.

## Tests

`LayoutConvergence.test.js`:
- second and third layout passes are **exact** no-ops (non-epsilon equality — idempotence is the contract);
- the backstop is never hit;
- a deep perturbation propagates to every ancestor in one call, already at the fixed point;
- paint passes stay single-pass.

Full suite green (188 files, 2303 tests) — including the `PanelHeight` and `GridMeasureSpacing` canaries, whose expected values did not shift. Lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)