### PR TITLE
perf(scenegraph): split renderNode into layout/paint passes and prune settled subtrees

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -10,6 +10,26 @@ lazy-field/lazy-method memory paths. Companion: [threading-and-rendezvous.md](th
 translation/rotation/opacity, draws through the passed `IfDraw2D`, updates bounding rects, then calls
 `renderChildren(...)` and `nodeRenderingDone(...)`.
 
+**Layout passes are pure (docs/scenegraph-layout-passes.md).** `Node.layoutNode` /
+`Node.paintNode` wrap `renderNode`, setting `sgRoot.renderPass`; `Node.isPaintPass(draw2D)` is the
+gate. A `renderNode` call with no `draw2D` (a bounding-rect refresh, `measureUnsizedChildren`)
+must be **idempotent and clock-free**: no `Date.now`/`performance.now` reads (use `sgClock`, which
+tests replace via `setSource`), no field writes that aren't a pure function of layout state, no
+`sgRoot.makeDirty()`, no popups/focus moves/postMessage. Time-driven nodes (BusySpinner,
+ScrollingLabel, TextEditBox, TrickPlayBar, Video, DynamicKeyGrid, TimeGrid) advance state only
+under `isPaintPass` and render stored state otherwise — regressions: `LayoutPurity.test.js`,
+`BusySpinnerClock.test.js`, `ScrollingLabelClock.test.js`. This purity is what makes **pruned
+refreshes** sound: `refreshLayoutFromRoot` skips subtrees whose `subtreeStale` is false under an
+unchanged origin/angle/opacity context (`Group.skipSettledLayout`). Invariants: a skipped child
+still hands its cached rect up (`updateParentRects`), the stale mark is cleared **before** a
+node's pass (writes made inside it must survive), `Group.isDirty = true` routes through a setter
+that also stale-marks, and `ContentNode.makeDirty` hops the field boundary to stale-mark the
+consuming node (content trees aren't parented into the render tree). Regressions:
+`LayoutPruning.test.js`, `PruneVerify.test.js`, and the `BRS_PRUNE_VERIFY=1` CLI runs in
+`test/cli/cli.test.js`. Debug toggles: `BRS_PRUNE_VERIFY=1` (diff pruned vs full every refresh),
+`BRS_PRUNE_DISABLE=1` (turn pruning off). LayoutGroup converges to a fixed point on layout passes
+(`MAX_LAYOUT_PASSES` is a divergence backstop only) — regression: `LayoutConvergence.test.js`.
+
 **Visibility vs. measurement:** plain containers (`Group`, `LayoutGroup`, `MaskGroup`) do their
 invisible early-return through `Group.skipRender(draw2D)`, which lets a **measurement pass** (a render
 with no `draw2D` — `getBoundingRect`'s refresh) traverse them when invisible: on Roku, layout/bounding

--- a/docs/scenegraph-layout-passes.md
+++ b/docs/scenegraph-layout-passes.md
@@ -1,7 +1,12 @@
 # Splitting `renderNode` into layout and paint passes
 
-**Status:** proposal, not implemented. Written after an attempt to optimize bounding-rect refreshes
-failed for reasons that are fixed only by this refactor.
+**Status:** implemented. Landed as four stacked PRs: the layout/paint seam + injectable `sgClock`
+(#1117), per-node clock/side-effect extraction (#1118), LayoutGroup fixed-point convergence
+(#1119), and subtree pruning + the `BRS_PRUNE_VERIFY` rect-diff verifier. The document below is
+the original proposal, kept for the analysis and the verification bar; where the implementation
+deviated (AnimationBase was already ticked outside render; `renderNode` remains the single
+override point with `layoutNode`/`paintNode` as base-class entry points setting
+`sgRoot.renderPass`), the PRs record why.
 
 ## The problem
 

--- a/src/extensions/scenegraph/SGClock.ts
+++ b/src/extensions/scenegraph/SGClock.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Engine (https://github.com/lvcabral/brs-engine)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/** Replaceable time source backing every render-path clock read in the SceneGraph extension. */
+export interface SGClockSource {
+    /** Wall-clock milliseconds (Date.now semantics). */
+    now(): number;
+    /** Monotonic high-resolution milliseconds (performance.now semantics). */
+    perfNow(): number;
+}
+
+const realSource: SGClockSource = {
+    now: () => Date.now(),
+    perfNow: () => performance.now(),
+};
+
+let source: SGClockSource = realSource;
+
+/**
+ * The SceneGraph clock. Time-driven nodes (animations, spinners, marquees, cursor blink, seek
+ * repeat, timers) read the clock through this object instead of `Date.now()`/`performance.now()`
+ * so tests can substitute a deterministic source through the built bundle via `setSource` —
+ * fake-timer libraries cannot reach into the bundle's captured globals.
+ */
+export const sgClock = {
+    now(): number {
+        return source.now();
+    },
+    perfNow(): number {
+        return source.perfNow();
+    },
+    /** Replaces the time source; call with no argument to restore the real clock. */
+    setSource(replacement?: SGClockSource): void {
+        source = replacement ?? realSource;
+    },
+};

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -53,6 +53,7 @@ export class SGRoot {
     private _dirty: boolean = false;
     private _rendering: boolean = false;
     private _measuring: boolean = false;
+    private _renderPass: "layout" | "paint" = "paint";
     private readonly _pendingPorts: RoMessagePort[] = [];
     /**
      * When `true`, recently-written fields can be re-read from the local copy for a short window,
@@ -217,6 +218,22 @@ export class SGRoot {
 
     set measuring(value: boolean) {
         this._measuring = value;
+    }
+
+    /**
+     * Which kind of render pass is currently traversing the tree. A `layout` pass (started by
+     * `Node.layoutNode` — bounding-rect refreshes, `measureUnsizedChildren`) must be idempotent
+     * and clock-free: rects only. A `paint` pass (`Node.paintNode` — the per-frame render) may
+     * additionally advance time-based state and draw. Defaults to `paint` so direct `renderNode`
+     * calls (external node registrations, tests) keep today's semantics. See
+     * `docs/scenegraph-layout-passes.md`.
+     */
+    get renderPass(): "layout" | "paint" {
+        return this._renderPass;
+    }
+
+    set renderPass(value: "layout" | "paint") {
+        this._renderPass = value;
     }
 
     private audioFlags: number = -1;

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -236,6 +236,24 @@ export class SGRoot {
         this._renderPass = value;
     }
 
+    /**
+     * True while a full-tree layout refresh may skip settled subtrees (`Node.subtreeStale` false
+     * and unchanged origin/angle/opacity). Enabled only around `refreshLayoutFromRoot`'s pass —
+     * scoped subtree measurements (the mid-render fallback, `measureUnsizedChildren`) never prune.
+     * Sound only because layout passes are pure (see docs/scenegraph-layout-passes.md).
+     */
+    pruneLayout: boolean = false;
+
+    /** Set by BRS_PRUNE_DISABLE: turns pruned layout refreshes off entirely (field debugging). */
+    pruneDisabled: boolean = false;
+
+    /**
+     * When true, every full-tree layout refresh runs twice — pruned then unpruned — and diffs
+     * every rect in the scene, reporting divergences to stderr (`[prune-verify]` lines). Enabled
+     * by the BRS_PRUNE_VERIFY env var (node builds) or programmatically (browser/tests).
+     */
+    pruneVerify: boolean = false;
+
     private audioFlags: number = -1;
     private audioIndex: number = -1;
     private audioDuration: number = -1;
@@ -259,6 +277,13 @@ export class SGRoot {
         // Default resolution and auto substitution parameters
         this._resolution = "HD";
         this._autoSub = { search: "", replace: "" };
+        // Pruned-layout debug toggles from the environment (node builds; browsers/tests set the
+        // fields programmatically). Runtime-guarded rather than ifdef'd — the same bundle also
+        // loads in Web Workers, where `process` does not exist.
+        if (typeof process !== "undefined" && process.env) {
+            this.pruneVerify = process.env.BRS_PRUNE_VERIFY === "1";
+            this.pruneDisabled = process.env.BRS_PRUNE_DISABLE === "1";
+        }
     }
 
     /**

--- a/src/extensions/scenegraph/SGVerify.ts
+++ b/src/extensions/scenegraph/SGVerify.ts
@@ -1,0 +1,103 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Engine (https://github.com/lvcabral/brs-engine)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { BrsDevice, Interpreter, Rect } from "brs-engine";
+import { sgRoot } from "./SGRoot";
+import type { Node } from "./nodes/Node";
+
+/**
+ * Rect-diff verifier for the pruned layout refresh (docs/scenegraph-layout-passes.md, Tooling).
+ * Runs the refresh pruned, snapshots every rect in the tree, forces a full (unpruned) pass,
+ * snapshots again, and reports every divergence as a `[prune-verify]` line naming the exact node.
+ * Enabled by BRS_PRUNE_VERIFY=1 (or `sgRoot.pruneVerify = true`); silence means the pruned and
+ * full passes agree. Running the pass twice is safe precisely because layout passes are pure —
+ * that purity is part of what this verifier proves.
+ */
+
+interface RectSnapshot {
+    path: string;
+    rectLocal: Rect;
+    rectToParent: Rect;
+    rectToScene: Rect;
+}
+
+function isNodeLike(value: unknown): value is Node {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        "rectLocal" in value &&
+        "rectToParent" in value &&
+        "getNodeChildren" in value
+    );
+}
+
+/** Builds `/Type[childIndex]#id` path segments, e.g. `/Scene[2]/.../Group#videoTileOverlayGroup`. */
+function collectRects(node: Node, path: string, out: RectSnapshot[]) {
+    out.push({
+        path,
+        rectLocal: { ...node.rectLocal },
+        rectToParent: { ...node.rectToParent },
+        rectToScene: { ...node.rectToScene },
+    });
+    const children = node.getNodeChildren();
+    for (const [index, child] of children.entries()) {
+        if (!isNodeLike(child)) {
+            continue;
+        }
+        const id = child.getValueJS("id") as string;
+        const segment = `${child.nodeSubtype}${id ? `#${id}` : `[${index}]`}`;
+        collectRects(child, `${path}/${segment}`, out);
+    }
+}
+
+function fmt(rect: Rect): string {
+    return `${rect.x},${rect.y},${rect.width},${rect.height}`;
+}
+
+function sameRect(a: Rect, b: Rect): boolean {
+    return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+}
+
+/**
+ * Runs the layout refresh pruned then unpruned and reports any rect divergence to stderr.
+ * @returns The number of diverging nodes (0 = the pruned pass is sound for this refresh).
+ */
+export function runPruneVerify(root: Node, interpreter: Interpreter): number {
+    const pruned: RectSnapshot[] = [];
+    const full: RectSnapshot[] = [];
+
+    sgRoot.pruneLayout = !sgRoot.pruneDisabled;
+    try {
+        root.layoutNode(interpreter, [0, 0], 0, 1);
+    } finally {
+        sgRoot.pruneLayout = false;
+    }
+    collectRects(root, `/${root.nodeSubtype}`, pruned);
+
+    root.layoutNode(interpreter, [0, 0], 0, 1);
+    collectRects(root, `/${root.nodeSubtype}`, full);
+
+    const fullByPath = new Map(full.map((snapshot) => [snapshot.path, snapshot]));
+    let divergences = 0;
+    for (const snapshot of pruned) {
+        const reference = fullByPath.get(snapshot.path);
+        if (!reference) {
+            continue; // tree changed between passes (BrightScript ran inside the refresh)
+        }
+        for (const key of ["rectLocal", "rectToParent", "rectToScene"] as const) {
+            if (!sameRect(snapshot[key], reference[key])) {
+                divergences++;
+                BrsDevice.stderr.write(
+                    `warning,[prune-verify] ${snapshot.path}.${key}: pruned=${fmt(snapshot[key])} full=${fmt(
+                        reference[key]
+                    )}`
+                );
+            }
+        }
+    }
+    return divergences;
+}

--- a/src/extensions/scenegraph/SGVerify.ts
+++ b/src/extensions/scenegraph/SGVerify.ts
@@ -63,12 +63,20 @@ function sameRect(a: Rect, b: Rect): boolean {
 }
 
 /**
- * Runs the layout refresh pruned then unpruned and reports any rect divergence to stderr.
+ * Runs the layout refresh pruned, then unpruned TWICE, and classifies every rect divergence:
+ *
+ * - `[layout-verify]` — the two full passes disagree with each other: the layout is not
+ *   idempotent for that node (a convergence bug — the pruned pass merely ran first and read the
+ *   pre-convergence value). Pruning is not the culprit; fix the node's layout.
+ * - `[prune-verify]` — the two full passes agree but the pruned pass differs: true pruning
+ *   unsoundness (a subtree was skipped whose layout inputs changed without a stale mark).
+ *
  * @returns The number of diverging nodes (0 = the pruned pass is sound for this refresh).
  */
 export function runPruneVerify(root: Node, interpreter: Interpreter): number {
     const pruned: RectSnapshot[] = [];
     const full: RectSnapshot[] = [];
+    const fullAgain: RectSnapshot[] = [];
 
     sgRoot.pruneLayout = !sgRoot.pruneDisabled;
     try {
@@ -81,15 +89,27 @@ export function runPruneVerify(root: Node, interpreter: Interpreter): number {
     root.layoutNode(interpreter, [0, 0], 0, 1);
     collectRects(root, `/${root.nodeSubtype}`, full);
 
+    root.layoutNode(interpreter, [0, 0], 0, 1);
+    collectRects(root, `/${root.nodeSubtype}`, fullAgain);
+
     const fullByPath = new Map(full.map((snapshot) => [snapshot.path, snapshot]));
+    const fullAgainByPath = new Map(fullAgain.map((snapshot) => [snapshot.path, snapshot]));
     let divergences = 0;
     for (const snapshot of pruned) {
         const reference = fullByPath.get(snapshot.path);
-        if (!reference) {
+        const confirmation = fullAgainByPath.get(snapshot.path);
+        if (!reference || !confirmation) {
             continue; // tree changed between passes (BrightScript ran inside the refresh)
         }
         for (const key of ["rectLocal", "rectToParent", "rectToScene"] as const) {
-            if (!sameRect(snapshot[key], reference[key])) {
+            if (!sameRect(reference[key], confirmation[key])) {
+                divergences++;
+                BrsDevice.stderr.write(
+                    `warning,[layout-verify] ${snapshot.path}.${key}: full1=${fmt(reference[key])} full2=${fmt(
+                        confirmation[key]
+                    )} (non-idempotent layout)`
+                );
+            } else if (!sameRect(snapshot[key], reference[key])) {
                 divergences++;
                 BrsDevice.stderr.write(
                     `warning,[prune-verify] ${snapshot.path}.${key}: pruned=${fmt(snapshot[key])} full=${fmt(

--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -215,13 +215,13 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
                     sgRoot.clearDirty();
                     sgRoot.rendering = true;
                     try {
-                        sgRoot.scene.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+                        sgRoot.scene.paintNode(interpreter, [0, 0], 0, 1, this.draw2D);
                         if (showDialog) {
                             const dialog = sgRoot.scene.dialog!;
                             dialog.setValueSilent("visible", BrsBoolean.True);
                             const screenRect = { x: 0, y: 0, width: this.width, height: this.height };
                             this.draw2D.doDrawRotatedRect(screenRect, 255, 0, [0, 0], 0.5);
-                            dialog.renderNode(interpreter, [0, 0], 0, 1, this.draw2D);
+                            dialog.paintNode(interpreter, [0, 0], 0, 1, this.draw2D);
                         }
                     } finally {
                         sgRoot.rendering = false;

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -560,9 +560,9 @@ export function initializeNode(
                     return BrsInvalid.Instance;
                 }, currentEnv);
 
-                // Pre-render default state of the tree.
+                // Pre-render default state of the tree (layout only — nothing to draw yet).
                 if (node instanceof Scene) {
-                    node.renderNode(interpreter, [0, 0], 0, 1);
+                    node.layoutNode(interpreter, [0, 0], 0, 1);
                 }
 
                 const init = interpreter.inSubEnv((subInterpreter: Interpreter) => {

--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -39,6 +39,7 @@ import packageInfo from "../../../packages/scenegraph/package.json";
 export * from "./SGClock";
 export * from "./SGRoot";
 export * from "./SGUtil";
+export * from "./SGVerify";
 export * from "./components/RoSGNode";
 export * from "./components/RoSGScreen";
 export * from "./components/RoRenderThreadQueue";

--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -36,6 +36,7 @@ import { RoSGScreen } from "./components/RoSGScreen";
 import { getRenderThreadQueue } from "./components/RoRenderThreadQueue";
 import packageInfo from "../../../packages/scenegraph/package.json";
 
+export * from "./SGClock";
 export * from "./SGRoot";
 export * from "./SGUtil";
 export * from "./components/RoSGNode";

--- a/src/extensions/scenegraph/nodes/AnimationBase.ts
+++ b/src/extensions/scenegraph/nodes/AnimationBase.ts
@@ -1,6 +1,7 @@
 import { AAMember, BrsString, BrsType, isBrsString } from "brs-engine";
 import { Node } from "./Node";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 
@@ -103,7 +104,7 @@ export abstract class AnimationBase extends Node {
             return false;
         }
 
-        const now = performance.now();
+        const now = sgClock.perfNow();
         const delta = (now - this.lastUpdateTime) / 1000; // seconds
         this.lastUpdateTime = now;
         let effectiveDelta = delta;
@@ -128,7 +129,7 @@ export abstract class AnimationBase extends Node {
             if (this.shouldRepeat()) {
                 this.elapsedTime = 0;
                 this.delayRemaining = this.getDelaySeconds();
-                this.lastUpdateTime = performance.now();
+                this.lastUpdateTime = sgClock.perfNow();
             } else {
                 this.stop();
             }
@@ -179,7 +180,7 @@ export abstract class AnimationBase extends Node {
     protected startFromBeginning() {
         this.elapsedTime = 0;
         this.delayRemaining = this.getDelaySeconds();
-        this.lastUpdateTime = performance.now();
+        this.lastUpdateTime = sgClock.perfNow();
         this.enterRunningState();
     }
 
@@ -187,7 +188,7 @@ export abstract class AnimationBase extends Node {
      * Continues from a paused state without resetting elapsed time.
      */
     protected resumeFromPause() {
-        this.lastUpdateTime = performance.now();
+        this.lastUpdateTime = sgClock.perfNow();
         this.enterRunningState();
     }
 

--- a/src/extensions/scenegraph/nodes/BusySpinner.ts
+++ b/src/extensions/scenegraph/nodes/BusySpinner.ts
@@ -1,5 +1,6 @@
 import { AAMember, Interpreter, BrsString, BrsType, RoArray, Float, IfDraw2D, Rect } from "brs-engine";
 import { sgClock } from "../SGClock";
+import { sgRoot } from "../SGRoot";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { rotateTranslation } from "../SGUtil";
 import { SGNodeType } from ".";
@@ -99,7 +100,10 @@ export class BusySpinner extends Group {
         if (this.isDirty) {
             this.updateChildren();
         }
-        if (this.active) {
+        // Advance the spin only on a paint pass: a layout pass (a bounding-rect refresh) must be
+        // pure and clock-free — it renders the poster at its stored rotation. Consuming the time
+        // delta here would also make measurement frequency change the spin speed.
+        if (this.active && this.isPaintPass(draw2D)) {
             if (this.lastRenderTime === 0) {
                 this.lastRenderTime = sgClock.now();
             }
@@ -112,7 +116,10 @@ export class BusySpinner extends Group {
             if (rotationChange !== 0) {
                 this.currentRotation += direction * rotationChange;
                 const spin = this.currentRotation + rotation;
-                this.poster.setValue("rotation", new Float(spin));
+                // Silent write + explicit dirty: the internal poster's rotation has no app
+                // observers to notify, but the spinner still needs the next frame drawn.
+                this.poster.setValueSilent("rotation", new Float(spin));
+                sgRoot.makeDirty();
                 this.lastRenderTime = now;
             }
         }

--- a/src/extensions/scenegraph/nodes/BusySpinner.ts
+++ b/src/extensions/scenegraph/nodes/BusySpinner.ts
@@ -1,4 +1,5 @@
 import { AAMember, Interpreter, BrsString, BrsType, RoArray, Float, IfDraw2D, Rect } from "brs-engine";
+import { sgClock } from "../SGClock";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { rotateTranslation } from "../SGUtil";
 import { SGNodeType } from ".";
@@ -39,7 +40,7 @@ export class BusySpinner extends Group {
             const control = value.toString();
             if (control === "start") {
                 this.active = true;
-                this.lastRenderTime = Date.now();
+                this.lastRenderTime = sgClock.now();
             } else if (control === "stop") {
                 this.active = false;
             } else {
@@ -100,9 +101,9 @@ export class BusySpinner extends Group {
         }
         if (this.active) {
             if (this.lastRenderTime === 0) {
-                this.lastRenderTime = Date.now();
+                this.lastRenderTime = sgClock.now();
             }
-            const now = Date.now();
+            const now = sgClock.now();
             const spinInterval = this.getValueJS("spinInterval") as number;
             const clockwise = this.getValueJS("clockwise") as boolean;
             const direction = clockwise ? -1 : 1;

--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -380,13 +380,23 @@ export class ContentNode extends Node {
      */
     protected makeDirty() {
         this.changed = true;
+        this.markSubtreeStale();
         // Propagate the dirty flag up to the content root so an ancestor ArrayGrid/TimeGrid
         // re-parses its model when a descendant ContentNode changes. This must happen on any
         // thread — in particular for mutations applied on the render thread on behalf of a Task
         // (rendezvous), where inTaskThread() is false but the parent grid still needs to refresh.
-        if (this.parent instanceof Node) {
-            const root = this.findRootNode();
-            root.changed = true;
+        // A content tree hangs off a FIELD (it is not parented into the render tree), so the
+        // stale walk above never reaches the render node consuming it — hop through the root's
+        // parent fields to their containers (the grid/label holding the content) so a pruned
+        // layout refresh re-descends into that consumer.
+        const root = this.parent instanceof Node ? this.findRootNode() : this;
+        root.changed = true;
+        // parentFields may be undefined here: the base Node constructor writes fields
+        // (setValueSilent → makeDirty) before this subclass's field initializers run.
+        if (root instanceof ContentNode && root.parentFields) {
+            for (const field of root.parentFields) {
+                field.getContainer()?.markSubtreeStale();
+            }
         }
         sgRoot.makeDirty();
     }

--- a/src/extensions/scenegraph/nodes/Dialog.ts
+++ b/src/extensions/scenegraph/nodes/Dialog.ts
@@ -210,7 +210,11 @@ export class Dialog extends Group {
         if (this.isDirty) {
             this.updateChildren();
         }
-        this.setNodeFocus(true);
+        // Claiming focus is a paint-side effect: a layout pass (a bounding-rect refresh that
+        // reaches the dialog) must not move focus.
+        if (this.isPaintPass(draw2D)) {
+            this.setNodeFocus(true);
+        }
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(boundingRect, origin, rotation);

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -501,7 +501,8 @@ export class DynamicKeyGrid extends Group {
 
         // Auto-open a "hover" suggestion pop-up once the focus has dwelled on the key, unless it
         // was suppressed by a previous selection (until focus leaves and returns to the key).
-        if (showFocus && !this.popup && !this.popupSuppressed) {
+        // Paint-only: opening a popup mutates the tree, which a layout pass must never do.
+        if (showFocus && !this.popup && !this.popupSuppressed && this.isPaintPass(draw2D)) {
             const key = this.renderedKeys[this.focusIndex];
             if (
                 key?.suggestions &&

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -17,6 +17,7 @@ import { SGNodeType } from ".";
 import { Group } from "./Group";
 import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { jsValueOf } from "../factory/Serializer";
 import { computeLayout, KeyInset, keyboardSize, KeyLayout, RenderedKey, resolveKeyIcon } from "./kdf/KeyDefinition";
 
@@ -171,7 +172,7 @@ export class DynamicKeyGrid extends Group {
         super.setValue("keyFocused", new BrsString(key?.out ?? ""));
         // Focus moved to a (possibly) different key: restart the hover dwell timer and
         // clear any pop-up suppression, so the timer applies again on the newly focused key.
-        this.lastFocusTime = Date.now();
+        this.lastFocusTime = sgClock.now();
         this.popupSuppressed = false;
     }
 
@@ -505,7 +506,7 @@ export class DynamicKeyGrid extends Group {
             if (
                 key?.suggestions &&
                 this.triggersInclude(key, "hover") &&
-                Date.now() - this.lastFocusTime > this.hoverDelay
+                sgClock.now() - this.lastFocusTime > this.hoverDelay
             ) {
                 this.openPopup(key);
             }

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -694,8 +694,17 @@ export class Group extends Node {
         // wipe the mark those writes set and strand the change until something unrelated dirties
         // this subtree again. Record the incoming context a completed pass ran under; a pruned
         // refresh may only skip when the same context comes back.
-        this.subtreeStale = false;
-        this.lastLayoutContext = { x: origin[0], y: origin[1], angle, opacity };
+        //
+        // Both happen ONLY inside the pruned full refresh itself: scoped measurements (the
+        // mid-render fallback, measureUnsizedChildren) render at origin [0,0], and a detached
+        // component root's real refresh ALSO runs at [0,0] — if a scoped pass recorded that
+        // context and cleared the mark, the real refresh would skip on the scoped pass's partial
+        // rects (its parent's union was snapshot/restored away, or its layout hadn't been applied
+        // yet). Paint passes don't participate in pruning at all.
+        if (sgRoot.pruneLayout) {
+            this.subtreeStale = false;
+            this.lastLayoutContext = { x: origin[0], y: origin[1], angle, opacity };
+        }
         this.layoutPassCount++;
         const nodeTrans = this.getTranslation();
         const drawTrans = nodeTrans.slice();

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -50,7 +50,34 @@ export class Group extends Node {
     protected resolution: string;
     private cachedLines: MeasuredText[] = [];
     private cachedHeight: number = 0;
-    isDirty: boolean;
+    private _isDirty: boolean = true;
+    /**
+     * The (origin, angle, opacity) context of this node's last completed layout pass. A pruned
+     * refresh may skip the subtree only when the incoming context matches EXACTLY (float
+     * equality): a moved/rotated/faded ancestor changes the context of every descendant, which
+     * re-renders them even though their own fields never changed.
+     */
+    private lastLayoutContext?: { x: number; y: number; angle: number; opacity: number };
+    /** @internal Number of non-skipped render passes this node has run; exposed for pruning tests. */
+    layoutPassCount = 0;
+
+    get isDirty(): boolean {
+        return this._isDirty;
+    }
+
+    /**
+     * Dirtying a node also marks its subtree stale for the pruned layout refresh: ~65 sites set
+     * `isDirty = true` directly (bypassing `makeDirty`), and each represents render-relevant state
+     * the next layout pass must see. Routing the stale mark through this setter keeps the pruning
+     * invariant without auditing every site. Clearing (`false`) leaves the stale mark alone —
+     * `subtreeStale` is cleared only at the start of the node's own layout pass.
+     */
+    set isDirty(value: boolean) {
+        this._isDirty = value;
+        if (value) {
+            this.markSubtreeStale();
+        }
+    }
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.Group) {
         super([], name);
@@ -659,6 +686,17 @@ export class Group extends Node {
         if (this.skipRender(draw2D)) {
             return;
         }
+        if (this.skipSettledLayout(origin, angle, opacity, draw2D)) {
+            return;
+        }
+        // Clear the stale mark BEFORE the pass, not after: BrightScript that runs inside it (an
+        // item component's init(), a field observer) can write fields — clearing afterwards would
+        // wipe the mark those writes set and strand the change until something unrelated dirties
+        // this subtree again. Record the incoming context a completed pass ran under; a pruned
+        // refresh may only skip when the same context comes back.
+        this.subtreeStale = false;
+        this.lastLayoutContext = { x: origin[0], y: origin[1], angle, opacity };
+        this.layoutPassCount++;
         const nodeTrans = this.getTranslation();
         const drawTrans = nodeTrans.slice();
         drawTrans[0] += origin[0];
@@ -753,6 +791,31 @@ export class Group extends Node {
         if (draw2D) {
             this.isDirty = false;
         }
+    }
+
+    /**
+     * Whether a pruned layout refresh may skip this settled subtree (docs/scenegraph-layout-passes.md).
+     * Active only during `refreshLayoutFromRoot`'s pruned pass (`sgRoot.pruneLayout`), never on
+     * paint. A subtree is skippable when nothing in it was written since its last layout pass
+     * (`subtreeStale` false — sound because layout passes are pure) AND the incoming
+     * origin/angle/opacity match the context that pass ran under. A skipped child must still hand
+     * its cached rect up: `updateBoundingRects` resets the parent's rects at the start of the
+     * parent's pass and rebuilds them from child unions, so skipping without contributing would
+     * make every ancestor's bounds come out short (a vertical LayoutGroup reporting one child's
+     * height instead of the stack's — MidRenderParentMeasure).
+     */
+    private skipSettledLayout(origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D): boolean {
+        if (draw2D || !sgRoot.pruneLayout || this.subtreeStale || !this.lastLayoutContext) {
+            return false;
+        }
+        const ctx = this.lastLayoutContext;
+        if (ctx.x !== origin[0] || ctx.y !== origin[1] || ctx.angle !== angle || ctx.opacity !== opacity) {
+            return false;
+        }
+        if (this.isVisible()) {
+            this.updateParentRects(origin, angle);
+        }
+        return true;
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -776,6 +776,13 @@ export class Group extends Node {
         return true;
     }
 
+    /**
+     * Runs on layout passes too (not gated on `isPaintPass`): tracking is a deterministic
+     * function of layout state (rects + visibility), the write only fires on a genuine change,
+     * and HiddenMeasure pins that a bounding-rect refresh reports "none" for UI measured under a
+     * hidden ancestor. That keeps layout passes idempotent without freezing tracking between
+     * frames.
+     */
     protected updateRenderTracking(invisible: boolean) {
         const enableRenderTracking = this.getValueJS("enableRenderTracking") as boolean;
         const renderTracking = this.getValueJS("renderTracking") as string;

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -140,8 +140,27 @@ export class LayoutGroup extends Group {
         // metrics oscillate (a bug to fix, not a state to paper over). A real frame draw (draw2D
         // present) keeps a single pass, preserving its next-frame correction.
         const maxPasses = draw2D === undefined && layoutChildren.length ? LayoutGroup.MAX_LAYOUT_PASSES : 1;
+        // Each inner pass ends with nodeRenderingDone → updateParentRects, unioning this group's
+        // rect into its PARENT — whose rects are reset once per ITS pass, not per inner pass here.
+        // Without restoring them between passes, a converging layout leaves the union of every
+        // intermediate position in the parent (e.g. a centered child's pre-center span ∪ its
+        // centered span — a 55-tall child reporting 82.5). Snapshot before the loop and restore
+        // before each retry so only the final, converged pass's union survives.
+        const parentGroup = this.parent instanceof Group ? this.parent : undefined;
+        const savedParentRects = parentGroup
+            ? {
+                  local: { ...parentGroup.rectLocal },
+                  toParent: { ...parentGroup.rectToParent },
+                  toScene: { ...parentGroup.rectToScene },
+              }
+            : undefined;
         this.lastPassCount = 0;
         for (let pass = 0; pass < maxPasses; pass++) {
+            if (pass > 0 && parentGroup && savedParentRects) {
+                parentGroup.rectLocal = { ...savedParentRects.local };
+                parentGroup.rectToParent = { ...savedParentRects.toParent };
+                parentGroup.rectToScene = { ...savedParentRects.toScene };
+            }
             this.lastPassCount = pass + 1;
             this.metricsUsedThisPass = undefined;
             if (layoutChildren.length && this.layoutDirty) {

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -32,6 +32,10 @@ export class LayoutGroup extends Group {
         { name: "addItemSpacingAfterChild", type: "boolean", value: "true" },
     ];
 
+    /** Divergence backstop for the layout-pass convergence loop; never reached by settling layouts. */
+    private static readonly MAX_LAYOUT_PASSES = 8;
+    /** @internal Passes the last layout call ran; exposed for convergence tests. */
+    lastPassCount = 0;
     private layoutDirty = true;
     private metricsUsedThisPass?: WeakMap<Node, LayoutMetrics>;
     private readonly childSizes = new WeakMap<Node, NodeSize>();
@@ -123,15 +127,21 @@ export class LayoutGroup extends Group {
 
         const addAfter = this.shouldAddSpacingAfterChild();
 
-        // On a measurement pass (no draw target — getBoundingRect's full-tree refresh and its
-        // single-subtree fallback both render with draw2D undefined), converge the layout in this one
-        // pass instead of deferring to the next frame. When a child's settled size differs from what
-        // applyLayout used (a wrapped Label laid out at a shorter height then rendered taller shifts
-        // its siblings), synchronizeChildMetrics re-dirties the layout; a one-shot boundingRect() query
-        // would otherwise read the pre-convergence size. A real frame draw (draw2D present) keeps
-        // maxPasses = 1, preserving its next-frame correction. Capped at 2 to terminate.
-        const maxPasses = draw2D === undefined && layoutChildren.length ? 2 : 1;
+        // On a layout/measurement pass (no draw target — getBoundingRect's full-tree refresh and
+        // its single-subtree fallback both render with draw2D undefined), converge the layout to a
+        // FIXED POINT in this one call instead of deferring to the next frame. When a child's
+        // settled size differs from what applyLayout used (a wrapped Label laid out at a shorter
+        // height then rendered taller shifts its siblings), synchronizeChildMetrics re-dirties the
+        // layout and the loop runs another pass; it exits only once a pass leaves the layout clean,
+        // so a one-shot boundingRect() query never reads a pre-convergence size. The former cap of
+        // 2 could exit while still dirty, returning rects that kept creeping on later refreshes.
+        // MAX_LAYOUT_PASSES is a divergence backstop, not the terminator — hitting it means child
+        // metrics oscillate (a bug to fix, not a state to paper over). A real frame draw (draw2D
+        // present) keeps a single pass, preserving its next-frame correction.
+        const maxPasses = draw2D === undefined && layoutChildren.length ? LayoutGroup.MAX_LAYOUT_PASSES : 1;
+        this.lastPassCount = 0;
         for (let pass = 0; pass < maxPasses; pass++) {
+            this.lastPassCount = pass + 1;
             this.metricsUsedThisPass = undefined;
             if (layoutChildren.length && this.layoutDirty) {
                 this.measureUnsizedChildren(layoutChildren, interpreter);

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -205,6 +205,10 @@ export class LayoutGroup extends Group {
                     child.rectToParent.width > 0 || child.rectToScene.width > 0 || child.rectLocal.width > 0;
                 if (!rectKnown && !(typeof dims.width === "number" && dims.width > 0)) {
                     child.layoutNode(interpreter, [0, 0], 0, 1);
+                    // The [0,0] measurement clobbered the subtree's rectToScene with origin-less
+                    // values; deep-mark it so the surrounding pruned refresh re-descends and
+                    // re-establishes in-tree rects instead of skipping the settled subtree.
+                    child.markSubtreeStaleDeep();
                 }
             }
         } finally {

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -167,7 +167,7 @@ export class LayoutGroup extends Group {
             const dims = child.getDimensions();
             const rectKnown = child.rectToParent.width > 0 || child.rectToScene.width > 0 || child.rectLocal.width > 0;
             if (!rectKnown && !(typeof dims.width === "number" && dims.width > 0)) {
-                child.renderNode(interpreter, [0, 0], 0, 1);
+                child.layoutNode(interpreter, [0, 0], 0, 1);
             }
         }
     }

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -2,6 +2,7 @@ import { AAMember, Interpreter, BrsBoolean, BrsType, Float, RoArray, IfDraw2D, R
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { jsValueOf } from "../factory/Serializer";
+import { sgRoot } from "../SGRoot";
 import { Group } from "./Group";
 import { Node } from "./Node";
 
@@ -173,12 +174,22 @@ export class LayoutGroup extends Group {
      * Posters, already-laid-out nodes) are skipped, so this is a no-op in the common case.
      */
     private measureUnsizedChildren(children: Group[], interpreter: Interpreter) {
-        for (const child of children) {
-            const dims = child.getDimensions();
-            const rectKnown = child.rectToParent.width > 0 || child.rectToScene.width > 0 || child.rectLocal.width > 0;
-            if (!rectKnown && !(typeof dims.width === "number" && dims.width > 0)) {
-                child.layoutNode(interpreter, [0, 0], 0, 1);
+        // Never prune this scoped measurement: it runs at origin [0,0] regardless of the child's
+        // tree position, so cached last-layout contexts do not apply — a skip here would also
+        // union the child's cached rect into this group's just-reset rects at the wrong moment.
+        const wasPruning = sgRoot.pruneLayout;
+        sgRoot.pruneLayout = false;
+        try {
+            for (const child of children) {
+                const dims = child.getDimensions();
+                const rectKnown =
+                    child.rectToParent.width > 0 || child.rectToScene.width > 0 || child.rectLocal.width > 0;
+                if (!rectKnown && !(typeof dims.width === "number" && dims.width > 0)) {
+                    child.layoutNode(interpreter, [0, 0], 0, 1);
+                }
             }
+        } finally {
+            sgRoot.pruneLayout = wasPruning;
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -2110,10 +2110,11 @@ export class Node extends RoSGNode implements BrsValue {
      * chain above it still is — an early exit would strand the write in a skipped subtree.
      */
     markSubtreeStale() {
-        let node: Node | undefined = this;
-        while (node) {
-            node.subtreeStale = true;
-            node = node.parent instanceof Node ? node.parent : undefined;
+        this.subtreeStale = true;
+        let ancestor = this.parent instanceof Node ? this.parent : undefined;
+        while (ancestor) {
+            ancestor.subtreeStale = true;
+            ancestor = ancestor.parent instanceof Node ? ancestor.parent : undefined;
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -49,6 +49,7 @@ import { createFlatNode, createNode, getBrsValueFromFieldType, subtypeHierarchy 
 import { Field } from "../nodes/Field";
 import { toAssociativeArray, jsValueOf, fromSGNode } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
+import { runPruneVerify } from "../SGVerify";
 import { SGNodeType } from ".";
 import { ComponentDefinition } from "../parser/ComponentDefinition";
 import { convertHexColor } from "../SGUtil";
@@ -117,6 +118,15 @@ export class Node extends RoSGNode implements BrsValue {
     protected address: string;
     /** Flags whether structural or field state changed since last render. */
     changed: boolean = false;
+    /**
+     * True when this node or anything below it changed since its subtree last completed a layout
+     * pass. Set by `makeDirty()` (the funnel for every field write and child-list mutation) and
+     * propagated UP the parent chain, so a pruned layout refresh (`sgRoot.pruneLayout`) can skip
+     * settled subtrees. Cleared at the START of a node's layout pass — BrightScript running
+     * inside the pass (an item component's init(), a field observer) re-marks it and that mark
+     * must survive for the next refresh. Starts true so everything lays out on first pass.
+     */
+    subtreeStale: boolean = true;
 
     /** Node bounds in local coordinates. */
     rectLocal: Rect = { x: 0, y: 0, width: 0, height: 0 };
@@ -1021,7 +1031,18 @@ export class Node extends RoSGNode implements BrsValue {
         const root = this.createPath()[0];
         sgRoot.rendering = true;
         try {
-            root.layoutNode(interpreter, [0, 0], 0, 1);
+            if (sgRoot.pruneVerify) {
+                runPruneVerify(root, interpreter);
+            } else {
+                // Prune settled subtrees (sound because layout passes are pure). Only this
+                // full-tree refresh prunes — scoped subtree measurements never do.
+                sgRoot.pruneLayout = !sgRoot.pruneDisabled;
+                try {
+                    root.layoutNode(interpreter, [0, 0], 0, 1);
+                } finally {
+                    sgRoot.pruneLayout = false;
+                }
+            }
         } finally {
             sgRoot.rendering = false;
         }
@@ -1078,10 +1099,16 @@ export class Node extends RoSGNode implements BrsValue {
             const savedToParent = parent ? { ...parent.rectToParent } : undefined;
             const savedToScene = parent ? { ...parent.rectToScene } : undefined;
             sgRoot.measuring = true;
+            // A scoped subtree measurement never prunes (it can run nested inside a pruned
+            // full-tree refresh — e.g. item creation measuring a label): it measures at origin
+            // [0,0], so cached last-layout contexts from tree positions do not apply.
+            const wasPruning = sgRoot.pruneLayout;
+            sgRoot.pruneLayout = false;
             try {
                 this.layoutNode(interpreter, [0, 0], 0, 1);
             } finally {
                 sgRoot.measuring = false;
+                sgRoot.pruneLayout = wasPruning;
                 if (parent && savedLocal && savedToParent && savedToScene) {
                     parent.rectLocal = savedLocal;
                     parent.rectToParent = savedToParent;
@@ -2066,11 +2093,28 @@ export class Node extends RoSGNode implements BrsValue {
      */
     protected makeDirty() {
         this.changed = true;
+        this.markSubtreeStale();
         if (sgRoot.inTaskThread() && this.parent instanceof Node) {
             const root = this.findRootNode();
             root.changed = true;
         }
         sgRoot.makeDirty();
+    }
+
+    /**
+     * Marks this node and every ancestor stale for the pruned layout refresh. Walks the FULL
+     * parent chain (O(depth), trivial next to the cost of the setValue that got us here) rather
+     * than early-exiting at the first stale ancestor: a node whose own pass never runs (a
+     * hard-skipped invisible leaf, an off-screen grid item) keeps its stale mark while its
+     * ancestors' marks are cleared by their passes, so "this node is stale" does not imply the
+     * chain above it still is — an early exit would strand the write in a skipped subtree.
+     */
+    markSubtreeStale() {
+        let node: Node | undefined = this;
+        while (node) {
+            node.subtreeStale = true;
+            node = node.parent instanceof Node ? node.parent : undefined;
+        }
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1114,6 +1114,10 @@ export class Node extends RoSGNode implements BrsValue {
                     parent.rectToParent = savedToParent;
                     parent.rectToScene = savedToScene;
                 }
+                // The [0,0] measurement clobbered this subtree's rectToScene with origin-less
+                // values; deep-mark it so the next pruned refresh re-descends and re-establishes
+                // in-tree rects instead of skipping the settled subtree.
+                this.markSubtreeStaleDeep();
             }
         }
         switch (type) {
@@ -2115,6 +2119,29 @@ export class Node extends RoSGNode implements BrsValue {
         while (ancestor) {
             ancestor.subtreeStale = true;
             ancestor = ancestor.parent instanceof Node ? ancestor.parent : undefined;
+        }
+    }
+
+    /**
+     * Marks this node, every descendant, AND the ancestor chain stale. Required after a scoped
+     * measurement rendered this subtree at origin [0,0] (`measureUnsizedChildren`,
+     * `getBoundingRect`'s mid-render fallback): that pass overwrites every descendant's
+     * `rectToScene` with origin-less values, relying on "the true origin is recomputed when the
+     * next pass reaches the node" — which a pruned refresh would skip. The deep mark forces the
+     * next refresh to re-descend and re-establish in-tree rects; the up-mark makes sure the
+     * refresh actually reaches this subtree.
+     */
+    markSubtreeStaleDeep() {
+        this.markSubtreeStale();
+        const stack: Node[] = [this];
+        while (stack.length > 0) {
+            const node = stack.pop()!;
+            node.subtreeStale = true;
+            for (const child of node.children) {
+                if (child instanceof Node) {
+                    stack.push(child);
+                }
+            }
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -949,6 +949,49 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Layout entry point: computes bounding rects for this node's subtree without drawing,
+     * advancing time-based state, or producing any other side effect. Must be idempotent —
+     * calling it twice with the same inputs and an unchanged tree yields identical rects.
+     * Default implementation runs `renderNode` with no draw target (today's measurement pass)
+     * under a `layout` render-pass context; node types with time-based render state gate that
+     * state on `isPaintPass`. See `docs/scenegraph-layout-passes.md`.
+     */
+    layoutNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number) {
+        const previousPass = sgRoot.renderPass;
+        sgRoot.renderPass = "layout";
+        try {
+            this.renderNode(interpreter, origin, angle, opacity);
+        } finally {
+            sgRoot.renderPass = previousPass;
+        }
+    }
+
+    /**
+     * Paint entry point: the per-frame render. Recomputes layout inline (as `renderNode` always
+     * has), advances time-based state (spinner rotation, marquee scroll, cursor blink, seek
+     * repeat), and draws through the required `IfDraw2D`.
+     */
+    paintNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D: IfDraw2D) {
+        const previousPass = sgRoot.renderPass;
+        sgRoot.renderPass = "paint";
+        try {
+            this.renderNode(interpreter, origin, angle, opacity, draw2D);
+        } finally {
+            sgRoot.renderPass = previousPass;
+        }
+    }
+
+    /**
+     * Whether the current traversal may advance time-based state and emit render side effects.
+     * True on paint passes and on direct `renderNode` calls with a draw target; false inside
+     * `layoutNode` traversals. The `draw2D` check keeps direct `renderNode(..., draw2D)` calls
+     * (external node registrations, tests) behaving as paint regardless of context.
+     */
+    protected isPaintPass(draw2D?: IfDraw2D): boolean {
+        return draw2D !== undefined || sgRoot.renderPass === "paint";
+    }
+
+    /**
      * Iterates through child nodes, invoking their render methods in order.
      * @param interpreter Active interpreter.
      * @param origin Parent-space translation.
@@ -978,7 +1021,7 @@ export class Node extends RoSGNode implements BrsValue {
         const root = this.createPath()[0];
         sgRoot.rendering = true;
         try {
-            root.renderNode(interpreter, [0, 0], 0, 1);
+            root.layoutNode(interpreter, [0, 0], 0, 1);
         } finally {
             sgRoot.rendering = false;
         }
@@ -1036,7 +1079,7 @@ export class Node extends RoSGNode implements BrsValue {
             const savedToScene = parent ? { ...parent.rectToScene } : undefined;
             sgRoot.measuring = true;
             try {
-                this.renderNode(interpreter, [0, 0], 0, 1);
+                this.layoutNode(interpreter, [0, 0], 0, 1);
             } finally {
                 sgRoot.measuring = false;
                 if (parent && savedLocal && savedToParent && savedToScene) {

--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -110,6 +110,50 @@ export class ScrollingLabel extends Label {
         }
     }
 
+    /**
+     * Advances the marquee state machine by the wall-clock time since the last paint. Called only
+     * from paint passes — layout renders the stored state without touching the clock.
+     */
+    private advanceScroll(scrollDistance: number, scrollDuration: number, repeatCount: number) {
+        const now = sgClock.now();
+        const deltaTime = now - this.lastUpdateTime;
+        this.lastUpdateTime = now;
+        this.elapsedTime += deltaTime;
+
+        switch (this.scrollState) {
+            case ScrollState.INITIAL_PAUSE:
+                if (this.elapsedTime >= INITIAL_PAUSE_MS) {
+                    this.scrollState = ScrollState.SCROLLING;
+                    this.elapsedTime = 0;
+                    this.scrollOffset = 0;
+                }
+                break;
+
+            case ScrollState.SCROLLING:
+                this.scrollOffset = Math.min(scrollDistance, (this.elapsedTime / scrollDuration) * scrollDistance);
+                if (this.elapsedTime >= scrollDuration) {
+                    this.scrollState = ScrollState.END_PAUSE;
+                    this.elapsedTime = 0;
+                    this.scrollOffset = scrollDistance; // Ensure it's exactly at the end
+                }
+                break;
+
+            case ScrollState.END_PAUSE:
+                if (this.elapsedTime >= END_PAUSE_MS) {
+                    this.currentRepeat++;
+                    if (repeatCount !== -1 && this.currentRepeat >= repeatCount) {
+                        this.scrollState = ScrollState.FINISHED;
+                    } else {
+                        // Repeat the cycle
+                        this.scrollState = ScrollState.INITIAL_PAUSE;
+                        this.elapsedTime = 0;
+                    }
+                    this.scrollOffset = 0;
+                }
+                break;
+        }
+    }
+
     // Reset scrolling state variables
     private resetScrollingState() {
         this.scrollState = this.needsScrolling ? ScrollState.INITIAL_PAUSE : ScrollState.STATIC;
@@ -131,11 +175,6 @@ export class ScrollingLabel extends Label {
         if (!(drawFont instanceof RoFont)) {
             return { text, width: 0, height: 0, ellipsized: false };
         }
-        const now = sgClock.now();
-        const deltaTime = now - this.lastUpdateTime;
-        this.lastUpdateTime = now;
-        this.elapsedTime += deltaTime;
-
         const scrollSpeed = this.getValueJS("scrollSpeed") as number;
         const repeatCount = this.getValueJS("repeatCount") as number;
         const maxWidth = this.getValueJS("maxWidth") as number;
@@ -148,68 +187,36 @@ export class ScrollingLabel extends Label {
         const color = this.getValueJS("color") as number;
         const vertAlign = this.getValueJS("vertAlign") || "top";
 
+        const scrollDistance = this.fullTextWidth - maxWidth; // How much the text needs to move
+        const scrollDuration = scrollDistance > 0 && scrollSpeed > 0 ? (scrollDistance / scrollSpeed) * 1000 : 0; // ms
+
+        // Advance the marquee only on a paint pass: a layout pass (a bounding-rect refresh) must
+        // be pure and clock-free — it renders the stored scroll position. Consuming the time delta
+        // here used to make measurement frequency change the scroll speed, and the makeDirty from
+        // inside a refresh re-dirtied the scene from a boundingRect() query.
+        if (this.needsScrolling && this.scrollState !== ScrollState.FINISHED && this.isPaintPass(draw2D)) {
+            sgRoot.makeDirty(); // Ensure continuous updates during scrolling
+            this.advanceScroll(scrollDistance, scrollDuration, repeatCount);
+        }
+
+        // Derive what to draw purely from the stored scroll state.
         let textToDraw = text;
         let drawOffset = 0;
         let isEllipsized = false;
-
-        if (this.needsScrolling && this.scrollState !== ScrollState.FINISHED) {
-            sgRoot.makeDirty(); // Ensure continuous updates during scrolling
-            const scrollDistance = this.fullTextWidth - maxWidth; // How much the text needs to move
-            const scrollDuration = scrollDistance > 0 && scrollSpeed > 0 ? (scrollDistance / scrollSpeed) * 1000 : 0; // ms
-
+        if (this.needsScrolling) {
             switch (this.scrollState) {
-                case ScrollState.INITIAL_PAUSE:
+                case ScrollState.SCROLLING:
+                    drawOffset = -this.scrollOffset;
+                    break;
+                case ScrollState.END_PAUSE:
+                    drawOffset = -scrollDistance;
+                    break;
+                default:
+                    // INITIAL_PAUSE and FINISHED show the truncated text at rest.
                     textToDraw = this.truncatedText;
                     isEllipsized = true;
-                    if (this.elapsedTime >= INITIAL_PAUSE_MS) {
-                        this.scrollState = ScrollState.SCROLLING;
-                        this.elapsedTime = 0;
-                    }
-                    break;
-
-                case ScrollState.SCROLLING:
-                    textToDraw = text; // Draw the full text
-                    // Calculate current offset based on elapsed time in this state
-                    this.scrollOffset = Math.min(scrollDistance, (this.elapsedTime / scrollDuration) * scrollDistance);
-                    drawOffset = -this.scrollOffset;
-
-                    if (this.elapsedTime >= scrollDuration) {
-                        this.scrollState = ScrollState.END_PAUSE;
-                        this.elapsedTime = 0;
-                        this.scrollOffset = scrollDistance; // Ensure it's exactly at the end
-                        drawOffset = -this.scrollOffset;
-                    }
-                    break;
-
-                case ScrollState.END_PAUSE:
-                    textToDraw = text; // Keep drawing full text, but fully scrolled
-                    drawOffset = -scrollDistance;
-                    if (this.elapsedTime >= END_PAUSE_MS) {
-                        this.currentRepeat++;
-                        if (repeatCount !== -1 && this.currentRepeat >= repeatCount) {
-                            this.scrollState = ScrollState.FINISHED;
-                            textToDraw = this.truncatedText; // Show truncated at the end
-                            drawOffset = 0;
-                            isEllipsized = true;
-                        } else {
-                            // Repeat the cycle
-                            this.scrollState = ScrollState.INITIAL_PAUSE;
-                            this.elapsedTime = 0;
-                            this.scrollOffset = 0;
-                            textToDraw = this.truncatedText;
-                            drawOffset = 0;
-                            isEllipsized = true;
-                        }
-                    }
                     break;
             }
-        } else if (this.scrollState === ScrollState.FINISHED) {
-            // If finished, just draw the truncated text statically
-            textToDraw = this.truncatedText;
-            isEllipsized = true;
-        } else {
-            // Static case: Text fits or scrolling is disabled/not needed
-            textToDraw = text;
         }
         const clipRect: Rect = { ...rect, height: Math.max(boxHeight, textHeight) };
         let drawX = rect.x + drawOffset;
@@ -234,6 +241,9 @@ export class ScrollingLabel extends Label {
         draw2D?.pushClip(clipRect);
         draw2D?.doDrawRotatedText(textToDraw, drawX, drawY, color, opacity, drawFont, rotation);
         draw2D?.popClip();
+        // Safe on layout passes too (matching the base Label): with the scroll state frozen
+        // during layout, the value derives purely from stored state, and setValue only notifies
+        // on a genuine change — idempotent.
         this.setEllipsized(isEllipsized);
         const measuredWidth = this.needsScrolling ? maxWidth : this.fullTextWidth;
         return {

--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -4,6 +4,7 @@ import { SGNodeType } from ".";
 import { Label } from "./Label";
 import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 
 // Enum to manage the scrolling state
 enum ScrollState {
@@ -43,7 +44,7 @@ export class ScrollingLabel extends Label {
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
 
-        this.lastUpdateTime = Date.now();
+        this.lastUpdateTime = sgClock.now();
         this.checkForScrolling();
     }
 
@@ -115,7 +116,7 @@ export class ScrollingLabel extends Label {
         this.scrollOffset = 0;
         this.elapsedTime = 0;
         this.currentRepeat = 0;
-        this.lastUpdateTime = Date.now();
+        this.lastUpdateTime = sgClock.now();
         this.measured = undefined;
     }
 
@@ -130,7 +131,7 @@ export class ScrollingLabel extends Label {
         if (!(drawFont instanceof RoFont)) {
             return { text, width: 0, height: 0, ellipsized: false };
         }
-        const now = Date.now();
+        const now = sgClock.now();
         const deltaTime = now - this.lastUpdateTime;
         this.lastUpdateTime = now;
         this.elapsedTime += deltaTime;

--- a/src/extensions/scenegraph/nodes/StandardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardDialog.ts
@@ -488,7 +488,11 @@ export class StandardDialog extends Group {
             this.pendingRelayout = false;
             this.layoutStandardDialog();
         }
-        this.setNodeFocus(true);
+        // Claiming focus is a paint-side effect: a layout pass (a bounding-rect refresh that
+        // reaches the dialog) must not move focus.
+        if (this.isPaintPass(draw2D)) {
+            this.setNodeFocus(true);
+        }
         const nodeTrans = this.getTranslation();
         const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
         drawTrans[0] += origin[0];

--- a/src/extensions/scenegraph/nodes/TextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/TextEditBox.ts
@@ -10,6 +10,7 @@ import {
     Int32,
     BrsBoolean,
 } from "brs-engine";
+import { sgClock } from "../SGClock";
 import { FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
@@ -93,7 +94,7 @@ export class TextEditBox extends Group {
         this.hintLabel.setValueSilent("color", new Int32(convertHexColor("0xAAAAAAFF")));
         this.linkField(this.hintLabel, "color", "hintTextColor");
 
-        this.lastCursorToggleTime = Date.now();
+        this.lastCursorToggleTime = sgClock.now();
     }
 
     private configureLabel(label: Label) {
@@ -125,7 +126,7 @@ export class TextEditBox extends Group {
                 position++;
                 this.setValue("text", new BrsString(text));
                 this.setValue("cursorPosition", new Float(position));
-                this.lastCharInputTime = Date.now();
+                this.lastCharInputTime = sgClock.now();
                 handled = true;
             }
         } else if (key === "replay") {
@@ -141,7 +142,7 @@ export class TextEditBox extends Group {
         // Reset cursor blink on key press
         if (handled) {
             this.cursorVisible = true;
-            this.lastCursorToggleTime = Date.now();
+            this.lastCursorToggleTime = sgClock.now();
         }
         return handled;
     }
@@ -169,7 +170,7 @@ export class TextEditBox extends Group {
         this.setValue("cursorPosition", new Float(position));
         // Reset cursor blink on move
         this.cursorVisible = true;
-        this.lastCursorToggleTime = Date.now();
+        this.lastCursorToggleTime = sgClock.now();
     }
 
     renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
@@ -186,7 +187,7 @@ export class TextEditBox extends Group {
         const combinedOpacity = opacity * this.getOpacity();
         const text = this.getValueJS("text") as string;
         const secureMode = this.getValueJS("secureMode") as boolean;
-        const now = Date.now(); // Get current time for checks
+        const now = sgClock.now(); // Get current time for checks
 
         // Ensure labels have correct width if TextEditBox width changes
         // And update background if URI changes

--- a/src/extensions/scenegraph/nodes/TextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/TextEditBox.ts
@@ -39,6 +39,8 @@ export class TextEditBox extends Group {
     private cursorVisible: boolean = true;
     private lastCursorToggleTime: number = 0;
     private lastCharInputTime: number = 0;
+    /** Clock captured on the last paint pass; layout passes reuse it instead of reading the clock. */
+    private lastPaintNow: number = 0;
     private readonly cursor?: RoBitmap;
     private readonly textLabel: Label;
     private readonly secureLabel: Label;
@@ -187,7 +189,13 @@ export class TextEditBox extends Group {
         const combinedOpacity = opacity * this.getOpacity();
         const text = this.getValueJS("text") as string;
         const secureMode = this.getValueJS("secureMode") as boolean;
-        const now = sgClock.now(); // Get current time for checks
+        // Read the clock only on a paint pass; a layout pass reuses the last paint's timestamp so
+        // its output (secure-char reveal, cursor phase) is identical between frames — layout must
+        // be pure and clock-free.
+        if (this.isPaintPass(draw2D)) {
+            this.lastPaintNow = sgClock.now();
+        }
+        const now = this.lastPaintNow;
 
         // Ensure labels have correct width if TextEditBox width changes
         // And update background if URI changes
@@ -259,7 +267,8 @@ export class TextEditBox extends Group {
         if (!isActive || !this.cursor?.isValid()) {
             return;
         }
-        if (now - this.lastCursorToggleTime > this.cursorBlinkInterval) {
+        // Flip the blink phase only on a paint pass — layout renders the stored phase.
+        if (this.isPaintPass(draw2D) && now - this.lastCursorToggleTime > this.cursorBlinkInterval) {
             this.cursorVisible = !this.cursorVisible;
             this.lastCursorToggleTime = now;
         }

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -16,6 +16,7 @@ import { ArrayGrid } from "./ArrayGrid";
 import { ContentNode } from "./ContentNode";
 import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 
 /** Cached parse of one channel's programs (see TimeGrid.channelParseCache). */
@@ -336,7 +337,7 @@ export class TimeGrid extends ArrayGrid {
     }
 
     protected nowEpoch(): number {
-        return Math.floor(Date.now() / 1000);
+        return Math.floor(sgClock.now() / 1000);
     }
 
     protected getDurationSec(): number {

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -155,6 +155,8 @@ export class TimeGrid extends ArrayGrid {
     protected gridX: number = 0;
     protected gridWidth: number = 0;
     protected rowHeight: number = 0;
+    /** "Now" epoch captured on the last paint pass; layout passes reuse it (clock-free layout). */
+    private cachedNowEpoch: number = 0;
     protected visibleChannels: number = 0;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TimeGrid) {
@@ -720,7 +722,13 @@ export class TimeGrid extends ArrayGrid {
         const secToPx = this.gridWidth / duration;
         this.updateTopRow();
         const topCh = this.topRow;
-        const now = this.nowEpoch();
+        // The "now" marker position is refreshed only on paint passes (or the first layout before
+        // any paint); a layout pass reuses the cached epoch so repeated bounding-rect refreshes
+        // are idempotent — layout must be clock-free.
+        if (this.isPaintPass(draw2D) || this.cachedNowEpoch === 0) {
+            this.cachedNowEpoch = this.nowEpoch();
+        }
+        const now = this.cachedNowEpoch;
         const center = this.getScaleRotateCenter();
         const nodeFocus = sgRoot.focused === this;
         let textIndex = 0;

--- a/src/extensions/scenegraph/nodes/Timer.ts
+++ b/src/extensions/scenegraph/nodes/Timer.ts
@@ -1,6 +1,7 @@
 import { AAMember, BrsInvalid, BrsString, BrsType, isBrsString } from "brs-engine";
 import { Node } from "./Node";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 
@@ -34,7 +35,7 @@ export class Timer extends Node {
         if (field && mapKey === "control" && isBrsString(value)) {
             let control = value.getValue().toLowerCase();
             if (control === "start") {
-                this.lastFireTime = performance.now();
+                this.lastFireTime = sgClock.perfNow();
                 this.active = true;
             } else if (control === "stop") {
                 this.active = false;
@@ -53,7 +54,7 @@ export class Timer extends Node {
     }
 
     checkFire() {
-        const now = performance.now();
+        const now = sgClock.perfNow();
         const duration = this.getValueJS("duration") as number;
         const repeat = this.getValueJS("repeat") as boolean;
         if (this.active && (now - this.lastFireTime) / 1000 >= duration) {

--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -28,6 +28,8 @@ export class TrickPlayBar extends Group {
     private readonly bmpIcons: Map<string, RoBitmap>;
     private stateIcon: RoBitmap | undefined;
     private stateIconTimeout: number = -1;
+    /** Clock captured on the last paint pass; layout passes reuse it instead of reading the clock. */
+    private lastPaintNow: number = 0;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TrickPlayBar) {
         super([], name);
@@ -152,7 +154,12 @@ export class TrickPlayBar extends Group {
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(rect, origin, angle);
         this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
-        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > sgClock.now())) {
+        // Check the icon expiry against the clock only on a paint pass; a layout pass reuses the
+        // last paint's timestamp so the icon cannot flip mid-refresh (layout must be clock-free).
+        if (this.isPaintPass(draw2D)) {
+            this.lastPaintNow = sgClock.now();
+        }
+        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > this.lastPaintNow)) {
             const iconRect = {
                 x: rect.x + (size.width - this.stateIcon.width) / 2,
                 y: rect.y + this.barH,

--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -5,6 +5,7 @@ import { Label } from "./Label";
 import { Poster } from "./Poster";
 import { Group } from "./Group";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 
 export class TrickPlayBar extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -133,7 +134,7 @@ export class TrickPlayBar extends Group {
         }
         this.stateIcon = this.bmpIcons.get(iconName);
         if (this.stateIcon) {
-            this.stateIconTimeout = timeout > 0 ? Date.now() + timeout : -1;
+            this.stateIconTimeout = timeout > 0 ? sgClock.now() + timeout : -1;
         }
     }
 
@@ -151,7 +152,7 @@ export class TrickPlayBar extends Group {
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(rect, origin, angle);
         this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
-        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > Date.now())) {
+        if (this.stateIcon && (this.stateIconTimeout === -1 || this.stateIconTimeout > sgClock.now())) {
             const iconRect = {
                 x: rect.x + (size.width - this.stateIcon.width) / 2,
                 y: rect.y + this.barH,

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -801,8 +801,20 @@ export class Video extends Group {
         const presenting =
             owner && (state === "playing" || state === "paused" || (state === "buffering" && this.hasPresented));
         const buffering = owner && state === "buffering" && !this.hasPresented && this.uiVisible();
-        if (this.isDirty && presenting) {
-            postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
+        // The video-plane rect postMessage, the ff/rw seek auto-repeat, and showUI's child field
+        // writes are paint-only: a layout pass (a bounding-rect refresh) must be pure — it would
+        // otherwise spam the host with rect messages and advance seek state per measurement.
+        if (this.isPaintPass(draw2D)) {
+            if (this.isDirty && presenting) {
+                postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
+            }
+            if (this.statusChanged) {
+                if (this.seekTimeout > 0 && this.seekTimeout < sgClock.now() && ["rw", "ff"].includes(this.seekMode)) {
+                    const duration = this.getValueJS("duration") as number;
+                    this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
+                }
+                this.showUI(this.uiVisible());
+            }
         }
         if (draw2D) {
             this.isDirty = false;
@@ -811,13 +823,6 @@ export class Video extends Group {
             } else if (buffering) {
                 draw2D.doDrawRotatedRect(rect, 0x000000ff, 0, [0, 0], opacity);
             }
-        }
-        if (this.statusChanged) {
-            if (this.seekTimeout > 0 && this.seekTimeout < sgClock.now() && ["rw", "ff"].includes(this.seekMode)) {
-                const duration = this.getValueJS("duration") as number;
-                this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
-            }
-            this.showUI(this.uiVisible());
         }
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -29,6 +29,7 @@ import {
 } from "brs-engine";
 import { fromAssociativeArray, toAssociativeArray, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { BusySpinner } from "./BusySpinner";
 import { ContentNode } from "./ContentNode";
 import { Label } from "./Label";
@@ -350,7 +351,7 @@ export class Video extends Group {
     }
 
     setState(eventType: number, eventIndex: number) {
-        const now = Date.now();
+        const now = sgClock.now();
         this.statusChanged = true;
         let state = "none";
         switch (eventType) {
@@ -615,7 +616,7 @@ export class Video extends Group {
             this.showPaused = 0;
             this.showTrickPlay = 0;
         }
-        const now = Date.now();
+        const now = sgClock.now();
         this.backgroundOverlay.setValueSilent("visible", BrsBoolean.from(this.showHeader > now));
         this.titleText.setValue("visible", BrsBoolean.from(this.showHeader > now));
         this.clockText.setValueSilent("visible", BrsBoolean.from(this.showHeader > now));
@@ -648,7 +649,7 @@ export class Video extends Group {
                 handled = true;
             }
         } else if (key === "OK" && this.enableTrickPlay) {
-            const now = Date.now();
+            const now = sgClock.now();
             if (this.showHeader < now) {
                 this.showHeader = now + 5000;
                 handled = true;
@@ -666,7 +667,7 @@ export class Video extends Group {
             if (state === "playing") {
                 const position = this.getValueJS("position") as number;
                 if (position > 0) {
-                    const now = Date.now();
+                    const now = sgClock.now();
                     postMessage(`video,seek,${Math.max(0, position - 20) * 1000}`);
                     this.showHeader = now + 1000;
                     this.showTrickPlay = now + 1000;
@@ -741,7 +742,7 @@ export class Video extends Group {
     }
 
     private updateSeekStep(forward: boolean, duration: number, timeout = 0) {
-        const now = Date.now();
+        const now = sgClock.now();
         const baseStep = Math.min(10, Math.max(1, Math.trunc(duration / 30)));
         const step = baseStep * Math.max(1, this.seekLevel * 3 - 3);
         this.showHeader = now + 30000;
@@ -812,7 +813,7 @@ export class Video extends Group {
             }
         }
         if (this.statusChanged) {
-            if (this.seekTimeout > 0 && this.seekTimeout < Date.now() && ["rw", "ff"].includes(this.seekMode)) {
+            if (this.seekTimeout > 0 && this.seekTimeout < sgClock.now() && ["rw", "ff"].includes(this.seekMode)) {
                 const duration = this.getValueJS("duration") as number;
                 this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
             }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -965,6 +965,30 @@ describe.concurrent("cli", () => {
             "",
         ]);
     }, 30000);
+    it("Builds the layout-pass performance probe (70 self-measuring components)", async () => {
+        let command = ["node", brsCliPath, "-r layout-perf-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+
+        // Committed form of the synthetic probe from docs/scenegraph-layout-passes.md: 70 custom
+        // components in a LayoutGroup, each measuring itself with boundingRect() from its `value`
+        // observer, so every append triggers a full-tree layout refresh. Only correctness is
+        // asserted (the layout height proves all 70 tiles laid out and stacked); the per-tile
+        // timings it prints are for the human device-shape comparison — flat per-component cost —
+        // and would be flaky as assertions. Height: 70 tiles * 60 + 69 gaps * 8 = 4752.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Layout Perf Probe ===");
+        expect(lines).toContain("tiles =  70");
+        // 70 tiles, each 60 (background) + label rows overflow = stacked LayoutGroup height;
+        // proves all 70 laid out. Kept exact so tile-content changes are deliberate.
+        expect(lines).toContain("layout height =  15532");
+        expect(lines).toContain("=== Layout Perf Probe Complete ===");
+        for (const marker of ["q1 tile ms = ", "q2 tile ms = ", "q3 tile ms = ", "q4 tile ms = ", "total ms = "]) {
+            expect(lines.some((line) => line.startsWith(marker))).toBe(true);
+        }
+    }, 60000);
     it("Resolves a component method in call position when an XML field shadows its name", async () => {
         let command = ["node", brsCliPath, "-r method-shadow-field-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -989,6 +989,21 @@ describe.concurrent("cli", () => {
             expect(lines.some((line) => line.startsWith(marker))).toBe(true);
         }
     }, 60000);
+    it("Pruned layout refreshes agree with full refreshes (BRS_PRUNE_VERIFY silent)", async () => {
+        // The rect-diff verifier runs every bounding-rect refresh twice — pruned then unpruned —
+        // and prints a [prune-verify] line for any diverging node. Silence across both apps'
+        // refresh-heavy workloads (70 self-measuring components; re-entrant grid item creation)
+        // proves the pruned pass computes the same rects as a full pass.
+        for (const app of ["layout-perf-app", "grid-measure-app"]) {
+            let command = ["node", brsCliPath, `-r ${app}`, "source/main.brs", "-c 0"].join(" ");
+            let { stderr } = await exec(command, {
+                cwd: path.join(__dirname, "resources"),
+                env: { ...process.env, BRS_PRUNE_VERIFY: "1" },
+            });
+            const verifyLines = stderr.split("\n").filter((line) => line.includes("[prune-verify]"));
+            expect(verifyLines).toEqual([]);
+        }
+    }, 120000);
     it("Resolves a component method in call position when an XML field shadows its name", async () => {
         let command = ["node", brsCliPath, "-r method-shadow-field-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/layout-perf-app/components/PerfTile.xml
+++ b/test/cli/resources/layout-perf-app/components/PerfTile.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Synthetic probe component for the layout-pass performance fixture
+    (docs/scenegraph-layout-passes.md). Its `value` observer measures the component with
+    boundingRect() — the ordinary app pattern (e.g. sizing a focus ring from a field change)
+    that makes every component creation trigger a full-tree layout refresh. With N components
+    in a LayoutGroup, a screen build is O(n²) unless the refresh prunes settled subtrees.
+-->
+<component name="PerfTile" extends="Group">
+    <interface>
+        <field id="value" type="string" alwaysNotify="true" />
+        <field id="measuredHeight" type="float" />
+    </interface>
+    <script type="text/brightscript">
+    <![CDATA[
+        sub init()
+            m.background = m.top.createChild("Rectangle")
+            m.background.width = 438
+            m.background.height = 60
+            ' An inner LayoutGroup with several labels gives each tile a realistic node count
+            ' (real app components average dozens of nodes), so a full-tree refresh has
+            ' measurable per-tile cost and the quadratic rise is visible in the timings.
+            m.rows = m.top.createChild("LayoutGroup")
+            m.rows.layoutDirection = "vert"
+            m.rows.itemSpacings = [2]
+            m.rows.translation = [12, 8]
+            for r = 1 to 8
+                row = m.rows.createChild("Label")
+                row.width = 400
+            end for
+            m.label = m.rows.getChild(0)
+            m.top.observeFieldScoped("value", "onValueChange")
+        end sub
+
+        sub onValueChange()
+            m.label.text = m.top.value
+            rect = m.top.boundingRect()
+            m.top.measuredHeight = rect.height
+        end sub
+    ]]>
+    </script>
+</component>

--- a/test/cli/resources/layout-perf-app/manifest
+++ b/test/cli/resources/layout-perf-app/manifest
@@ -1,0 +1,4 @@
+title=Layout Perf Probe
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/layout-perf-app/source/main.brs
+++ b/test/cli/resources/layout-perf-app/source/main.brs
@@ -1,0 +1,42 @@
+' Layout-pass performance probe (docs/scenegraph-layout-passes.md): appends N custom
+' components into a LayoutGroup; each component's `value` observer measures itself with
+' boundingRect(), so every append triggers a full-tree layout refresh. On an engine with
+' incremental (pruned) layout the per-component cost is flat, like a device; without
+' pruning it rises linearly and the build is O(n²) overall.
+sub Main()
+    print "=== Layout Perf Probe ==="
+    tileCount = 70
+
+    layout = CreateObject("roSGNode", "LayoutGroup")
+    layout.layoutDirection = "vert"
+    layout.itemSpacings = [8]
+
+    clock = CreateObject("roTimespan")
+    total = CreateObject("roTimespan")
+    timings = []
+    total.mark()
+    for i = 1 to tileCount
+        clock.mark()
+        tile = CreateObject("roSGNode", "PerfTile")
+        layout.appendChild(tile)
+        ' Set `value` after attach so the observer's boundingRect() refresh walks the whole
+        ' (growing) tree from the root — the O(tree)-per-component pattern the probe exists
+        ' to measure. Set before attach it would only measure the orphan tile.
+        tile.value = "tile " + i.toStr()
+        timings.push(clock.totalMilliseconds())
+    end for
+    totalMs = total.totalMilliseconds()
+
+    rect = layout.boundingRect()
+    print "tiles = "; tileCount
+    print "layout height = "; rect.height
+    ' Quartile samples instead of first/last: tile 1 is inflated by font-load/JIT warmup.
+    ' Flat q1..q4 = device shape (incremental layout); rising = quadratic full refreshes.
+    q = int(tileCount / 4)
+    print "q1 tile ms = "; timings[q - 1]
+    print "q2 tile ms = "; timings[2 * q - 1]
+    print "q3 tile ms = "; timings[3 * q - 1]
+    print "q4 tile ms = "; timings[tileCount - 1]
+    print "total ms = "; totalMs
+    print "=== Layout Perf Probe Complete ==="
+end sub

--- a/test/extensions/scenegraph/BusySpinnerClock.test.js
+++ b/test/extensions/scenegraph/BusySpinnerClock.test.js
@@ -1,0 +1,67 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsString, Interpreter } = core;
+
+/**
+ * BusySpinner advances its rotation only on paint passes, by the paint-to-paint time delta —
+ * layout passes (bounding-rect refreshes) render the stored rotation without consuming time.
+ * Before the layout/paint split a measurement pass both advanced the spin (making measurement
+ * frequency change the spin speed) and re-dirtied the scene via the poster field write.
+ */
+describe("BusySpinner clock behavior across pass kinds", () => {
+    let interpreter;
+    let fakeNow;
+    const draw2D = { doDrawRotatedBitmap: () => {}, doDrawRotatedRect: () => {} };
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        fakeNow = 50_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+    });
+
+    function buildSpinner() {
+        const group = SGNodeFactory.createNode("Group");
+        const spinner = SGNodeFactory.createNode("BusySpinner");
+        group.appendChildToParent(spinner);
+        spinner.setValue("control", new BrsString("start"));
+        return { group, spinner, poster: spinner.getValue("poster") };
+    }
+
+    test("rotation advances only on paint, by the paint-to-paint delta", () => {
+        const { group, poster } = buildSpinner();
+
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        const start = poster.getValueJS("rotation");
+
+        // Interleave layout passes across 1s of clock: no advancement.
+        fakeNow += 400;
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+        fakeNow += 600;
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(poster.getValueJS("rotation")).toBe(start);
+
+        // The next paint advances by the FULL elapsed second (spinInterval default 2s =>
+        // half a revolution) — the interleaved layouts did not eat the delta.
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        const advanced = poster.getValueJS("rotation");
+        expect(Math.abs(advanced - start)).toBeCloseTo(Math.PI, 5);
+    });
+
+    test("layout passes do not re-dirty the scene from the spin", () => {
+        const { group } = buildSpinner();
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        sgRoot.clearDirty();
+        fakeNow += 300;
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.isDirty).toBe(false);
+    });
+});

--- a/test/extensions/scenegraph/ClockSource.test.js
+++ b/test/extensions/scenegraph/ClockSource.test.js
@@ -1,0 +1,67 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgClock } = scenegraph;
+const { BrsString, Float, RoArray } = core;
+
+const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
+
+/**
+ * The SceneGraph clock is injectable (SGClock.ts): time-driven state reads `sgClock` instead of
+ * `Date.now()`/`performance.now()` so tests can substitute a deterministic source through the
+ * built bundle. This also pins the animation-timing property the layout/paint split relies on:
+ * animations advance in `tick()` (driven by the frame loop via sgRoot.processAnimations), NOT
+ * inside renderNode — see docs/scenegraph-layout-passes.md.
+ */
+describe("sgClock injectable time source", () => {
+    afterEach(() => {
+        sgClock.setSource();
+    });
+
+    test("AnimationBase.tick interpolates against the injected clock", () => {
+        let fakeNow = 10_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("id", new BrsString("target"));
+        poster.setValue("opacity", new Float(0));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(2)); // seconds
+        const interp = SGNodeFactory.createNode("FloatFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("target.opacity"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", floatArray([0.0, 1.0]));
+        animation.appendChildToParent(interp);
+        poster.appendChildToParent(animation);
+
+        // Linear easing so the eased fraction equals the raw fraction at the midpoint.
+        animation.setValue("easeFunction", new BrsString("linear"));
+        animation.setValue("control", new BrsString("start"));
+
+        // Fraction 0: no time has passed.
+        animation.tick();
+        expect(poster.getValueJS("opacity")).toBeCloseTo(0, 5);
+
+        // Fraction 0.5: half the 2s duration.
+        fakeNow += 1000;
+        animation.tick();
+        expect(poster.getValueJS("opacity")).toBeCloseTo(0.5, 5);
+
+        // Fraction 1: full duration reached; the animation stops at the end value.
+        fakeNow += 1000;
+        animation.tick();
+        expect(poster.getValueJS("opacity")).toBeCloseTo(1, 5);
+        expect(animation.getValueJS("state")).toBe("stopped");
+    });
+
+    test("setSource() with no argument restores the real clock", () => {
+        sgClock.setSource({ now: () => 42, perfNow: () => 42 });
+        expect(sgClock.now()).toBe(42);
+
+        sgClock.setSource();
+
+        const realNow = Date.now();
+        expect(Math.abs(sgClock.now() - realNow)).toBeLessThan(1000);
+    });
+});

--- a/test/extensions/scenegraph/LayoutConvergence.test.js
+++ b/test/extensions/scenegraph/LayoutConvergence.test.js
@@ -1,0 +1,141 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, BrsBoolean, Float, RoArray, Interpreter } = core;
+
+/**
+ * LayoutGroup converges to a fixed point within a single layout pass
+ * (docs/scenegraph-layout-passes.md, "Make container convergence explicit"): after one
+ * layoutNode call, further calls must change NOTHING — exact equality, not epsilon. The former
+ * hard cap of 2 inner passes could exit while the layout was still dirty, so rects kept creeping
+ * asymptotically across refreshes (observed 659 → 631 → 629 in a real app).
+ */
+describe("LayoutGroup layout-pass convergence", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    const vector = (vals) => new RoArray(vals.map((v) => new Float(v)));
+
+    function snapshotTree(node, out = []) {
+        out.push({ ...node.rectLocal }, { ...node.rectToParent }, { ...node.rectToScene });
+        for (const child of node.getNodeChildren()) {
+            snapshotTree(child, out);
+        }
+        return out;
+    }
+
+    /** 4-level LayoutGroup nest, each level with a sibling Rectangle, deepest holds a wrapped Label. */
+    function buildDeepNest() {
+        const scene = SGNodeFactory.createNode("Scene");
+        let parent = scene;
+        const groups = [];
+        for (let d = 0; d < 4; d++) {
+            const g = SGNodeFactory.createNode("LayoutGroup");
+            g.setValue("layoutDirection", new BrsString("vert"));
+            g.setValue("itemSpacings", vector([4]));
+            const sib = SGNodeFactory.createNode("Rectangle");
+            sib.setValue("width", new Float(100));
+            sib.setValue("height", new Float(20));
+            g.appendChildToParent(sib);
+            parent.appendChildToParent(g);
+            groups.push(g);
+            parent = g;
+        }
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("wrap", BrsBoolean.True);
+        label.setValue("width", new Float(200));
+        label.setValue("text", new BrsString("short"));
+        parent.appendChildToParent(label);
+        return { scene, groups, label };
+    }
+
+    test("a second and third layout pass are exact no-ops", () => {
+        const { scene, label } = buildDeepNest();
+        label.setValue(
+            "text",
+            new BrsString(
+                "a much longer text that wraps to several lines when constrained to two hundred pixels of width"
+            )
+        );
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        const first = snapshotTree(scene);
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(snapshotTree(scene)).toEqual(first);
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(snapshotTree(scene)).toEqual(first);
+    });
+
+    test("convergence does not hit the divergence backstop", () => {
+        const { scene, groups, label } = buildDeepNest();
+        label.setValue(
+            "text",
+            new BrsString("another wrapped text long enough to grow the innermost group by a few line heights")
+        );
+
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+
+        for (const group of groups) {
+            expect(group.lastPassCount).toBeGreaterThan(0);
+            expect(group.lastPassCount).toBeLessThan(8);
+        }
+    });
+
+    test("a deep perturbation settles every ancestor in one layout pass", () => {
+        const { scene, groups, label } = buildDeepNest();
+        for (let p = 0; p < 3; p++) {
+            scene.layoutNode(interpreter, [0, 0], 0, 1);
+        }
+        const settled = groups.map((g) => g.rectToParent.height);
+
+        label.setValue(
+            "text",
+            new BrsString(
+                "now a much longer text that wraps to many lines when constrained to two hundred pixels wide, growing the innermost group by several line heights"
+            )
+        );
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        const afterOne = groups.map((g) => g.rectToParent.height);
+        // Every level grew (the innermost change propagated all the way up in ONE call)...
+        for (let i = 0; i < groups.length; i++) {
+            expect(afterOne[i]).toBeGreaterThan(settled[i]);
+        }
+        // ...and a second call confirms it was already the fixed point.
+        scene.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(groups.map((g) => g.rectToParent.height)).toEqual(afterOne);
+    });
+
+    test("a paint pass keeps single-pass next-frame correction semantics", () => {
+        const { scene, label } = buildDeepNest();
+        label.setValue("text", new BrsString("wrapped text that is long enough to span at least a couple of lines"));
+        const draw2D = {
+            doDrawRotatedRect: () => {},
+            doDrawRotatedText: () => {},
+            doDrawRotatedBitmap: () => {},
+            pushClip: () => {},
+            popClip: () => {},
+        };
+
+        // Paint from the outer LayoutGroup (Scene.renderNode needs a full canvas surface).
+        const outer = scene.getNodeChildren()[0];
+        outer.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        expect(outer.lastPassCount).toBe(1);
+    });
+});

--- a/test/extensions/scenegraph/LayoutPaintSeam.test.js
+++ b/test/extensions/scenegraph/LayoutPaintSeam.test.js
@@ -1,0 +1,114 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsString, Float, RoArray, Interpreter } = core;
+
+/**
+ * The layout/paint seam (docs/scenegraph-layout-passes.md): `layoutNode` is the pure measurement
+ * entry point (today it wraps renderNode with no draw target), `paintNode` is the per-frame render.
+ * Each sets `sgRoot.renderPass` for the duration of its traversal and restores it afterwards, so
+ * node internals can gate time-based state on the pass kind without a signature change.
+ */
+describe("layoutNode/paintNode seam", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    function buildTree() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const group = SGNodeFactory.createNode("Group");
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        layout.setValue("translation", vector([30, 40]));
+        const first = SGNodeFactory.createNode("Rectangle");
+        first.setValue("width", new Float(200));
+        first.setValue("height", new Float(80));
+        const second = SGNodeFactory.createNode("Rectangle");
+        second.setValue("width", new Float(120));
+        second.setValue("height", new Float(60));
+        layout.appendChildToParent(first);
+        layout.appendChildToParent(second);
+        group.appendChildToParent(layout);
+        scene.appendChildToParent(group);
+        return { scene, group, layout, first, second };
+    }
+
+    function snapshotRects(node) {
+        return {
+            local: { ...node.rectLocal },
+            toParent: { ...node.rectToParent },
+            toScene: { ...node.rectToScene },
+        };
+    }
+
+    test("layoutNode computes the same rects as renderNode without a draw target", () => {
+        const measured = buildTree();
+        measured.scene.layoutNode(interpreter, [0, 0], 0, 1);
+        const viaLayout = [measured.group, measured.layout, measured.first, measured.second].map(snapshotRects);
+
+        const rendered = buildTree();
+        rendered.scene.renderNode(interpreter, [0, 0], 0, 1);
+        const viaRender = [rendered.group, rendered.layout, rendered.first, rendered.second].map(snapshotRects);
+
+        expect(viaLayout).toEqual(viaRender);
+    });
+
+    test("paintNode draws through the provided draw target", () => {
+        // Paint from the group (Scene.renderNode needs a full canvas surface; the fake only
+        // records rect draws).
+        const { group } = buildTree();
+        const calls = [];
+        const draw2D = {
+            doDrawRotatedRect: (...args) => calls.push(args),
+        };
+
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls.length).toBeGreaterThan(0);
+    });
+
+    test("renderPass is 'layout'/'paint' inside each traversal and restored afterwards", () => {
+        const { group, layout } = buildTree();
+        const seen = [];
+        const originalRenderNode = layout.renderNode.bind(layout);
+        layout.renderNode = (...args) => {
+            seen.push(sgRoot.renderPass);
+            return originalRenderNode(...args);
+        };
+
+        expect(sgRoot.renderPass).toBe("paint");
+        group.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(sgRoot.renderPass).toBe("paint");
+        group.paintNode(interpreter, [0, 0], 0, 1, { doDrawRotatedRect: () => {} });
+        expect(sgRoot.renderPass).toBe("paint");
+
+        expect(seen).toEqual(["layout", "paint"]);
+    });
+
+    test("getBoundingRect's refresh runs as a layout pass", () => {
+        const { scene, layout } = buildTree();
+        const passes = [];
+        const originalRenderNode = scene.renderNode.bind(scene);
+        scene.renderNode = (...args) => {
+            passes.push(sgRoot.renderPass);
+            return originalRenderNode(...args);
+        };
+
+        const rect = layout.getBoundingRect("toParent", interpreter);
+
+        expect(passes).toEqual(["layout"]);
+        expect(rect.width).toBe(200);
+        expect(rect.height).toBe(140);
+    });
+});

--- a/test/extensions/scenegraph/LayoutPruning.test.js
+++ b/test/extensions/scenegraph/LayoutPruning.test.js
@@ -1,0 +1,223 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float, RoArray, Interpreter } = core;
+
+/**
+ * Pruned layout refreshes (docs/scenegraph-layout-passes.md): a full-tree bounding-rect refresh
+ * skips subtrees nothing has written to since their last pass (subtreeStale false) under an
+ * unchanged origin/angle/opacity context. Sound only because layout passes are pure (PR #1118).
+ * The two hard-won invariants from the abandoned attempt: a skipped child still hands its cached
+ * rect up to the parent union, and the stale mark is cleared BEFORE a pass so writes made inside
+ * it (init(), observers) survive to the next refresh.
+ */
+describe("pruned layout refresh", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    const vector = (vals) => new RoArray(vals.map((v) => new Float(v)));
+
+    function makeRect(width, height) {
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(width));
+        rect.setValue("height", new Float(height));
+        return rect;
+    }
+
+    /** Scene > Group(left: Group > Rect) + Group(right: Group > Rect) — two independent subtrees. */
+    function buildTwoSubtrees() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const left = SGNodeFactory.createNode("Group");
+        const leftInner = SGNodeFactory.createNode("Group");
+        leftInner.appendChildToParent(makeRect(100, 50));
+        left.appendChildToParent(leftInner);
+        const right = SGNodeFactory.createNode("Group");
+        right.setValue("translation", vector([500, 0]));
+        const rightInner = SGNodeFactory.createNode("Group");
+        rightInner.appendChildToParent(makeRect(80, 40));
+        right.appendChildToParent(rightInner);
+        scene.appendChildToParent(left);
+        scene.appendChildToParent(right);
+        return { scene, left, leftInner, right, rightInner };
+    }
+
+    test("an unwritten subtree is skipped on the second refresh", () => {
+        const { scene, left, leftInner, right, rightInner } = buildTwoSubtrees();
+
+        // First refresh lays out everything.
+        left.getBoundingRect("toParent", interpreter);
+        const leftPasses = leftInner.layoutPassCount;
+        const rightPasses = rightInner.layoutPassCount;
+
+        // Write only into the LEFT subtree, refresh again: right subtree must be skipped.
+        leftInner.getNodeChildren()[0].setValue("width", new Float(120));
+        left.getBoundingRect("toParent", interpreter);
+
+        expect(leftInner.layoutPassCount).toBeGreaterThan(leftPasses);
+        expect(rightInner.layoutPassCount).toBe(rightPasses);
+        // The refreshed left rect reflects the write.
+        expect(leftInner.rectToParent.width).toBe(120);
+    });
+
+    test("a skipped child still unions its cached rect into the parent", () => {
+        // Wrap both subtrees in a container so the union is observable (Scene's own rect is the
+        // fixed screen size, not a child union).
+        const scene = SGNodeFactory.createNode("Scene");
+        const container = SGNodeFactory.createNode("Group");
+        const left = SGNodeFactory.createNode("Group");
+        left.appendChildToParent(makeRect(100, 50));
+        const right = SGNodeFactory.createNode("Group");
+        right.setValue("translation", vector([500, 0]));
+        right.appendChildToParent(makeRect(80, 40));
+        container.appendChildToParent(left);
+        container.appendChildToParent(right);
+        scene.appendChildToParent(container);
+
+        container.getBoundingRect("toParent", interpreter);
+        expect(container.rectToParent.width).toBe(580); // right at x=500 + width 80
+
+        // Dirty only the left; the skipped right subtree must still contribute its 80px at x=500.
+        left.getNodeChildren()[0].setValue("height", new Float(60));
+        container.getBoundingRect("toParent", interpreter);
+        expect(container.rectToParent.width).toBe(580);
+        expect(right.rectToParent).toEqual({ x: 500, y: 0, width: 80, height: 40 });
+    });
+
+    test("a write made during the pass survives to the next refresh (clear-before-pass)", () => {
+        const { scene, left, leftInner } = buildTwoSubtrees();
+        scene.getBoundingRect("toParent", interpreter);
+
+        // Simulate an observer writing into the subtree WHILE its pass runs: hook renderNode.
+        const inner = leftInner;
+        const original = inner.renderNode.bind(inner);
+        let wroteOnce = false;
+        inner.renderNode = (...args) => {
+            const result = original(...args);
+            if (!wroteOnce) {
+                wroteOnce = true;
+                inner.getNodeChildren()[0].setValue("width", new Float(300));
+            }
+            return result;
+        };
+        inner.getNodeChildren()[0].setValue("width", new Float(200)); // make it stale
+        scene.getBoundingRect("toParent", interpreter);
+        inner.renderNode = original;
+
+        // The mid-pass write set the stale mark AFTER the clear, so the subtree is stale and the
+        // NEXT refresh re-lays it out at the new width.
+        expect(inner.subtreeStale).toBe(true);
+        scene.getBoundingRect("toParent", interpreter);
+        expect(inner.rectToParent.width).toBe(300);
+    });
+
+    test("an ancestor translation change invalidates settled children via the context check", () => {
+        const { scene, right, rightInner } = buildTwoSubtrees();
+        scene.getBoundingRect("toParent", interpreter);
+        const passes = rightInner.layoutPassCount;
+
+        // Move the right container: its children are NOT stale, but their incoming origin
+        // changed, so the context check forces them to re-lay-out at the new position.
+        right.setValue("translation", vector([600, 20]));
+        scene.getBoundingRect("toParent", interpreter);
+
+        expect(rightInner.layoutPassCount).toBeGreaterThan(passes);
+        expect(rightInner.rectToScene.x).toBe(600);
+        expect(rightInner.rectToScene.y).toBe(20);
+    });
+
+    test("content mutation reaches the consuming grid through the field boundary", () => {
+        // A ContentNode tree hangs off a FIELD, not the render tree — writing into it must
+        // still stale-mark the consuming node (and its ancestors) so a pruned refresh
+        // re-descends. (In practice grids re-mark themselves during their own pass via item
+        // focus writes and thus never skip, but the field-boundary hop must hold regardless —
+        // it is what protects any settled consumer of a content tree.)
+        const scene = SGNodeFactory.createNode("Scene");
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("itemSize", vector([100, 50]));
+        grid.setValue("numRows", new Float(4));
+        grid.setValue("numColumns", new Float(1));
+        scene.appendChildToParent(grid);
+        const content = SGNodeFactory.createNode("ContentNode");
+        for (let i = 0; i < 2; i++) {
+            const item = SGNodeFactory.createNode("ContentNode");
+            item.setValue("title", new BrsString(`item ${i}`));
+            content.appendChildToParent(item);
+        }
+        grid.setValue("content", content);
+        scene.getBoundingRect("toParent", interpreter);
+
+        // Force the settled state (a real grid keeps re-marking itself; the hop matters for
+        // the refreshes where it does not).
+        grid.subtreeStale = false;
+        scene.subtreeStale = false;
+
+        // Mutate the content tree only — nothing in the RENDER tree is written.
+        const extra = SGNodeFactory.createNode("ContentNode");
+        extra.setValue("title", new BrsString("late item"));
+        content.appendChildToParent(extra);
+
+        expect(grid.subtreeStale).toBe(true);
+        expect(scene.subtreeStale).toBe(true);
+    });
+
+    test("pruned and unpruned refreshes produce identical rects (grid item creation included)", () => {
+        function buildScene() {
+            const scene = SGNodeFactory.createNode("Scene");
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            layout.setValue("layoutDirection", new BrsString("vert"));
+            layout.setValue("itemSpacings", vector([6]));
+            layout.appendChildToParent(makeRect(200, 40));
+            layout.appendChildToParent(makeRect(150, 70));
+            const grid = SGNodeFactory.createNode("MarkupGrid");
+            grid.setValue("itemSize", vector([100, 50]));
+            grid.setValue("numRows", new Float(3));
+            grid.setValue("numColumns", new Float(1));
+            const content = SGNodeFactory.createNode("ContentNode");
+            for (let i = 0; i < 3; i++) {
+                content.appendChildToParent(SGNodeFactory.createNode("ContentNode"));
+            }
+            grid.setValue("content", content);
+            layout.appendChildToParent(grid);
+            scene.appendChildToParent(layout);
+            return { scene, layout };
+        }
+
+        function snapshotTree(node, out = []) {
+            out.push({ ...node.rectLocal }, { ...node.rectToParent }, { ...node.rectToScene });
+            for (const child of node.getNodeChildren()) {
+                if (child.rectLocal) snapshotTree(child, out);
+            }
+            return out;
+        }
+
+        const pruned = buildScene();
+        pruned.layout.getBoundingRect("toParent", interpreter); // create items
+        pruned.layout.getBoundingRect("toParent", interpreter); // pruned steady-state refresh
+        const prunedRects = snapshotTree(pruned.scene);
+
+        const unpruned = buildScene();
+        sgRoot.pruneDisabled = true;
+        try {
+            unpruned.layout.getBoundingRect("toParent", interpreter);
+            unpruned.layout.getBoundingRect("toParent", interpreter);
+        } finally {
+            sgRoot.pruneDisabled = false;
+        }
+        expect(prunedRects).toEqual(snapshotTree(unpruned.scene));
+    });
+});

--- a/test/extensions/scenegraph/LayoutPurity.test.js
+++ b/test/extensions/scenegraph/LayoutPurity.test.js
@@ -1,0 +1,149 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsDevice, BrsString, Float, Int32, Interpreter } = core;
+
+/**
+ * The central invariant of the layout/paint split (docs/scenegraph-layout-passes.md): a layout
+ * pass is pure — idempotent and clock-free. Running layoutNode twice while the clock ADVANCES
+ * between calls must produce identical rects and must not advance any node's time-based state,
+ * for every node type that reads the clock during render.
+ */
+describe("layout passes are pure (idempotent, clock-free)", () => {
+    let interpreter;
+    let fakeNow;
+
+    beforeAll(() => {
+        // Label/keyboard nodes resolve fonts from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        fakeNow = 100_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+    });
+
+    function snapshot(node) {
+        return {
+            local: { ...node.rectLocal },
+            toParent: { ...node.rectToParent },
+            toScene: { ...node.rectToScene },
+        };
+    }
+
+    /** Two layout passes with 5s of clock between them must agree exactly. */
+    function expectIdempotentLayout(root, node) {
+        root.layoutNode(interpreter, [0, 0], 0, 1);
+        const first = snapshot(node);
+        fakeNow += 5000;
+        root.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(snapshot(node)).toEqual(first);
+    }
+
+    test("BusySpinner: layout does not advance the spin nor write the poster rotation", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const spinner = SGNodeFactory.createNode("BusySpinner");
+        group.appendChildToParent(spinner);
+        spinner.setValue("control", new BrsString("start"));
+        const poster = spinner.getValue("poster");
+        const before = poster.getValueJS("rotation");
+
+        expectIdempotentLayout(group, spinner);
+
+        expect(poster.getValueJS("rotation")).toBe(before);
+
+        // A paint pass advances it.
+        fakeNow += 500;
+        group.paintNode(interpreter, [0, 0], 0, 1, { doDrawRotatedBitmap: () => {}, doDrawRotatedRect: () => {} });
+        expect(poster.getValueJS("rotation")).not.toBe(before);
+    });
+
+    test("ScrollingLabel: layout does not consume the marquee time delta nor re-dirty the scene", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const label = SGNodeFactory.createNode("ScrollingLabel");
+        label.setValue("text", new BrsString("A very long text that certainly does not fit the maximum width"));
+        label.setValue("maxWidth", new Int32(120));
+        group.appendChildToParent(label);
+
+        sgRoot.clearDirty();
+        expectIdempotentLayout(group, label);
+        // The makeDirty that keeps the marquee animating is paint-only; a bounding-rect
+        // refresh must not re-dirty the scene (that made every measurement force a frame).
+        expect(sgRoot.isDirty).toBe(false);
+    });
+
+    test("TextEditBox: layout does not flip the cursor blink phase", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const editBox = SGNodeFactory.createNode("TextEditBox");
+        editBox.setValue("text", new BrsString("hello"));
+        editBox.setValue("active", core.BrsBoolean.True);
+        group.appendChildToParent(editBox);
+
+        // Paint once to seed lastPaintNow, then layout repeatedly across several blink
+        // intervals — the phase must not change (each flip would mutate state).
+        const draw2D = {
+            doDrawRotatedBitmap: () => {},
+            doDrawRotatedRect: () => {},
+            doDrawRotatedText: () => {},
+            doDrawScaledObject: () => {},
+            drawNinePatch: () => {},
+            drawImage: () => {},
+        };
+        group.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        expectIdempotentLayout(group, editBox);
+    });
+
+    test("Video: layout does not advance seek state", () => {
+        const group = SGNodeFactory.createNode("Group");
+        const video = SGNodeFactory.createNode("Video");
+        group.appendChildToParent(video);
+
+        expectIdempotentLayout(group, video);
+    });
+
+    test("DynamicKeyGrid: a layout pass after the hover dwell does not open the popup", () => {
+        const grid = SGNodeFactory.createNode("DynamicKeyGrid");
+        const kdfUri = "common:/keyboards/kdf/qwerty_suggestions.json";
+        if (grid.getValueJS("keyDefinitionUri") !== undefined) {
+            grid.setValue("keyDefinitionUri", new BrsString(kdfUri));
+        }
+        sgRoot.setFocused(grid);
+        const childCountBefore = grid.getNodeChildren().length;
+
+        fakeNow += 10_000; // way past any hover delay
+        grid.layoutNode(interpreter, [0, 0], 0, 1);
+
+        // No popup node was appended by the layout pass.
+        expect(grid.getNodeChildren().length).toBe(childCountBefore);
+    });
+
+    test("a LayoutGroup subtree with mixed content lays out identically across advancing clock", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(100));
+        const marquee = SGNodeFactory.createNode("ScrollingLabel");
+        marquee.setValue("text", new BrsString("Another long scrolling text that overflows its container"));
+        marquee.setValue("maxWidth", new Int32(200));
+        const spinner = SGNodeFactory.createNode("BusySpinner");
+        spinner.setValue("control", new BrsString("start"));
+        layout.appendChildToParent(rect);
+        layout.appendChildToParent(marquee);
+        layout.appendChildToParent(spinner);
+        scene.appendChildToParent(layout);
+
+        expectIdempotentLayout(scene, layout);
+    });
+});

--- a/test/extensions/scenegraph/PruneVerify.test.js
+++ b/test/extensions/scenegraph/PruneVerify.test.js
@@ -1,0 +1,72 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, runPruneVerify } = scenegraph;
+const { BrsDevice, BrsString, Float, RoArray, Interpreter } = core;
+
+/**
+ * BRS_PRUNE_VERIFY tooling (docs/scenegraph-layout-passes.md): runs a layout refresh pruned then
+ * unpruned and diffs every rect, printing path-addressed `[prune-verify]` lines for divergences.
+ * Silence == the pruned pass is sound for that refresh.
+ */
+describe("prune verifier", () => {
+    let interpreter;
+    let stderrLines;
+    let originalWrite;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        stderrLines = [];
+        originalWrite = BrsDevice.stderr.write.bind(BrsDevice.stderr);
+        BrsDevice.stderr.write = (line) => stderrLines.push(String(line));
+    });
+
+    afterEach(() => {
+        BrsDevice.stderr.write = originalWrite;
+        sgRoot.setFocused();
+    });
+
+    const vector = (vals) => new RoArray(vals.map((v) => new Float(v)));
+
+    function buildScene() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const group = SGNodeFactory.createNode("Group");
+        group.setValue("id", new BrsString("container"));
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(200));
+        rect.setValue("height", new Float(90));
+        group.appendChildToParent(rect);
+        scene.appendChildToParent(group);
+        return { scene, group, rect };
+    }
+
+    test("silent on a consistent tree", () => {
+        const { scene, rect } = buildScene();
+        scene.layoutNode(interpreter, [0, 0], 0, 1); // settle once
+        rect.setValue("width", new Float(220)); // then a normal write
+
+        const divergences = runPruneVerify(scene, interpreter);
+
+        expect(divergences).toBe(0);
+        expect(stderrLines.filter((l) => l.includes("[prune-verify]"))).toHaveLength(0);
+    });
+
+    test("reports a path-addressed line when a skipped subtree lies about its rect", () => {
+        const { scene, group, rect } = buildScene();
+        scene.layoutNode(interpreter, [0, 0], 0, 1); // settle: group is now skippable
+
+        // Corrupt the settled subtree's cached rect WITHOUT marking it stale — the pruned pass
+        // skips it and hands the lie up; the full pass recomputes the truth. The verifier must
+        // name the diverging node.
+        rect.rectToParent = { x: 0, y: 0, width: 999, height: 90 };
+        rect.rectLocal = { x: 0, y: 0, width: 999, height: 90 };
+        rect.rectToScene = { x: 0, y: 0, width: 999, height: 90 };
+
+        const divergences = runPruneVerify(scene, interpreter);
+
+        expect(divergences).toBeGreaterThan(0);
+        const lines = stderrLines.filter((l) => l.includes("[prune-verify]"));
+        expect(lines.length).toBeGreaterThan(0);
+        expect(lines.some((l) => l.includes("Rectangle") && l.includes("pruned=") && l.includes("full="))).toBe(true);
+    });
+});

--- a/test/extensions/scenegraph/PruneVerify.test.js
+++ b/test/extensions/scenegraph/PruneVerify.test.js
@@ -42,7 +42,7 @@ describe("prune verifier", () => {
 
     test("silent on a consistent tree", () => {
         const { scene, rect } = buildScene();
-        scene.layoutNode(interpreter, [0, 0], 0, 1); // settle once
+        scene.getBoundingRect("toParent", interpreter); // settle once (pruned refresh)
         rect.setValue("width", new Float(220)); // then a normal write
 
         const divergences = runPruneVerify(scene, interpreter);
@@ -53,7 +53,9 @@ describe("prune verifier", () => {
 
     test("reports a path-addressed line when a skipped subtree lies about its rect", () => {
         const { scene, group, rect } = buildScene();
-        scene.layoutNode(interpreter, [0, 0], 0, 1); // settle: group is now skippable
+        // Settle through the pruned refresh (getBoundingRect): only that pass clears stale
+        // marks and records skip contexts — a direct layoutNode call is a scoped measurement.
+        scene.getBoundingRect("toParent", interpreter);
 
         // Corrupt the settled subtree's cached rect WITHOUT marking it stale — the pruned pass
         // skips it and hands the lie up; the full pass recomputes the truth. The verifier must

--- a/test/extensions/scenegraph/PruneVerify.test.js
+++ b/test/extensions/scenegraph/PruneVerify.test.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
@@ -13,6 +15,12 @@ describe("prune verifier", () => {
     let interpreter;
     let stderrLines;
     let originalWrite;
+
+    beforeAll(() => {
+        // Regression scenarios include nodes with font-typed fields; mount the common: volume.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
 
     beforeEach(() => {
         interpreter = new Interpreter();
@@ -49,6 +57,70 @@ describe("prune verifier", () => {
 
         expect(divergences).toBe(0);
         expect(stderrLines.filter((l) => l.includes("[prune-verify]"))).toHaveLength(0);
+    });
+
+    test("convergence repositioning does not pollute ancestor unions (real-app regression)", () => {
+        // Found by the verifier in real apps: a vert LayoutGroup with vertAlignment=center holding
+        // a derived-size child. Settle at one height, grow the child, refresh: pass 1 positions
+        // with the cached old height, the child renders taller, synchronizeChildMetrics re-dirties,
+        // pass 2 re-centers — and each inner pass unioned into the PARENT, whose rects reset only
+        // once per its own pass. The pruned refresh (first to need two passes after the change)
+        // reported the union of both positions (a 55-tall child spanning y -27.5..55, height 82.5).
+        // Parent rects are now restored between convergence passes.
+        const comp = SGNodeFactory.createNode("Group");
+        const button = SGNodeFactory.createNode("Group");
+        const lg = SGNodeFactory.createNode("LayoutGroup");
+        lg.setValue("layoutDirection", new BrsString("vert"));
+        lg.setValue("vertAlignment", new BrsString("center"));
+        const child = SGNodeFactory.createNode("Group");
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(0.0001));
+        rect.setValue("height", new Float(30));
+        child.appendChildToParent(rect);
+        lg.appendChildToParent(child);
+        button.appendChildToParent(lg);
+        comp.appendChildToParent(button);
+
+        comp.getBoundingRect("toParent", interpreter); // settle at h=30
+        rect.setValue("height", new Float(55)); // grow: next refresh must re-center
+
+        const divergences = runPruneVerify(comp, interpreter);
+
+        expect(divergences).toBe(0);
+        expect(comp.rectToParent).toEqual({ x: 0, y: -27.5, width: 0.0001, height: 55 });
+    });
+
+    test("a zero-width subtree re-measured at [0,0] keeps its in-tree scene rects (real-app regression)", () => {
+        // Found by the verifier in real apps: scoped measurements (measureUnsizedChildren) render
+        // a subtree at origin [0,0], clobbering every descendant's rectToScene. Zero-width
+        // children (empty labels/badges) are re-measured on EVERY dirty layout (the rectKnown
+        // check requires width > 0), and the pruned refresh then skipped the settled subtree,
+        // handing up scene rects with x=0 instead of the true in-tree x. The scoped measurement
+        // now deep-stales the subtree so the refresh re-descends.
+        const scene = SGNodeFactory.createNode("Scene");
+        const offsetGroup = SGNodeFactory.createNode("Group");
+        offsetGroup.setValue("translation", new RoArray([new Float(223), new Float(0)]));
+        const lg = SGNodeFactory.createNode("LayoutGroup");
+        lg.setValue("layoutDirection", new BrsString("vert"));
+        const child = SGNodeFactory.createNode("Group");
+        const inner = SGNodeFactory.createNode("Rectangle");
+        inner.setValue("width", new Float(0));
+        inner.setValue("height", new Float(56));
+        child.appendChildToParent(inner);
+        lg.appendChildToParent(child);
+        offsetGroup.appendChildToParent(lg);
+        scene.appendChildToParent(offsetGroup);
+
+        scene.getBoundingRect("toParent", interpreter); // settle
+        // Dirty the LayoutGroup WITHOUT touching the child: measureUnsizedChildren re-measures
+        // the zero-width child at [0,0]; the refresh must then re-descend, not skip.
+        lg.setValue("horizAlignment", new BrsString("left"));
+
+        const divergences = runPruneVerify(scene, interpreter);
+
+        expect(divergences).toBe(0);
+        expect(child.rectToScene.x).toBe(223);
+        expect(inner.rectToScene.x).toBe(223);
     });
 
     test("reports a path-addressed line when a skipped subtree lies about its rect", () => {

--- a/test/extensions/scenegraph/ScrollingLabelClock.test.js
+++ b/test/extensions/scenegraph/ScrollingLabelClock.test.js
@@ -1,0 +1,114 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsDevice, BrsString, Int32, Interpreter } = core;
+
+/**
+ * ScrollingLabel's marquee advances only on paint passes; a layout pass (bounding-rect refresh)
+ * renders the stored scroll position without consuming the time delta. Before the layout/paint
+ * split, a measurement between two frames ate part of the elapsed time (stuttering the marquee
+ * under boundingRect polling) and the mid-render makeDirty re-dirtied the scene from inside a
+ * refresh.
+ */
+describe("ScrollingLabel marquee across pass kinds", () => {
+    let interpreter;
+    let fakeNow;
+
+    /** Captures the x offset the marquee text is drawn at. */
+    function paintAndCaptureX(label) {
+        let capturedX;
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            doDrawRotatedText(text, x) {
+                capturedX = x;
+            },
+        };
+        label.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+        return capturedX;
+    }
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        fakeNow = 200_000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+    });
+
+    function buildMarquee() {
+        const label = SGNodeFactory.createNode("ScrollingLabel");
+        label.setValue("maxWidth", new Int32(150));
+        label.setValue("text", new BrsString("A very long text that certainly does not fit into 150 pixels"));
+        return label;
+    }
+
+    test("interleaved layout passes do not eat the scroll delta", () => {
+        // Two identical marquees; one gets layout passes interleaved between its paints.
+        // Both must land on the same scroll offset at the same wall-clock time.
+        const plain = buildMarquee();
+        const measured = buildMarquee();
+
+        paintAndCaptureX(plain);
+        paintAndCaptureX(measured);
+
+        // Get both past the initial pause (2500ms) into SCROLLING.
+        fakeNow += 3000;
+        paintAndCaptureX(plain);
+        paintAndCaptureX(measured);
+
+        // Advance 1s of scrolling; hammer one with layout passes mid-interval.
+        fakeNow += 500;
+        measured.layoutNode(interpreter, [0, 0], 0, 1);
+        measured.layoutNode(interpreter, [0, 0], 0, 1);
+        fakeNow += 500;
+        const plainX = paintAndCaptureX(plain);
+        const measuredX = paintAndCaptureX(measured);
+
+        expect(measuredX).toBe(plainX);
+        // And it actually scrolled (offset went negative).
+        expect(plainX).toBeLessThan(0);
+    });
+
+    test("a layout pass during scrolling does not move the drawn offset", () => {
+        const label = buildMarquee();
+        paintAndCaptureX(label);
+        fakeNow += 3000; // into SCROLLING
+        const x1 = paintAndCaptureX(label);
+
+        fakeNow += 1000;
+        label.layoutNode(interpreter, [0, 0], 0, 1);
+        // Paint with a zero-delta clock read (no time passed since the layout): the offset
+        // moved only by the paint-to-paint delta, unaffected by the layout in between.
+        const x2 = paintAndCaptureX(label);
+        expect(x2).toBeLessThan(x1); // scrolled by the 1000ms between paints
+
+        // Now verify layout alone never moves it: two layouts with clock advancing.
+        const rectBefore = { ...label.rectToParent };
+        fakeNow += 700;
+        label.layoutNode(interpreter, [0, 0], 0, 1);
+        expect(label.rectToParent).toEqual(rectBefore);
+    });
+
+    test("layout passes do not re-dirty the scene while the marquee is active", () => {
+        const label = buildMarquee();
+        paintAndCaptureX(label);
+        fakeNow += 3000;
+
+        sgRoot.clearDirty();
+        label.layoutNode(interpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.isDirty).toBe(false);
+    });
+});


### PR DESCRIPTION
Implements the full program of `docs/scenegraph-layout-passes.md` (#1114): SceneGraph screen builds were O(n²) because every `boundingRect()` query re-rendered the whole scene, and that refresh couldn't be pruned while `renderNode` also advanced wall-clock state and converged derived sizes. This PR separates those jobs and then prunes.

Originally developed as a 4-PR stack (#1117, #1118, #1119 → this PR); consolidated here for a single review — the commit history preserves the steps.

## 1. Layout/paint seam + injectable clock (`72591af4`)

- `Node.layoutNode` (pure measurement) / `Node.paintNode` (per-frame render) wrap `renderNode`, setting `sgRoot.renderPass`; `isPaintPass(draw2D)` is the gate node internals use. `renderNode` stays the single override point — external `SGNodeFactory.addNodeTypes` consumers unaffected.
- All render-path clock reads route through the injectable `sgClock` so tests drive time deterministically through the built bundles.
- Commits the proposal doc's synthetic probe as `test/cli/resources/layout-perf-app` (70 self-measuring components in a LayoutGroup).

## 2. Layout passes are pure (`696c06e3`)

Clock reads and side effects gated on `isPaintPass`, per node: BusySpinner spin, ScrollingLabel marquee (+ its mid-refresh `makeDirty`), TextEditBox cursor blink, TrickPlayBar icon expiry, Video seek auto-repeat / `showUI` / plane-rect postMessage, DynamicKeyGrid hover popup, TimeGrid "now" epoch, Dialog/StandardDialog `setNodeFocus`. Behavior changes are deliberate and closer to Roku (marquees no longer stutter under `boundingRect()` polling; spinners advance only on frames).

## 3. LayoutGroup fixed-point convergence (`d3463555`)

Layout passes iterate until a pass leaves the layout clean instead of the former cap of 2, which could exit mid-convergence (the doc's observed 659→631→629 creep). `MAX_LAYOUT_PASSES = 8` is a divergence backstop only.

## 4. Pruning + verifier (`403bcbe0`)

- `Node.subtreeStale` set by `makeDirty` (full parent-chain walk), `Group.isDirty` setter also stale-marks (~65 direct-assignment sites covered), `ContentNode.makeDirty` hops the field boundary to stale-mark content consumers.
- `Group.skipSettledLayout`: skip only inside the pruned refresh, on `!subtreeStale` + exact origin/angle/opacity context match; skipped visible children still hand their cached rect up; stale marks clear **before** a pass.
- `SGVerify.runPruneVerify` (`BRS_PRUNE_VERIFY=1`): runs each refresh pruned→full→full and classifies `[layout-verify]` (non-idempotent layout) vs `[prune-verify]` (true unsoundness). `BRS_PRUNE_DISABLE=1` escape hatch.

## 5. Real-app hardening (`c428bd17`, `50725dde`, `6446d9a6`, `0d2da6ee`)

Verifier runs against two production apps in brs-desktop surfaced three divergence families, each fixed + pinned in `PruneVerify.test.js`:
- prune bookkeeping leaking into scoped `[0,0]` measurements (incl. detached-root `Label.getMeasured()`);
- LayoutGroup convergence passes unioning into the parent without resets between passes — a **pre-existing** `boundingRect()` correctness bug the verifier unmasked;
- zero-width subtrees keeping `[0,0]`-origin `rectToScene` after `measureUnsizedChildren`, fixed via `markSubtreeStaleDeep`.

Final verification: **zero verifier lines across both apps**, which also satisfies the doc's "verify against an app that animates" bar. Apps confirmed visually good and fast without the flag.

## Numbers

layout-perf-app (70 self-measuring components): **425 ms unpruned → 268 ms pruned**, per-tile quartiles flat (the device shape the doc targets).

## Tests

New: `LayoutPaintSeam`, `ClockSource`, `LayoutPurity`, `BusySpinnerClock`, `ScrollingLabelClock`, `LayoutConvergence`, `LayoutPruning`, `PruneVerify` + `layout-perf-app` CLI fixture (also run under `BRS_PRUNE_VERIFY=1` alongside `grid-measure-app`, asserting silence). Full suite green (2314 tests), lint + prettier clean.

A follow-up PR removes the verifier harness (its job is done; the regression tests keep the coverage) and updates the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)