### PR TITLE
fix(scenegraph): match device behavior for LayoutGroup's enum fields, spacing and size

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -69,12 +69,44 @@ Two counter-intuitive consequences, both easy to "simplify" away:
 
 `horizontal`/`vertical` are **not** aliases, despite reading like the obvious long forms; the engine
 used to accept them and mapped `vertical` → vert, the opposite of hardware. Canonicalization happens on
-write (`canonicalizeDirection`, applied in `setValue`, `setValueSilent`, and `registerInitializedFields`
+write (`canonicalizeEnumField`, applied in `setValue`, `setValueSilent`, and `registerInitializedFields`
 — the last because XML/deserialized fields are written straight into the field map, bypassing
 `setValue`); `getLayoutDirection` then only has to ask whether the stored value is `"vert"`. Use
 `isBrsString`, not `instanceof BrsString`, so a boxed `roString` normalizes too. `ButtonGroup` extends
 `LayoutGroup` and inherits all of this while keeping its `vert` default. Regression:
 `test/extensions/scenegraph/LayoutDirection.test.js`.
+
+## `horizAlignment`/`vertAlignment` are the same enum — and a rejected CROSS value collapses the layout
+
+**Device-measured** (probe channel: `Samples/layoutalign-probe`, 48 cases — 12 spellings × the four
+`layoutDirection`/field combinations × 3 passes; the engine now reproduces all 48 rows exactly).
+
+Storage works exactly like `layoutDirection` and shares `canonicalizeEnumField`: documented values
+(`left`/`center`/`right`/`custom`, `top`/`center`/`bottom`/`custom`) match case-insensitively and store
+lowercase; anything else is rejected to `""`; a rejected write clobbers a valid one. A value belonging
+to the **sibling** field is rejected too (`horizAlignment = "top"` → `""`), so the two fields do **not**
+share one value table.
+
+Geometry, however, splits by axis — and this is the part that is not guessable:
+
+| Stored value | Field governs the PRIMARY axis | Field governs the CROSS axis |
+| --- | --- | --- |
+| documented value | aligns the whole run | aligns each child independently |
+| `custom` | falls back to `left`/`top` (as documented) | honors each child's own translation |
+| rejected (`""`) | falls back to `left`/`top` | **collapses: every child at (0,0)** |
+
+The collapse (`collapseChildren`) is the surprise: a rejected cross-axis alignment makes the device
+**abandon layout entirely** — no primary-axis stacking, no item spacing, and the children's own
+translations are discarded (they land at exactly `(0,0)`, not at their authored offsets), even though
+the primary-axis alignment is still perfectly valid. It is almost certainly a device bug, but the
+engine reproduces it deliberately: an app with a typo'd alignment piles its children on the origin on
+hardware, and a simulator that quietly laid them out neatly would hide that until it shipped.
+
+Two implementation notes: `applyLayout` must check `isCrossAlignmentRejected` **before** measuring
+anything (nothing downstream runs), and `collapseChildren` must write **no** `metricsUsedThisPass`
+entries — zeroed expectations compared against real child sizes would re-dirty the layout on every
+pass and burn the whole `MAX_LAYOUT_PASSES` budget. Regression:
+`test/extensions/scenegraph/LayoutAlignment.test.js`.
 
 ## XML `<interface>` field redeclaration — system vs. XML-defined (`addFields`)
 

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -45,6 +45,37 @@ Renderable/complex nodes (Poster, Label, ArrayGrid, …) keep the hard skip so h
 textures or creates item components. Regression:
 `test/extensions/scenegraph/HiddenMeasure.test.js`.
 
+## `LayoutGroup.layoutDirection` is an enum, and its rejected state is HORIZONTAL
+
+**Device-measured** (probe channel: `Samples/layoutgroup-probe`, 12 spellings × XML-attribute and
+runtime-write paths × 3 passes — every row agreed). Roku does **not** treat `layoutDirection` as free
+text:
+
+| Written | Reads back | Lays out |
+| --- | --- | --- |
+| never written | `"vert"` | **vert** |
+| `horiz` / `HORIZ` / `Horiz` | `"horiz"` | horiz |
+| `vert` | `"vert"` | vert |
+| `horz`, `horizontal`, `vertical`, `bogus`, `""` | `""` | **horiz** |
+
+Two counter-intuitive consequences, both easy to "simplify" away:
+
+1. An unrecognized value is **rejected, not stored-and-ignored** — the field reads back as `""`, and a
+   rejected write **clobbers** a previously valid one (`horiz` then `horz` → `""`).
+2. That empty state lays out **horizontally**, while the untouched `"vert"` default lays out
+   vertically. So `<LayoutGroup layoutDirection="horz" />` is a horizontal row on hardware. Do **not**
+   "fix" `getLayoutDirection` to fall back to the documented `vert` default — that silently stacks real
+   apps' menu bars (this is exactly the bug that prompted the probe).
+
+`horizontal`/`vertical` are **not** aliases, despite reading like the obvious long forms; the engine
+used to accept them and mapped `vertical` → vert, the opposite of hardware. Canonicalization happens on
+write (`canonicalizeDirection`, applied in `setValue`, `setValueSilent`, and `registerInitializedFields`
+— the last because XML/deserialized fields are written straight into the field map, bypassing
+`setValue`); `getLayoutDirection` then only has to ask whether the stored value is `"vert"`. Use
+`isBrsString`, not `instanceof BrsString`, so a boxed `roString` normalizes too. `ButtonGroup` extends
+`LayoutGroup` and inherits all of this while keeping its `vert` default. Regression:
+`test/extensions/scenegraph/LayoutDirection.test.js`.
+
 ## XML `<interface>` field redeclaration — system vs. XML-defined (`addFields`)
 
 When `addFields` builds a custom component's fields, a `<field>` whose name already exists is handled by

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -108,6 +108,42 @@ entries — zeroed expectations compared against real child sizes would re-dirty
 pass and burn the whole `MAX_LAYOUT_PASSES` budget. Regression:
 `test/extensions/scenegraph/LayoutAlignment.test.js`.
 
+## A LayoutGroup has NO `width`/`height` fields — read `getDimensions()`
+
+**Device-measured** (`Samples/layoutspacing-probe`): on a real LayoutGroup `hasField("width")` and
+`hasField("height")` are **false** and `lg.width` reads `invalid`, while `localBoundingRect()` reports
+the correct size. Roku declares neither field on `Group` or `LayoutGroup`.
+
+The engine used to publish its measurement by writing real `width`/`height` fields (`setValueSilent`
+creates a field that does not exist), so an app reading `lg.width` got a number here and `invalid` on
+hardware. The measurement now lives in the private `layoutWidth`/`layoutHeight` and is surfaced by
+overriding **`getDimensions()`**.
+
+So: **never read a LayoutGroup's size with `getValueJS("width")`** — use `getDimensions()`, which
+works for every node type (`Group.getDimensions` reads the fields; `LayoutGroup` overrides). This bit
+`StdDlgCustomItem.measureContentHeight`, which measured its children with the raw field and silently
+sized a dialog to 0 around a LayoutGroup once the fields went away. Regressions:
+`test/extensions/scenegraph/LayoutAlignment.test.js` (field absence) and the
+`StdDlgCustomItem` case in `StandardDialogNodes.test.js`.
+
+## `itemSpacings` — the last entry repeats, extra entries are dropped
+
+**Device-measured** (`Samples/layoutspacing-probe`, three children, all rows reproduced):
+
+- The **last entry repeats** for every gap past the end of the array, so `itemSpacings="[4]"` spaces
+  *every* gap by 4. Apps rely on this constantly; it was an assumption in `getSpacingValue` until the
+  probe confirmed it.
+- Entries **past the last gap are dropped** — `[4,9,15]` with three children lays out exactly like
+  `[4,9]` and produces the same group size. No trailing space is added, which matters because the
+  group's measured size is what parents lay out against.
+- Negative spacings **overlap** (not clamped); fractional spacings are used **as-is** (not rounded).
+- With `addItemSpacingAfterChild=false` the space is inserted **before** each child *including the
+  first*, so the whole run shifts by `spacings[0]` and the gaps come from the *following* entries
+  (`[4,9]` → run starts at 4, both gaps 9). A third entry is then genuinely used (`[4,9,15]` → gaps
+  9, 15) where the `true` case would have dropped it.
+
+Regression: `test/extensions/scenegraph/LayoutSpacing.test.js`.
+
 ## XML `<interface>` field redeclaration — system vs. XML-defined (`addFields`)
 
 When `addFields` builds a custom component's fields, a `<field>` whose name already exists is handled by

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -1,4 +1,15 @@
-import { AAMember, Interpreter, BrsBoolean, BrsType, Float, RoArray, IfDraw2D, Rect } from "brs-engine";
+import {
+    AAMember,
+    Interpreter,
+    BrsBoolean,
+    BrsString,
+    BrsType,
+    Float,
+    RoArray,
+    IfDraw2D,
+    Rect,
+    isBrsString,
+} from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { jsValueOf } from "../factory/Serializer";
@@ -60,17 +71,66 @@ export class LayoutGroup extends Group {
 
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
         const fieldName = index.toLowerCase();
-        super.setValue(index, value, alwaysNotify, kind);
+        super.setValue(index, this.canonicalizeDirection(fieldName, value), alwaysNotify, kind);
         if (this.isLayoutField(fieldName)) {
             this.layoutDirty = true;
         }
     }
 
     setValueSilent(fieldName: string, value: BrsType) {
-        super.setValueSilent(fieldName, value);
+        super.setValueSilent(fieldName, this.canonicalizeDirection(fieldName.toLowerCase(), value));
         if (this.isLayoutField(fieldName)) {
             this.layoutDirty = true;
         }
+    }
+
+    /**
+     * XML attributes are written straight into the field map by `registerInitializedFields`, never
+     * through `setValue`, so canonicalize once more after they land. The device applies the same
+     * enum normalization to both paths — `<LayoutGroup layoutDirection="Horiz" />` reads back
+     * `"horiz"` exactly as a runtime write does.
+     */
+    protected registerInitializedFields(fields: AAMember[]) {
+        super.registerInitializedFields(fields);
+        // Read the primitive: getValue hands back a boxed RoString for string fields.
+        const current = this.getValueJS("layoutDirection");
+        if (typeof current === "string") {
+            const canonical = this.canonicalDirectionValue(current);
+            if (canonical !== current) {
+                this.setValueSilent("layoutDirection", new BrsString(canonical));
+            }
+        }
+    }
+
+    /**
+     * `layoutDirection` is an ENUM field on Roku, not free text. Device-measured behavior (all
+     * spellings below, identical for XML attributes and runtime writes):
+     *
+     * - `horiz` / `vert` match case-insensitively and are stored in canonical lowercase, so
+     *   writing `"HORIZ"` reads back as `"horiz"`.
+     * - Anything else is REJECTED rather than stored-and-ignored: the field reads back as `""`.
+     *   `horizontal`, `vertical`, `horz` and `bogus` all land here — near-misses get no leniency.
+     * - A rejected write clobbers a previously valid one (`horiz` then `horz` reads back `""`).
+     *
+     * The layout consequence of that empty state lives in `getLayoutDirection`.
+     */
+    private canonicalizeDirection(fieldName: string, value: BrsType): BrsType {
+        // isBrsString (not instanceof) so a boxed roString assignment normalizes like a literal.
+        if (fieldName !== "layoutdirection" || !isBrsString(value)) {
+            return value;
+        }
+        const raw = jsValueOf(value);
+        if (typeof raw !== "string") {
+            return value;
+        }
+        const canonical = this.canonicalDirectionValue(raw);
+        return canonical === raw ? value : new BrsString(canonical);
+    }
+
+    /** "horiz"/"vert" match case-insensitively; everything else collapses to the rejected state. */
+    private canonicalDirectionValue(value: string): string {
+        const normalized = value.toLowerCase();
+        return normalized === "horiz" || normalized === "vert" ? normalized : "";
     }
 
     appendChildToParent(child: BrsType): boolean {
@@ -482,18 +542,17 @@ export class LayoutGroup extends Group {
         return children;
     }
 
+    /**
+     * Only a stored `"vert"` lays out vertically. Every other state — `"horiz"`, or the `""` that
+     * `canonicalizeDirection` leaves after a rejected write — lays out HORIZONTALLY on the device.
+     *
+     * That asymmetry is the counter-intuitive part, so spell it out: an untouched field keeps its
+     * `"vert"` default and stacks vertically, but a field written with an unrecognized value ends
+     * up empty and rows out horizontally. `<LayoutGroup layoutDirection="horz" />` is therefore a
+     * horizontal row on hardware, even though `horz` is not a documented value.
+     */
     private getLayoutDirection(): LayoutDirection {
-        const direction = this.getValueJS("layoutDirection");
-        if (typeof direction === "string") {
-            const normalized = direction.toLowerCase();
-            if (normalized === "horiz" || normalized === "horizontal") {
-                return "horiz";
-            }
-            if (normalized === "vert" || normalized === "vertical") {
-                return "vert";
-            }
-        }
-        return "vert";
+        return this.getValueJS("layoutDirection") === "vert" ? "vert" : "horiz";
     }
 
     private normalizeHorizAlignment(direction: LayoutDirection): HorizontalAlignment {

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -422,13 +422,29 @@ export class LayoutGroup extends Group {
         this.setLayoutDimensions(maxWidth, maxHeight);
     }
 
+    /**
+     * The measured size of the laid-out run.
+     *
+     * A Roku LayoutGroup exposes **no** `width`/`height` fields — device-measured:
+     * `hasField("width")` returns false and `lg.width` reads `invalid`, while
+     * `localBoundingRect()` reports the real size. The engine used to publish its measurement as
+     * real node fields, which meant an app reading `lg.width` got a number here and `invalid` on
+     * hardware — a silent divergence that never surfaces as a crash.
+     *
+     * So the measurement lives here instead, surfaced through `getDimensions()`, which is what every
+     * internal measurement path actually reads (`chooseActiveRect`, `measureUnsizedChildren`, and a
+     * parent LayoutGroup measuring this one as a child).
+     */
+    private layoutWidth = 0;
+    private layoutHeight = 0;
+
+    getDimensions() {
+        return { width: this.layoutWidth, height: this.layoutHeight };
+    }
+
     private setLayoutDimensions(width: number, height: number) {
-        if (!this.nearlyEqual(this.getValueJS("width") as number, width)) {
-            super.setValueSilent("width", new Float(width));
-        }
-        if (!this.nearlyEqual(this.getValueJS("height") as number, height)) {
-            super.setValueSilent("height", new Float(height));
-        }
+        this.layoutWidth = width;
+        this.layoutHeight = height;
     }
 
     private synchronizeChildMetrics(children: Group[], direction: LayoutDirection) {

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -71,14 +71,14 @@ export class LayoutGroup extends Group {
 
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
         const fieldName = index.toLowerCase();
-        super.setValue(index, this.canonicalizeDirection(fieldName, value), alwaysNotify, kind);
+        super.setValue(index, this.canonicalizeEnumField(fieldName, value), alwaysNotify, kind);
         if (this.isLayoutField(fieldName)) {
             this.layoutDirty = true;
         }
     }
 
     setValueSilent(fieldName: string, value: BrsType) {
-        super.setValueSilent(fieldName, this.canonicalizeDirection(fieldName.toLowerCase(), value));
+        super.setValueSilent(fieldName, this.canonicalizeEnumField(fieldName.toLowerCase(), value));
         if (this.isLayoutField(fieldName)) {
             this.layoutDirty = true;
         }
@@ -92,45 +92,66 @@ export class LayoutGroup extends Group {
      */
     protected registerInitializedFields(fields: AAMember[]) {
         super.registerInitializedFields(fields);
-        // Read the primitive: getValue hands back a boxed RoString for string fields.
-        const current = this.getValueJS("layoutDirection");
-        if (typeof current === "string") {
-            const canonical = this.canonicalDirectionValue(current);
+        for (const [mapKey, fieldName] of LayoutGroup.enumFieldNames) {
+            // Read the primitive: getValue hands back a boxed RoString for string fields.
+            const current = this.getValueJS(fieldName);
+            if (typeof current !== "string") {
+                continue;
+            }
+            const canonical = LayoutGroup.canonicalEnumValue(mapKey, current);
             if (canonical !== current) {
-                this.setValueSilent("layoutDirection", new BrsString(canonical));
+                this.setValueSilent(fieldName, new BrsString(canonical));
             }
         }
     }
 
     /**
-     * `layoutDirection` is an ENUM field on Roku, not free text. Device-measured behavior (all
-     * spellings below, identical for XML attributes and runtime writes):
+     * `layoutDirection`, `horizAlignment` and `vertAlignment` are ENUM fields on Roku, not free
+     * text. Device-measured (probe channels `Samples/layoutgroup-probe` and
+     * `Samples/layoutalign-probe`; every spelling tried on XML-attribute and runtime-write paths,
+     * three passes, all agreeing):
      *
-     * - `horiz` / `vert` match case-insensitively and are stored in canonical lowercase, so
-     *   writing `"HORIZ"` reads back as `"horiz"`.
-     * - Anything else is REJECTED rather than stored-and-ignored: the field reads back as `""`.
-     *   `horizontal`, `vertical`, `horz` and `bogus` all land here — near-misses get no leniency.
-     * - A rejected write clobbers a previously valid one (`horiz` then `horz` reads back `""`).
+     * - A documented value matches **case-insensitively** and is stored in **canonical lowercase**,
+     *   so writing `"HORIZ"` or `"LEFT"` reads back `"horiz"` / `"left"`.
+     * - Anything else is **REJECTED** rather than stored-and-ignored: the field reads back `""`.
+     *   Near-misses get no leniency — `horz`, `horizontal`, `centre`, `middle` and `bogus` all land
+     *   here, as does a value belonging to the *sibling* field (`horizAlignment = "top"`), so the
+     *   two alignment fields do not share one value table.
+     * - A rejected write **clobbers** a previously valid one (`center` then `bogus` reads back `""`).
      *
-     * The layout consequence of that empty state lives in `getLayoutDirection`.
+     * The layout consequences of the rejected state differ per field and live in
+     * `getLayoutDirection` (horizontal) and `applyLayout` (cross-axis collapse).
      */
-    private canonicalizeDirection(fieldName: string, value: BrsType): BrsType {
+    private static readonly enumFieldValues = new Map<string, ReadonlySet<string>>([
+        ["layoutdirection", new Set(["horiz", "vert"])],
+        ["horizalignment", new Set(["left", "center", "right", "custom"])],
+        ["vertalignment", new Set(["top", "center", "bottom", "custom"])],
+    ]);
+
+    /** Lowercase map key → the field's declared (camelCase) name. */
+    private static readonly enumFieldNames = new Map<string, string>([
+        ["layoutdirection", "layoutDirection"],
+        ["horizalignment", "horizAlignment"],
+        ["vertalignment", "vertAlignment"],
+    ]);
+
+    private canonicalizeEnumField(fieldName: string, value: BrsType): BrsType {
         // isBrsString (not instanceof) so a boxed roString assignment normalizes like a literal.
-        if (fieldName !== "layoutdirection" || !isBrsString(value)) {
+        if (!LayoutGroup.enumFieldValues.has(fieldName) || !isBrsString(value)) {
             return value;
         }
         const raw = jsValueOf(value);
         if (typeof raw !== "string") {
             return value;
         }
-        const canonical = this.canonicalDirectionValue(raw);
+        const canonical = LayoutGroup.canonicalEnumValue(fieldName, raw);
         return canonical === raw ? value : new BrsString(canonical);
     }
 
-    /** "horiz"/"vert" match case-insensitively; everything else collapses to the rejected state. */
-    private canonicalDirectionValue(value: string): string {
+    /** Documented values match case-insensitively; everything else becomes the rejected state. */
+    private static canonicalEnumValue(fieldName: string, value: string): string {
         const normalized = value.toLowerCase();
-        return normalized === "horiz" || normalized === "vert" ? normalized : "";
+        return LayoutGroup.enumFieldValues.get(fieldName)?.has(normalized) ? normalized : "";
     }
 
     appendChildToParent(child: BrsType): boolean {
@@ -283,6 +304,13 @@ export class LayoutGroup extends Group {
         addSpacingAfterChild: boolean,
         metricsMap: WeakMap<Node, LayoutMetrics>
     ) {
+        // A REJECTED cross-axis alignment abandons the layout entirely on the device — see
+        // collapseChildren. Checked before anything is measured, because nothing downstream runs.
+        if (this.isCrossAlignmentRejected(direction)) {
+            this.collapseChildren(children);
+            return;
+        }
+
         const metricsList = children.map((child) => this.measureChild(child, direction, metricsMap));
         const primaryAlignment =
             direction === "horiz" ? this.getHorizontalPrimaryAlignment() : this.getVerticalPrimaryAlignment();
@@ -352,6 +380,46 @@ export class LayoutGroup extends Group {
         } else {
             this.setLayoutDimensions(maxCross, totalPrimary);
         }
+    }
+
+    /**
+     * True when the alignment field governing the CROSS axis holds the rejected (`""`) state — i.e.
+     * `vertAlignment` for a horizontal group, `horizAlignment` for a vertical one. Never true unless
+     * an app wrote an unrecognized value: the defaults are `left`/`top`.
+     */
+    private isCrossAlignmentRejected(direction: LayoutDirection): boolean {
+        const fieldName = direction === "horiz" ? "vertAlignment" : "horizAlignment";
+        return this.getValueJS(fieldName) === "";
+    }
+
+    /**
+     * Device behavior when the CROSS-axis alignment is rejected: the group abandons layout and puts
+     * every child at its own origin — no stacking, no item spacing, and the children's own
+     * translations are discarded too (they measure at exactly (0,0), not at their authored offsets).
+     * The primary-axis alignment is ignored even when it is perfectly valid.
+     *
+     * Measured, not inferred: with `layoutDirection="vert"` and a junk `horizAlignment`, both probe
+     * children report offset (0,0) instead of the (0,0)/(0,12) a `left` fallback would produce; same
+     * for `layoutDirection="horiz"` with a junk `vertAlignment`. A rejected PRIMARY-axis alignment
+     * does not do this — it simply falls back to `left`/`top`, which the normalizers handle.
+     *
+     * This looks like a device bug, but reproducing it matters: an app with a typo'd alignment shows
+     * a pile-up at the origin on hardware, and a simulator that quietly lays the children out neatly
+     * would hide the breakage until it shipped.
+     */
+    private collapseChildren(children: Group[]) {
+        let maxWidth = 0;
+        let maxHeight = 0;
+        for (const child of children) {
+            this.setChildTranslation(child, [0, 0]);
+            this.assignedTranslations.set(child, [0, 0]);
+            const { rect } = this.chooseActiveRect(child);
+            maxWidth = Math.max(maxWidth, rect.width);
+            maxHeight = Math.max(maxHeight, rect.height);
+        }
+        // No metricsMap entries: synchronizeChildMetrics must not compare these against a laid-out
+        // expectation, or a collapsed group would re-dirty every pass and burn the whole budget.
+        this.setLayoutDimensions(maxWidth, maxHeight);
     }
 
     private setLayoutDimensions(width: number, height: number) {
@@ -555,24 +623,33 @@ export class LayoutGroup extends Group {
         return this.getValueJS("layoutDirection") === "vert" ? "vert" : "horiz";
     }
 
+    /**
+     * The stored value is already canonical (`canonicalizeEnumField`), so this only resolves the two
+     * documented context rules, both device-confirmed:
+     *
+     * - `custom` is a CROSS-axis-only setting. On the primary axis it falls back to `left`/`top`,
+     *   exactly as Roku documents ("If the layoutDirection is horiz, custom is not a valid setting").
+     * - The rejected (`""`) state falls back to `left`/`top`. Only reachable for the PRIMARY axis —
+     *   a rejected cross alignment never gets here, because `applyLayout` collapses first.
+     */
     private normalizeHorizAlignment(direction: LayoutDirection): HorizontalAlignment {
-        const raw = this.getValueJS("horizAlignment");
-        if (typeof raw === "string") {
-            const value = raw.toLowerCase() as HorizontalAlignment;
-            if (value === "left" || value === "center" || value === "right" || value === "custom") {
-                return direction === "horiz" && value === "custom" ? "left" : value;
-            }
+        const value = this.getValueJS("horizAlignment");
+        if (value === "left" || value === "center" || value === "right") {
+            return value;
+        }
+        if (value === "custom") {
+            return direction === "horiz" ? "left" : "custom";
         }
         return "left";
     }
 
     private normalizeVertAlignment(direction: LayoutDirection): VerticalAlignment {
-        const raw = this.getValueJS("vertAlignment");
-        if (typeof raw === "string") {
-            const value = raw.toLowerCase() as VerticalAlignment;
-            if (value === "top" || value === "center" || value === "bottom" || value === "custom") {
-                return direction === "vert" && value === "custom" ? "top" : value;
-            }
+        const value = this.getValueJS("vertAlignment");
+        if (value === "top" || value === "center" || value === "bottom") {
+            return value;
+        }
+        if (value === "custom") {
+            return direction === "vert" ? "top" : "custom";
         }
         return "top";
     }

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -4,7 +4,6 @@ import {
     BrsBoolean,
     BrsString,
     BrsType,
-    Float,
     RoArray,
     IfDraw2D,
     Rect,

--- a/src/extensions/scenegraph/nodes/StdDlgCustomItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgCustomItem.ts
@@ -46,8 +46,9 @@ export class StdDlgCustomItem extends Group implements StdDlgItem {
                 continue;
             }
             const trans = (child.getValueJS("translation") as number[]) ?? [0, 0];
-            let childHeight =
-                child instanceof Label ? child.getMeasured().height : (child.getValueJS("height") as number);
+            // getDimensions(), not the raw height field: a LayoutGroup has no width/height fields on
+            // a real device (see LayoutGroup.layoutHeight) and reports its measured size only here.
+            let childHeight = child instanceof Label ? child.getMeasured().height : child.getDimensions().height;
             // Not `childHeight <= 0`: childHeight can be NaN (unmeasured child), which must also fall
             // back to bitmapHeight. `!(childHeight > 0)` is true for NaN, whereas `NaN <= 0` is false.
             if (!(childHeight > 0)) {

--- a/test/extensions/scenegraph/LayoutAlignment.test.js
+++ b/test/extensions/scenegraph/LayoutAlignment.test.js
@@ -58,6 +58,24 @@ function layoutCase(direction, fieldName, value, secondValue) {
     };
 }
 
+/** Appends the two probe children to an already-configured group, renders, and reports positions. */
+function buildAndRender(layout) {
+    for (const spec of [CHILD_A, CHILD_B]) {
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("width", new Float(spec.width));
+        child.setValue("height", new Float(spec.height));
+        child.setValue("translation", vector(spec.translation));
+        layout.appendChildToParent(child);
+    }
+    layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+    const children = layout.getNodeChildren();
+    return {
+        first: children[0].getValueJS("translation"),
+        second: children[1].getValueJS("translation"),
+    };
+}
+
 function expectPositions(result, first, second) {
     expect(result.first[0]).toBeCloseTo(first[0]);
     expect(result.first[1]).toBeCloseTo(first[1]);
@@ -213,6 +231,54 @@ describe("LayoutGroup alignment fields match device enum behavior", () => {
 
         test("a rejected value written over a valid one also collapses", () => {
             expectPositions(layoutCase("horiz", "vertAlignment", "center", "bogus"), [0, 0], [0, 0]);
+        });
+    });
+
+    // Probe group R (Samples/layoutspacing-probe). The cross-axis collapse was extrapolated to these
+    // combinations before they were measured; hardware confirmed every one.
+    describe("rejected-value combinations", () => {
+        test("both alignments rejected still collapses (the cross-axis rule wins)", () => {
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            layout.setValue("layoutDirection", new BrsString("vert"));
+            layout.setValue("horizAlignment", new BrsString("bogus"));
+            layout.setValue("vertAlignment", new BrsString("bogus"));
+            expectPositions(buildAndRender(layout), [0, 0], [0, 0]);
+        });
+
+        test("a rejected layoutDirection resolves to horiz, making vertAlignment the cross field", () => {
+            // dir rejected → horizontal. A rejected vertAlignment is then the CROSS field → collapse.
+            const collapsing = SGNodeFactory.createNode("LayoutGroup");
+            collapsing.setValue("layoutDirection", new BrsString("bogus"));
+            collapsing.setValue("vertAlignment", new BrsString("bogus"));
+            expectPositions(buildAndRender(collapsing), [0, 0], [0, 0]);
+
+            // Whereas a rejected horizAlignment is the PRIMARY field there → plain left fallback.
+            const laying = SGNodeFactory.createNode("LayoutGroup");
+            laying.setValue("layoutDirection", new BrsString("bogus"));
+            laying.setValue("horizAlignment", new BrsString("bogus"));
+            laying.setValue("itemSpacings", vector([4]));
+            expectPositions(buildAndRender(laying), [0, 0], [34, 0]);
+        });
+    });
+
+    // Probe section F. Roku's Group/LayoutGroup declare no width/height, and the device confirms it:
+    // hasField("width") is false and lg.width reads invalid, while localBoundingRect() is correct.
+    describe("a LayoutGroup exposes no width/height fields", () => {
+        test("the fields are absent before and after layout, but getDimensions() reports the size", () => {
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            layout.setValue("layoutDirection", new BrsString("horiz"));
+            layout.setValue("itemSpacings", vector([4]));
+
+            expect(layout.hasNodeField("width")).toBe(false);
+            expect(layout.hasNodeField("height")).toBe(false);
+
+            buildAndRender(layout);
+
+            expect(layout.hasNodeField("width")).toBe(false);
+            expect(layout.hasNodeField("height")).toBe(false);
+            // 30 + 4 + 50 wide; tallest child is 16.
+            expect(layout.getDimensions().width).toBeCloseTo(84);
+            expect(layout.getDimensions().height).toBeCloseTo(16);
         });
     });
 

--- a/test/extensions/scenegraph/LayoutAlignment.test.js
+++ b/test/extensions/scenegraph/LayoutAlignment.test.js
@@ -1,0 +1,237 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsString, Float, RoArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren when draw2D is absent. */
+const fakeInterpreter = {};
+
+/**
+ * `horizAlignment` and `vertAlignment` are ENUM fields, exactly like `layoutDirection` — see
+ * LayoutDirection.test.js. This file pins the device-measured behavior from the companion probe
+ * channel `Samples/layoutalign-probe` (48 cases: 12 spellings × 4 direction/field combinations,
+ * three passes, all agreeing; the engine now reproduces all 48 rows byte for byte).
+ *
+ * Two children of deliberately different sizes, each with its own non-zero translation, so an
+ * unmanaged ("custom") axis is distinguishable from an aligned one. These are the probe's exact
+ * child specs, so the expected numbers below are the device's numbers, not re-derived ones.
+ */
+const CHILD_A = { width: 30, height: 8, translation: [7, 13] };
+const CHILD_B = { width: 50, height: 16, translation: [11, 17] };
+const SPACING = 4;
+
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
+
+/**
+ * Builds one probe case and returns both children's translations after layout. The group sits at
+ * the origin, so a child's translation is exactly the probe's measured offset from the group origin.
+ */
+function layoutCase(direction, fieldName, value, secondValue) {
+    const layout = SGNodeFactory.createNode("LayoutGroup");
+    layout.setValue("layoutDirection", new BrsString(direction));
+    layout.setValue("itemSpacings", vector([SPACING]));
+    if (value !== undefined) {
+        layout.setValue(fieldName, new BrsString(value));
+    }
+    if (secondValue !== undefined) {
+        layout.setValue(fieldName, new BrsString(secondValue));
+    }
+
+    for (const spec of [CHILD_A, CHILD_B]) {
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("width", new Float(spec.width));
+        child.setValue("height", new Float(spec.height));
+        child.setValue("translation", vector(spec.translation));
+        layout.appendChildToParent(child);
+    }
+
+    layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+    const children = layout.getNodeChildren();
+    return {
+        stored: layout.getValueJS(fieldName),
+        first: children[0].getValueJS("translation"),
+        second: children[1].getValueJS("translation"),
+    };
+}
+
+function expectPositions(result, first, second) {
+    expect(result.first[0]).toBeCloseTo(first[0]);
+    expect(result.first[1]).toBeCloseTo(first[1]);
+    expect(result.second[0]).toBeCloseTo(second[0]);
+    expect(result.second[1]).toBeCloseTo(second[1]);
+}
+
+describe("LayoutGroup alignment fields match device enum behavior", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    describe("storage: documented values canonicalize, everything else is rejected", () => {
+        const cases = [
+            { field: "horizAlignment", written: "left", stored: "left" },
+            { field: "horizAlignment", written: "LEFT", stored: "left" },
+            { field: "horizAlignment", written: "Center", stored: "center" },
+            { field: "horizAlignment", written: "custom", stored: "custom" },
+            { field: "horizAlignment", written: "centre", stored: "" },
+            { field: "horizAlignment", written: "middle", stored: "" },
+            { field: "horizAlignment", written: "", stored: "" },
+            { field: "horizAlignment", written: "bogus", stored: "" },
+            // A value valid for the SIBLING field is rejected: the two fields do not share a table.
+            { field: "horizAlignment", written: "top", stored: "" },
+            { field: "vertAlignment", written: "top", stored: "top" },
+            { field: "vertAlignment", written: "TOP", stored: "top" },
+            { field: "vertAlignment", written: "Center", stored: "center" },
+            { field: "vertAlignment", written: "custom", stored: "custom" },
+            { field: "vertAlignment", written: "centre", stored: "" },
+            { field: "vertAlignment", written: "bogus", stored: "" },
+            { field: "vertAlignment", written: "left", stored: "" },
+        ];
+
+        test.each(cases)('$field = "$written" reads back "$stored"', ({ field, written, stored }) => {
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            layout.setValue(field, new BrsString(written));
+            expect(layout.getValueJS(field)).toBe(stored);
+        });
+
+        test("defaults are left/top and are not the rejected state", () => {
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            expect(layout.getValueJS("horizAlignment")).toBe("left");
+            expect(layout.getValueJS("vertAlignment")).toBe("top");
+        });
+
+        test("a rejected write clobbers a previously valid one", () => {
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            layout.setValue("horizAlignment", new BrsString("center"));
+            layout.setValue("horizAlignment", new BrsString("bogus"));
+            expect(layout.getValueJS("horizAlignment")).toBe("");
+        });
+    });
+
+    // Probe group A. horizAlignment is the CROSS axis: each child is aligned independently.
+    describe("layoutDirection=vert, horizAlignment (cross axis)", () => {
+        test("left aligns both left edges at the origin", () => {
+            expectPositions(layoutCase("vert", "horizAlignment", "left"), [0, 0], [0, 12]);
+        });
+
+        test("center centers each child on the origin independently", () => {
+            expectPositions(layoutCase("vert", "horizAlignment", "center"), [-15, 0], [-25, 12]);
+        });
+
+        test("right aligns both right edges at the origin", () => {
+            expectPositions(layoutCase("vert", "horizAlignment", "right"), [-30, 0], [-50, 12]);
+        });
+
+        test("custom keeps each child's own x while still stacking on y", () => {
+            expectPositions(layoutCase("vert", "horizAlignment", "custom"), [7, 0], [11, 12]);
+        });
+
+        test("a rejected value collapses every child onto the origin", () => {
+            // Device behavior, not a left fallback: the primary-axis stacking is abandoned too, and
+            // the children's own translations are discarded. A `left` fallback would give [0,12] for
+            // the second child; the device gives [0,0].
+            expectPositions(layoutCase("vert", "horizAlignment", "bogus"), [0, 0], [0, 0]);
+        });
+    });
+
+    // Probe group B. horizAlignment is the PRIMARY axis: the whole row is placed as a unit.
+    describe("layoutDirection=horiz, horizAlignment (primary axis)", () => {
+        test("left starts the row at the origin", () => {
+            expectPositions(layoutCase("horiz", "horizAlignment", "left"), [0, 0], [34, 0]);
+        });
+
+        test("center centers the whole row on the origin", () => {
+            expectPositions(layoutCase("horiz", "horizAlignment", "center"), [-42, 0], [-8, 0]);
+        });
+
+        test("right ends the row at the origin", () => {
+            expectPositions(layoutCase("horiz", "horizAlignment", "right"), [-84, 0], [-50, 0]);
+        });
+
+        test("custom is not valid on the primary axis and falls back to left", () => {
+            expectPositions(layoutCase("horiz", "horizAlignment", "custom"), [0, 0], [34, 0]);
+        });
+
+        test("a rejected value falls back to left without collapsing", () => {
+            // The cross axis (vertAlignment) is still valid here, so the layout runs normally —
+            // only a rejected CROSS alignment collapses.
+            expectPositions(layoutCase("horiz", "horizAlignment", "bogus"), [0, 0], [34, 0]);
+        });
+    });
+
+    // Probe group C. vertAlignment is the PRIMARY axis.
+    describe("layoutDirection=vert, vertAlignment (primary axis)", () => {
+        test("top starts the column at the origin", () => {
+            expectPositions(layoutCase("vert", "vertAlignment", "top"), [0, 0], [0, 12]);
+        });
+
+        test("center centers the whole column on the origin", () => {
+            expectPositions(layoutCase("vert", "vertAlignment", "center"), [0, -14], [0, -2]);
+        });
+
+        test("bottom ends the column at the origin", () => {
+            expectPositions(layoutCase("vert", "vertAlignment", "bottom"), [0, -28], [0, -16]);
+        });
+
+        test("custom is not valid on the primary axis and falls back to top", () => {
+            expectPositions(layoutCase("vert", "vertAlignment", "custom"), [0, 0], [0, 12]);
+        });
+
+        test("a rejected value falls back to top without collapsing", () => {
+            expectPositions(layoutCase("vert", "vertAlignment", "bogus"), [0, 0], [0, 12]);
+        });
+
+        test("a rejected value written over a valid one still falls back to top", () => {
+            expectPositions(layoutCase("vert", "vertAlignment", "center", "bogus"), [0, 0], [0, 12]);
+        });
+    });
+
+    // Probe group D. vertAlignment is the CROSS axis.
+    describe("layoutDirection=horiz, vertAlignment (cross axis)", () => {
+        test("top aligns both top edges at the origin", () => {
+            expectPositions(layoutCase("horiz", "vertAlignment", "top"), [0, 0], [34, 0]);
+        });
+
+        test("center centers each child on the origin independently", () => {
+            expectPositions(layoutCase("horiz", "vertAlignment", "center"), [0, -4], [34, -8]);
+        });
+
+        test("bottom aligns both bottom edges at the origin", () => {
+            expectPositions(layoutCase("horiz", "vertAlignment", "bottom"), [0, -8], [34, -16]);
+        });
+
+        test("custom keeps each child's own y while still packing on x", () => {
+            expectPositions(layoutCase("horiz", "vertAlignment", "custom"), [0, 13], [34, 17]);
+        });
+
+        test("a rejected value collapses every child onto the origin", () => {
+            expectPositions(layoutCase("horiz", "vertAlignment", "bogus"), [0, 0], [0, 0]);
+        });
+
+        test("a rejected value written over a valid one also collapses", () => {
+            expectPositions(layoutCase("horiz", "vertAlignment", "center", "bogus"), [0, 0], [0, 0]);
+        });
+    });
+
+    test("a collapsed group settles instead of re-dirtying every layout pass", () => {
+        // collapseChildren deliberately writes no metricsMap entries; if it did, synchronizeChildMetrics
+        // would compare real child sizes against zeroed expectations and burn all 8 passes forever.
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        layout.setValue("horizAlignment", new BrsString("bogus"));
+
+        for (const spec of [CHILD_A, CHILD_B]) {
+            const child = SGNodeFactory.createNode("Rectangle");
+            child.setValue("width", new Float(spec.width));
+            child.setValue("height", new Float(spec.height));
+            layout.appendChildToParent(child);
+        }
+
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        expect(layout.lastPassCount).toBe(1);
+    });
+});

--- a/test/extensions/scenegraph/LayoutDirection.test.js
+++ b/test/extensions/scenegraph/LayoutDirection.test.js
@@ -1,0 +1,162 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { LayoutGroup, SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float } = core;
+
+/** AAMember is a plain `{ name, value }` interface — the shape XML attributes arrive in. */
+function member(name, value) {
+    return { name: new BrsString(name), value: new BrsString(value) };
+}
+
+/** Minimal interpreter accepted by renderNode → renderChildren when draw2D is absent. */
+const fakeInterpreter = {};
+
+/**
+ * `layoutDirection` is an ENUM field on Roku, not free text. This table is DEVICE-MEASURED — every
+ * row was produced by a probe channel (Samples/layoutgroup-probe) that reads each case back with
+ * `sceneBoundingRect()` and reports which axis the children advanced along. Three passes, and the
+ * XML-attribute and runtime-write columns agreed on every row.
+ *
+ * The two counter-intuitive results, and the reason this file exists:
+ *
+ *  1. An unrecognized value is REJECTED, not stored-and-ignored — the field reads back as `""`.
+ *  2. That empty state lays out HORIZONTALLY, even though a never-written field keeps its `"vert"`
+ *     default and lays out vertically. So `layoutDirection="horz"` is a horizontal row on hardware.
+ *
+ * The engine previously treated any unrecognized value as `vert` and accepted `horizontal`/
+ * `vertical` as aliases — both wrong in the direction that silently breaks a real app's menu bar.
+ */
+const deviceCases = [
+    { spelling: "horiz", stored: "horiz", direction: "horiz" },
+    { spelling: "vert", stored: "vert", direction: "vert" },
+    { spelling: "horz", stored: "", direction: "horiz" },
+    { spelling: "horizontal", stored: "", direction: "horiz" },
+    { spelling: "vertical", stored: "", direction: "horiz" },
+    { spelling: "HORIZ", stored: "horiz", direction: "horiz" },
+    { spelling: "Horiz", stored: "horiz", direction: "horiz" },
+    { spelling: "", stored: "", direction: "horiz" },
+    { spelling: "bogus", stored: "", direction: "horiz" },
+];
+
+/**
+ * Builds a group of three fixed-size children and renders it, then reports which axis the children
+ * advanced along — the same inference the device probe makes, so a failure here reads the same way
+ * as a failure on hardware.
+ */
+function layoutAxisOf(layout) {
+    for (let i = 0; i < 3; i++) {
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("width", new Float(40));
+        child.setValue("height", new Float(10));
+        layout.appendChildToParent(child);
+    }
+    layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+    const first = layout.getNodeChildren()[0].getValueJS("translation");
+    const second = layout.getNodeChildren()[1].getValueJS("translation");
+    const dx = second[0] - first[0];
+    const dy = second[1] - first[1];
+
+    if (dx > 1 && dy <= 1) return "horiz";
+    if (dy > 1 && dx <= 1) return "vert";
+    return `neither (dx=${dx} dy=${dy})`;
+}
+
+describe("LayoutGroup layoutDirection matches device enum behavior", () => {
+    beforeAll(() => {
+        // ButtonGroup's default fields include fonts from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("an untouched layoutDirection keeps its vert default and stacks vertically", () => {
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+
+        expect(layout.getValueJS("layoutDirection")).toBe("vert");
+        expect(layoutAxisOf(layout)).toBe("vert");
+    });
+
+    test.each(deviceCases)(
+        'writing "$spelling" stores "$stored" and lays out $direction',
+        ({ spelling, stored, direction }) => {
+            const layout = SGNodeFactory.createNode("LayoutGroup");
+            layout.setValue("layoutDirection", new BrsString(spelling));
+
+            expect(layout.getValueJS("layoutDirection")).toBe(stored);
+            expect(layoutAxisOf(layout)).toBe(direction);
+        }
+    );
+
+    test("a rejected write clobbers a previously valid one and leaves the field empty", () => {
+        // Device case 10: horiz then horz → stored "", laid out HORIZ. The invalid write does not
+        // preserve the earlier valid value; the layout stays horizontal only because the empty
+        // state is itself horizontal.
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("horiz"));
+        layout.setValue("layoutDirection", new BrsString("horz"));
+
+        expect(layout.getValueJS("layoutDirection")).toBe("");
+        expect(layoutAxisOf(layout)).toBe("horiz");
+    });
+
+    test("a rejected write flips a vertical group to horizontal", () => {
+        // The consequence of case 10 that actually bites: a group that WAS laying out vertically
+        // does not stay vertical when handed junk — it rows out. Nothing in the device table covers
+        // vert→invalid directly, but it follows from "stored is now empty, empty is horizontal".
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        layout.setValue("layoutDirection", new BrsString("bogus"));
+
+        expect(layout.getValueJS("layoutDirection")).toBe("");
+        expect(layoutAxisOf(layout)).toBe("horiz");
+    });
+
+    test("a valid re-write still switches direction", () => {
+        // Device case 11: vert then horiz → stored "horiz", laid out HORIZ. Guards against a fix
+        // that canonicalizes so eagerly it stops honoring legitimate changes.
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("vert"));
+        layout.setValue("layoutDirection", new BrsString("horiz"));
+
+        expect(layout.getValueJS("layoutDirection")).toBe("horiz");
+        expect(layoutAxisOf(layout)).toBe("horiz");
+    });
+
+    test("setValueSilent canonicalizes exactly like setValue", () => {
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValueSilent("layoutDirection", new BrsString("HORIZ"));
+        expect(layout.getValueJS("layoutDirection")).toBe("horiz");
+
+        layout.setValueSilent("layoutDirection", new BrsString("horz"));
+        expect(layout.getValueJS("layoutDirection")).toBe("");
+    });
+
+    test("fields supplied at construction are canonicalized too", () => {
+        // The constructor's initializedFields path bypasses setValue (Node writes those straight
+        // into the field map), and it is how cross-thread deserialization and createFlatNode
+        // rebuild a node — so a Task-side copy must report the same value as the render thread.
+        const layout = new LayoutGroup([member("layoutDirection", "Horiz")]);
+        expect(layout.getValueJS("layoutDirection")).toBe("horiz");
+
+        const rejected = new LayoutGroup([member("layoutDirection", "horz")]);
+        expect(rejected.getValueJS("layoutDirection")).toBe("");
+        expect(layoutAxisOf(rejected)).toBe("horiz");
+    });
+
+    test("ButtonGroup inherits the enum behavior without losing its vertical default", () => {
+        // ButtonGroup extends LayoutGroup; its buttons stack vertically by default and that must
+        // not change, but an explicit bad write must behave like any other LayoutGroup.
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        expect(group.getValueJS("layoutDirection")).toBe("vert");
+
+        group.setValue("layoutDirection", new BrsString("horz"));
+        expect(group.getValueJS("layoutDirection")).toBe("");
+    });
+});

--- a/test/extensions/scenegraph/LayoutSpacing.test.js
+++ b/test/extensions/scenegraph/LayoutSpacing.test.js
@@ -1,0 +1,141 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsBoolean, BrsString, Float, RoArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren when draw2D is absent. */
+const fakeInterpreter = {};
+
+const CHILD = { width: 30, height: 10 };
+
+/**
+ * Device-measured `itemSpacings` / `addItemSpacingAfterChild` behavior, from the probe channel
+ * `Samples/layoutspacing-probe` (three children of 30x10, three passes; the engine reproduces every
+ * row). The load-bearing rule is the first one: apps write a single-element `itemSpacings` with many
+ * children constantly, and the engine's "repeat the last entry" reading was an assumption until this
+ * probe confirmed it.
+ */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
+
+/**
+ * Lays out three equal children and reports the first child's offset plus the two gaps BETWEEN
+ * children (distance minus child size, so 0 means touching and negative means overlapping) — the
+ * same quantities the probe prints.
+ */
+function spacingCase(spacings, { addAfter = true, direction = "horiz" } = {}) {
+    const layout = SGNodeFactory.createNode("LayoutGroup");
+    layout.setValue("layoutDirection", new BrsString(direction));
+    layout.setValue("itemSpacings", vector(spacings));
+    layout.setValue("addItemSpacingAfterChild", BrsBoolean.from(addAfter));
+
+    for (let i = 0; i < 3; i++) {
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("width", new Float(CHILD.width));
+        child.setValue("height", new Float(CHILD.height));
+        layout.appendChildToParent(child);
+    }
+    layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+    const axis = direction === "vert" ? 1 : 0;
+    const size = direction === "vert" ? CHILD.height : CHILD.width;
+    const positions = layout.getNodeChildren().map((child) => child.getValueJS("translation")[axis]);
+
+    return {
+        start: positions[0],
+        gaps: [positions[1] - positions[0] - size, positions[2] - positions[1] - size],
+        dimensions: layout.getDimensions(),
+    };
+}
+
+describe("LayoutGroup itemSpacings matches device behavior", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("no spacing packs the children edge to edge", () => {
+        const result = spacingCase([]);
+        expect(result.start).toBeCloseTo(0);
+        expect(result.gaps).toEqual([0, 0]);
+        expect(result.dimensions.width).toBeCloseTo(90);
+    });
+
+    test("a single-entry array repeats that entry for every gap", () => {
+        // The rule that matters most: itemSpacings="[4]" with three children spaces BOTH gaps by 4,
+        // not just the first. Confirmed on hardware.
+        const result = spacingCase([4]);
+        expect(result.gaps).toEqual([4, 4]);
+        expect(result.dimensions.width).toBeCloseTo(98);
+    });
+
+    test("an exactly-sized array maps entry i to the gap after child i", () => {
+        const result = spacingCase([4, 9]);
+        expect(result.gaps).toEqual([4, 9]);
+        expect(result.dimensions.width).toBeCloseTo(103);
+    });
+
+    test("entries past the last gap are ignored, adding no trailing space", () => {
+        // The extra entries must not widen the group: a trailing space would change the size every
+        // parent measures (a wrapping LayoutGroup, a dialog sizing itself around it).
+        const three = spacingCase([4, 9, 15]);
+        const four = spacingCase([4, 9, 15, 20]);
+        expect(three.gaps).toEqual([4, 9]);
+        expect(four.gaps).toEqual([4, 9]);
+        expect(three.dimensions.width).toBeCloseTo(103);
+        expect(four.dimensions.width).toBeCloseTo(103);
+    });
+
+    test("negative spacing overlaps the children instead of clamping to zero", () => {
+        const result = spacingCase([-6]);
+        expect(result.gaps).toEqual([-6, -6]);
+        expect(result.dimensions.width).toBeCloseTo(78);
+    });
+
+    test("fractional spacing is used as-is, not rounded", () => {
+        const result = spacingCase([2.5]);
+        expect(result.gaps[0]).toBeCloseTo(2.5);
+        expect(result.gaps[1]).toBeCloseTo(2.5);
+        expect(result.dimensions.width).toBeCloseTo(95);
+    });
+
+    test("the same index mapping applies to a vertical layout", () => {
+        expect(spacingCase([4], { direction: "vert" }).gaps).toEqual([4, 4]);
+
+        const exact = spacingCase([4, 9], { direction: "vert" });
+        expect(exact.gaps).toEqual([4, 9]);
+        expect(exact.dimensions.height).toBeCloseTo(43);
+    });
+
+    describe("addItemSpacingAfterChild=false inserts the space BEFORE each child", () => {
+        test("the whole run shifts by the first entry", () => {
+            // The first child is pushed off the origin by spacings[0] — the visible signature of
+            // before-placement insertion, and the reason the group's own rect starts at x=4.
+            const result = spacingCase([4], { addAfter: false });
+            expect(result.start).toBeCloseTo(4);
+            expect(result.gaps).toEqual([4, 4]);
+        });
+
+        test("gaps come from the FOLLOWING entries, not the preceding ones", () => {
+            // [4,9]: 4 before child 0, 9 before child 1, then 9 repeated before child 2 → gaps 9,9.
+            const result = spacingCase([4, 9], { addAfter: false });
+            expect(result.start).toBeCloseTo(4);
+            expect(result.gaps).toEqual([9, 9]);
+        });
+
+        test("a third entry is consumed by the third child rather than ignored", () => {
+            // Mirror of the addAfter=true case: with before-placement there IS a third gap position,
+            // so [4,9,15] is fully used where addAfter=true would have dropped the 15.
+            const result = spacingCase([4, 9, 15], { addAfter: false });
+            expect(result.start).toBeCloseTo(4);
+            expect(result.gaps).toEqual([9, 15]);
+        });
+
+        test("an empty array leaves the run at the origin", () => {
+            const result = spacingCase([], { addAfter: false });
+            expect(result.start).toBeCloseTo(0);
+            expect(result.gaps).toEqual([0, 0]);
+        });
+    });
+});

--- a/test/extensions/scenegraph/StandardDialogNodes.test.js
+++ b/test/extensions/scenegraph/StandardDialogNodes.test.js
@@ -807,10 +807,14 @@ describe("Standard Dialog Framework nodes", () => {
             dialog.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
             dialog.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
 
-            const listHeight = list.getValueJS("height");
+            // getDimensions(), not getValueJS("height"): a LayoutGroup exposes no width/height FIELDS
+            // on a real device (hasField("width") is false, lg.width reads invalid — device-measured
+            // in Samples/layoutspacing-probe), so its measured size is only readable this way.
+            const listHeight = list.getDimensions().height;
             // The LayoutGroup reports its stacked size (3 rows + 2 gaps), and the custom item wraps it.
             expect(listHeight).toBeGreaterThan(0);
             expect(custom.getValueJS("height")).toBe(listHeight);
+            expect(list.hasNodeField("width")).toBe(false);
             // The button row sits below the custom item's content, not overlapping it.
             const buttonTop = buttonArea.getValueJS("translation")[1];
             const customBottom = custom.getValueJS("translation")[1] + custom.getValueJS("height");


### PR DESCRIPTION
## Summary

Three device probes' worth of `LayoutGroup` fidelity fixes. Everything here is **measured on
hardware**, not reasoned from the docs — three purpose-built probe channels covering **94 cases**,
each run over both the XML-attribute and runtime-write paths, three passes, with the engine's output
diffed against the device log mechanically rather than by eye.

| Probe | Cases | Found |
| --- | --- | --- |
| `layoutgroup-probe` | 22 | `layoutDirection` is a **rejecting enum**; its empty state lays out **horizontally**, not `vert` |
| `layoutalign-probe` | 48 | same storage rule for the alignment fields; a rejected **cross-axis** alignment **collapses** every child onto the origin |
| `layoutspacing-probe` | 24 | a LayoutGroup has **no `width`/`height` fields** |

All three probes now reproduce their device tables exactly: 22/22, 48/48, 24/24.

## 1. The three string fields are rejecting enums

`layoutDirection`, `horizAlignment` and `vertAlignment` are enums, not free text:

- Documented values match **case-insensitively** and are stored **lowercase-canonical**: `"HORIZ"`
  reads back `"horiz"`, `"LEFT"` reads back `"left"`.
- Anything else is **REJECTED**, not stored-and-ignored: the field reads back `""`. Near-misses get
  no leniency — `horz`, `horizontal`, `vertical`, `centre`, `middle`, `bogus` — and a value belonging
  to the **sibling** field is rejected too (`horizAlignment = "top"`), so the alignment fields do not
  share one value table.
- A rejected write **clobbers** a previously valid one.

What the rejected state *does* differs per field:

| Field | Rejected-state behavior | engine before |
| --- | --- | --- |
| `layoutDirection` | lays out **HORIZONTALLY** | ❌ fell back to `vert` |
| alignment on the **primary** axis | falls back to `left`/`top` | ✅ matched |
| alignment on the **cross** axis | **collapses: every child at (0,0)** | ❌ laid out as `left`/`top` |

The `layoutDirection` asymmetry is the counter-intuitive one: an untouched field keeps its `"vert"`
default and stacks vertically, but a field written with an unrecognized value ends up empty and
**rows out horizontally**. So `<LayoutGroup layoutDirection="horz" />` is a horizontal row on
hardware. The engine mapped every unrecognized value to `vert` and stacked the children — the bug
that started this. It also accepted `horizontal`/`vertical` as aliases, mapping `vertical` → vert,
the opposite of hardware.

## 2. The cross-axis collapse

With `layoutDirection="vert"` and a junk `horizAlignment`, both probe children report offset `(0,0)`:

```
  left     "left"   left   c0=(0,0)   c1=(0,12)     <- normal: stacked 8+4 apart
  bogus    ""       left   c0=(0,0)   c1=(0,0)      <- both children ON the origin
```

A `left` fallback would still stack them. The device abandons the layout entirely — no stacking, no
item spacing, children's own translations discarded — even though the primary-axis alignment is
perfectly valid. A rejected *primary*-axis alignment does not do this.

This looks like a device bug, and is reproduced deliberately (`collapseChildren`): an app with a
typo'd alignment piles its children on the origin on hardware, and a simulator that quietly laid them
out neatly would hide the breakage until it shipped. Easy to revert — it is one guarded branch.

## 3. A LayoutGroup has no `width`/`height` fields

```
                        device                    engine (before)
  hasField(width)       false                     true
  width                 invalid                   98
  localBoundingRect()   (0,0,98,10)               (0,0,98,10)
```

The engine published its measurement by writing real node fields, so an app reading `lg.width` got a
number here and `invalid` on hardware — a silent difference that surfaces only as wrong layout in
whatever the app computed from it. The measurement moves to private `layoutWidth`/`layoutHeight`,
surfaced by overriding `getDimensions()`, which is what every internal measurement path already used.

One caller read the raw field instead — `StdDlgCustomItem.measureContentHeight` — and would have
sized a dialog to 0 around a LayoutGroup. It now uses `getDimensions()` too. **New rule: never read a
LayoutGroup's size with `getValueJS("width")`.**

## What was already right

Worth recording, because the probes confirmed several load-bearing assumptions rather than breaking
them: `itemSpacings` repeats its last entry for gaps past the end of the array (`[4]` spaces every
gap), drops entries past the last gap with no trailing space, overlaps on negative values, uses
fractional values as-is, and with `addItemSpacingAfterChild=false` inserts space before each child
including the first. Valid alignment values matched on every row, including `custom` falling back to
`left`/`top` on the primary axis exactly as documented. And the cross-axis collapse rule held for
every rejected-value combination, including ones that had only been extrapolated.

## Changes

- **`nodes/LayoutGroup.ts`** — `canonicalizeEnumField` normalizes all three fields on write, applied
  in `setValue`, `setValueSilent` **and** `registerInitializedFields` (XML attributes and cross-thread
  deserialization write straight into the field map, bypassing `setValue`, so a Task-side copy would
  otherwise disagree with the render thread). Uses `isBrsString`, not `instanceof`, so a boxed
  `roString` normalizes and the guard stays realm-safe. `applyLayout` checks `isCrossAlignmentRejected`
  before measuring anything. `setLayoutDimensions` writes private state; `getDimensions()` is overridden.
- **`nodes/StdDlgCustomItem.ts`** — measures children via `getDimensions()`.
- **Tests** — `LayoutDirection.test.js` (16), `LayoutAlignment.test.js` (44), `LayoutSpacing.test.js`
  (11), plus a `StandardDialogNodes.test.js` update. Between them they pin every device row, the
  constructor/`initializedFields` path, clobbering, `ButtonGroup` inheriting the enum behavior while
  keeping its `vert` default, field absence before and after layout, and a guard that a collapsed
  group settles in one pass instead of burning the layout-convergence budget.
- **`.claude/docs/scenegraph-invariants.md`** — all four measured tables, with explicit warnings not
  to "fix" `getLayoutDirection` back to the documented default, not to populate the metrics map from
  `collapseChildren`, and not to read a LayoutGroup's size from the raw fields.

## Verification

- All three probes re-run under `brs-cli` reproduce their device logs exactly (22/22, 48/48, 24/24
  lines), diffed mechanically.
- Full suite: **192 files, 2383 tests passing**. `npm run lint` and `npm run prettier` clean.

## Follow-up (not in this PR)

Other node types may declare `width`/`height` the device does not have — `Group` is the obvious next
candidate, since the engine writes those fields on several nodes Roku documents without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)