### PR TITLE
fix(scenegraph): keep script-scope references to global/top alive across a Task launch

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -696,6 +696,20 @@ export function initializeTask(interpreter: Interpreter, taskData: TaskData) {
 }
 
 /**
+ * Maps the address a node was serialized under to this thread's instance of it, so circular
+ * references elsewhere in the same payload resolve to the live node.
+ * @param nodeMap Address map being built.
+ * @param source Serialized node representation, if present.
+ * @param node This thread's instance of that node.
+ */
+function registerSerializedAddress(nodeMap: Map<string, Node>, source: any, node: Node | undefined) {
+    const address: unknown = source?.["_address_"];
+    if (node && typeof address === "string") {
+        nodeMap.set(address, node);
+    }
+}
+
+/**
  * Restores task fields and context from serialized task data.
  * Sets up the task's m pointer, global state, and scene reference.
  * Restores field observers and message port connections.
@@ -705,13 +719,20 @@ export function initializeTask(interpreter: Interpreter, taskData: TaskData) {
  */
 function loadTaskData(interpreter: Interpreter, node: Node, taskData: TaskData) {
     let port: RoMessagePort | undefined;
+    // `m.global`/`m.top` are serialized first, so anything else in `m` that also references them
+    // (a script-scope cache, or a class instance that stored `GetGlobalAA().global` in a field)
+    // arrives as a `_circular_` stub pointing at their addresses. Seed the map with this thread's
+    // own instances so those stubs resolve to the live nodes instead of deserializing to invalid.
+    const nodeMap = new Map<string, Node>();
+    registerSerializedAddress(nodeMap, taskData.m?.global, sgRoot.mGlobal);
+    registerSerializedAddress(nodeMap, taskData.m?.top, node);
     if (taskData.m) {
         for (let [key, value] of Object.entries(taskData.m)) {
             if (key === "global" || key === "top") {
                 // Ignore special fields to be set later
                 continue;
             }
-            const brsValue = brsValueOf(value);
+            const brsValue = brsValueOf(value, undefined, nodeMap);
             if (!port && brsValue instanceof RoMessagePort) {
                 port = brsValue;
             }
@@ -719,10 +740,10 @@ function loadTaskData(interpreter: Interpreter, node: Node, taskData: TaskData) 
         }
     }
     if (taskData.m?.global) {
-        restoreNode(interpreter, taskData.m.global, sgRoot.mGlobal, port);
+        restoreNode(interpreter, taskData.m.global, sgRoot.mGlobal, port, nodeMap);
     }
     if (taskData.m?.top) {
-        restoreNode(interpreter, taskData.m.top, node, port);
+        restoreNode(interpreter, taskData.m.top, node, port, nodeMap);
     }
     // Deliver events that were already queued on the task's ports before launch (a device task
     // sees them because its copied `m` references the same native port).
@@ -765,8 +786,15 @@ export function updateTypeDefHierarchy(typeDef: ComponentDefinition | undefined)
  * @param source Serialized source object containing field values
  * @param node Node to restore fields into
  * @param port Optional message port for field observers
+ * @param nodeMap Optional address map used to resolve circular references to already-known nodes
  */
-function restoreNode(interpreter: Interpreter, source: any, node: Node, port?: RoMessagePort) {
+function restoreNode(
+    interpreter: Interpreter,
+    source: any,
+    node: Node,
+    port?: RoMessagePort,
+    nodeMap?: Map<string, Node>
+) {
     const observedFields = source["_observed_"];
     node.setOwner(source["_owner_"] ?? sgRoot.threadId);
     node.setAddress(source["_address_"] ?? node.getAddress());
@@ -775,7 +803,7 @@ function restoreNode(interpreter: Interpreter, source: any, node: Node, port?: R
             // Ignore serialization metadata fields
             continue;
         }
-        const brsValue = brsValueOf(value);
+        const brsValue = brsValueOf(value, undefined, nodeMap);
         if (brsValue instanceof Node) {
             postMessage(`debug,[thread:${sgRoot.threadId}] Restoring Node ${node.nodeSubtype} field "${key}"`);
         }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1200,6 +1200,26 @@ describe.concurrent("cli", () => {
         expect(lines).toContain("=== Task Clear Node Repro Complete ===");
     }, 30000);
 
+    it("Keeps script-scope references to global/top alive across a Task launch", async () => {
+        let command = ["node", brsCliPath, "-r task-script-scope-ref-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // `m.global` and `m.top` are serialized before the rest of `m`, so any other entry holding
+        // the same nodes (a cache, or a transpiled class instance that stored `GetGlobalAA().global`
+        // in a field) crosses as a `_circular_` stub. The task-side restore deserialized those with
+        // an empty address map, so every such reference came back `invalid` and the first dot access
+        // on it crashed the task thread.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("HELPER GLOBAL TYPE: roSGNode");
+        expect(lines).toContain("HELPER TOP TYPE: roSGNode");
+        expect(lines).toContain("HELPER GLOBAL VERSION: 10.9.0");
+        expect(lines).toContain("HELPER TOP LABEL: grid");
+        expect(lines).toContain("TASK RESULT: ok");
+        expect(lines).toContain("=== Task Script Scope Ref Repro Complete ===");
+    }, 30000);
+
     it("Resolves an anonymous function observer registered by its toStr() name", async () => {
         let command = ["node", brsCliPath, "-r anon-observer-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/task-script-scope-ref-app/components/MainScene.xml
+++ b/test/cli/resources/task-script-scope-ref-app/components/MainScene.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.task = createObject("roSGNode", "TaskTest")
+        m.task.observeField("result", "onResult")
+        m.task.label = "grid"
+        m.task.control = "run"
+    end sub
+
+    sub onResult(event as object)
+        print "TASK RESULT: "; event.getData()
+        m.top.done = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-script-scope-ref-app/components/TaskTest.xml
+++ b/test/cli/resources/task-script-scope-ref-app/components/TaskTest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="TaskTest" extends="Task">
+    <interface>
+        <field id="label" type="string" />
+        <field id="result" type="string" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+        ' Mirrors what a transpiled BrighterScript class instance looks like in `m`: a plain AA
+        ' that cached the global/top nodes in its fields during construction. `m.global` and
+        ' `m.top` are serialized before it, so its copies of them cross as circular references.
+        m.helper = { global: GetGlobalAA().global, top: m.top }
+    end sub
+
+    sub runTask()
+        print "HELPER GLOBAL TYPE: "; type(m.helper.global)
+        print "HELPER TOP TYPE: "; type(m.helper.top)
+        print "HELPER GLOBAL VERSION: "; m.helper.global.server.version
+        print "HELPER TOP LABEL: "; m.helper.top.label
+        m.top.result = "ok"
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-script-scope-ref-app/manifest
+++ b/test/cli/resources/task-script-scope-ref-app/manifest
@@ -1,0 +1,4 @@
+title=Task Script Scope Ref Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-script-scope-ref-app/source/main.brs
+++ b/test/cli/resources/task-script-scope-ref-app/source/main.brs
@@ -1,0 +1,16 @@
+sub Main()
+    print "=== Task Script Scope Ref Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    globalNode = screen.getGlobalNode()
+    globalNode.addFields({ server: { version: "10.9.0" } })
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Pump the message loop until the Task observer fires (the scene sets `done`).
+    for i = 0 to 250
+        msg = wait(20, port)
+        if scene.done then exit for
+    end for
+    print "=== Task Script Scope Ref Repro Complete ==="
+end sub


### PR DESCRIPTION
## Summary

A script-scope value that holds a reference to `m.global` or `m.top` becomes `invalid` the moment
it crosses into a Task thread. The first dot access on it crashes the task:

```
'Dot' Operator attempted with invalid BrightScript Component or interface reference.
```

The render thread sees a perfectly valid node, so nothing looks wrong until the Task launches —
and the backtrace points at whatever code dereferenced the reference, not at the serialization
that broke it.

## The bug

`serializeTaskM` walks the Task node's `m` in insertion order. `top` and `global` are set at node
creation, so they are serialized **first** and land in the pass's `visited` set. Any *other* entry
in `m` that also holds one of those nodes is therefore emitted as a `_circular_` stub carrying
only an `_address_`:

```jsonc
// m.helper, serialized
{ "global": { "_circular_": "Node:Global", "_address_": "0x…" } }
```

On the receiving side, `loadTaskData` deserialized every non-`top`/`global` entry with
`brsValueOf(value)` — **with no address map**. `toSGNode` looks a `_circular_` stub up in that map,
finds nothing, and falls through to:

```ts
// If we don't have the node yet, this might be a forward reference
// Return invalid for now (should not happen in valid serialized data)
return BrsInvalid.Instance as any;
```

It is not a forward reference here — the task *does* have both nodes, built locally in
`initializeTask` — they were simply never registered under the addresses the payload refers to.

## Why this shows up in real apps

The obvious form (`m.someCache = { g: m.global }`) is rare, but **every transpiled BrighterScript
class instance stored in `m` takes this shape** when its constructor caches the global node — a
common pattern, because `m` inside a class method is the instance, not the thread AA, so classes
have to capture it up front:

```brightscript
class DataTransformer
  private global = invalid
  sub new()
    m.global = GetGlobalAA().global   ' m is the instance here
  end sub
  function transform(data)
    version = m.global.server.version  ' crashes in a Task thread
  end function
end class
```

`init()` runs on the render thread and stores the instance in `m`; the task thread then gets the
instance back with its `global` field emptied out.

## The fix

Seed a `Map<string, Node>` with the addresses `global`/`top` were serialized under, mapped to this
thread's own instances, before restoring the rest of `m` — then thread it through every
`brsValueOf` call in `loadTaskData` and `restoreNode` so node-valued fields resolve to the same
instances rather than duplicating them.

```ts
const nodeMap = new Map<string, Node>();
registerSerializedAddress(nodeMap, taskData.m?.global, sgRoot.mGlobal);
registerSerializedAddress(nodeMap, taskData.m?.top, node);
```

## Not covered

A `_circular_` reference to a **descendant** of `m.top` (serialized inside `top`'s subtree, but
restored *after* the other `m` entries) is still a genuine forward reference and still resolves to
invalid. Closing that means restoring `top`/`global` before the rest of `m`, which conflicts with
the port-discovery pass that has to run first to give `restoreNode` its `roMessagePort`. Left as a
separate change — it is a rarer shape than caching `m.global`, and this PR is the crash people
actually hit.

## Testing

New regression app `test/cli/resources/task-script-scope-ref-app`: a Task whose `init()` stores
`m.helper = { global: GetGlobalAA().global, top: m.top }`, then reads a field through each of them
from the task thread. Both references come back `roSGNode` and rendezvous correctly; before the
fix both were `roInvalid` and the first read crashed the thread.

- `npm test` — 2384 passed / 192 files
- `npm run lint`, `npm run prettier` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
