### PR TITLE
fix(scenegraph): resolve script-scope references into the top/global subtrees on Task launch

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -719,31 +719,39 @@ function registerSerializedAddress(nodeMap: Map<string, Node>, source: any, node
  */
 function loadTaskData(interpreter: Interpreter, node: Node, taskData: TaskData) {
     let port: RoMessagePort | undefined;
-    // `m.global`/`m.top` are serialized first, so anything else in `m` that also references them
-    // (a script-scope cache, or a class instance that stored `GetGlobalAA().global` in a field)
-    // arrives as a `_circular_` stub pointing at their addresses. Seed the map with this thread's
-    // own instances so those stubs resolve to the live nodes instead of deserializing to invalid.
+    // Restore `m` in the order the payload was written. `serializeTaskM` emits `top` and `global`
+    // first and writes any node it has already emitted as a `_circular_` back-reference, so
+    // replaying that order is what makes those back-references resolve: every one of them points
+    // at a node an earlier entry has already rebuilt. Restoring the other entries first (as this
+    // did) turned every reference into a subtree of `top`/`global` into a forward reference with
+    // nothing to resolve against, and it deserialized to invalid.
     const nodeMap = new Map<string, Node>();
+    // `top`/`global` themselves are rebuilt by the caller, not by this pass — register the
+    // addresses they were serialized under so references to them resolve regardless of key order.
     registerSerializedAddress(nodeMap, taskData.m?.global, sgRoot.mGlobal);
     registerSerializedAddress(nodeMap, taskData.m?.top, node);
     if (taskData.m) {
         for (let [key, value] of Object.entries(taskData.m)) {
-            if (key === "global" || key === "top") {
-                // Ignore special fields to be set later
-                continue;
+            if (key === "global") {
+                restoreNodeFields(taskData.m.global, sgRoot.mGlobal, nodeMap);
+            } else if (key === "top") {
+                restoreNodeFields(taskData.m.top, node, nodeMap);
+            } else {
+                const brsValue = brsValueOf(value, undefined, nodeMap);
+                if (!port && brsValue instanceof RoMessagePort) {
+                    port = brsValue;
+                }
+                node.m.set(new BrsString(key), brsValue);
             }
-            const brsValue = brsValueOf(value, undefined, nodeMap);
-            if (!port && brsValue instanceof RoMessagePort) {
-                port = brsValue;
-            }
-            node.m.set(new BrsString(key), brsValue);
         }
-    }
-    if (taskData.m?.global) {
-        restoreNode(interpreter, taskData.m.global, sgRoot.mGlobal, port, nodeMap);
-    }
-    if (taskData.m?.top) {
-        restoreNode(interpreter, taskData.m.top, node, port, nodeMap);
+        // Observers are attached in a second pass: they need the task's message port, and that
+        // only turns up while restoring `m`'s other entries.
+        if (taskData.m.global) {
+            restoreNodeObservers(interpreter, taskData.m.global, sgRoot.mGlobal, port);
+        }
+        if (taskData.m.top) {
+            restoreNodeObservers(interpreter, taskData.m.top, node, port);
+        }
     }
     // Deliver events that were already queued on the task's ports before launch (a device task
     // sees them because its copied `m` references the same native port).
@@ -780,24 +788,20 @@ export function updateTypeDefHierarchy(typeDef: ComponentDefinition | undefined)
 }
 
 /**
- * Restores node fields from a serialized object.
- * Sets field values and reattaches field observers with message ports.
- * @param interpreter Interpreter instance for observer setup
+ * Restores a node's identity and field values from a serialized object.
+ *
+ * Split from observer restoration ({@link restoreNodeObservers}) so the fields can be rebuilt in
+ * payload order — the port the observers need is only discovered later.
  * @param source Serialized source object containing field values
  * @param node Node to restore fields into
- * @param port Optional message port for field observers
  * @param nodeMap Optional address map used to resolve circular references to already-known nodes
  */
-function restoreNode(
-    interpreter: Interpreter,
-    source: any,
-    node: Node,
-    port?: RoMessagePort,
-    nodeMap?: Map<string, Node>
-) {
-    const observedFields = source["_observed_"];
+function restoreNodeFields(source: any, node: Node, nodeMap?: Map<string, Node>) {
     node.setOwner(source["_owner_"] ?? sgRoot.threadId);
     node.setAddress(source["_address_"] ?? node.getAddress());
+    // Register under the address it was serialized with (which `setAddress` has just applied), so
+    // back-references to this node later in the payload resolve to it.
+    nodeMap?.set(node.getAddress(), node);
     for (let [key, value] of Object.entries(source)) {
         if (key.startsWith("_") && key.endsWith("_") && key.length > 2) {
             // Ignore serialization metadata fields
@@ -808,12 +812,29 @@ function restoreNode(
             postMessage(`debug,[thread:${sgRoot.threadId}] Restoring Node ${node.nodeSubtype} field "${key}"`);
         }
         node.setValueSilent(key, brsValue);
-        if (port && Array.isArray(observedFields)) {
-            const observed = observedFields.find((field: ObservedField) => field.name === key);
-            if (observed) {
-                const infoFields = observed.info ? brsValueOf(observed.info) : undefined;
-                node.addObserver(interpreter, "unscoped", new BrsString(key), port, infoFields);
-            }
+    }
+}
+
+/**
+ * Reattaches the field observers a serialized node carried, binding them to the task's port.
+ * @param interpreter Interpreter instance for observer setup
+ * @param source Serialized source object containing the observed-field list
+ * @param node Node to attach the observers to
+ * @param port Message port for the field observers; no-op when the task has none
+ */
+function restoreNodeObservers(interpreter: Interpreter, source: any, node: Node, port?: RoMessagePort) {
+    const observedFields = source["_observed_"];
+    if (!port || !Array.isArray(observedFields)) {
+        return;
+    }
+    for (const key of Object.keys(source)) {
+        if (key.startsWith("_") && key.endsWith("_") && key.length > 2) {
+            continue;
+        }
+        const observed = observedFields.find((field: ObservedField) => field.name === key);
+        if (observed) {
+            const infoFields = observed.info ? brsValueOf(observed.info) : undefined;
+            node.addObserver(interpreter, "unscoped", new BrsString(key), port, infoFields);
         }
     }
 }

--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -490,6 +490,24 @@ function applyRemotePortObservers(obj: any, node: Node) {
     }
 }
 
+/**
+ * Constructs a bare node of the given type, without running any render-side initialization.
+ *
+ * The `deserializing` guard keeps media nodes (Video/Audio) rebuilt as cross-thread copies from
+ * running their render-init, which would hijack the singleton `sgRoot.video`/`audio` and reset the
+ * real player. The prior value is restored so nested/recursive deserialization stays correct.
+ * @param type Serialized node type.
+ * @param subtype Serialized node subtype.
+ * @returns The new node, falling back to a plain `Node` for an unknown type.
+ */
+function buildFlatNode(type: string, subtype: string): Node {
+    const wasDeserializing = sgRoot.deserializing;
+    sgRoot.deserializing = true;
+    const created = createFlatNode(type, subtype);
+    sgRoot.deserializing = wasDeserializing;
+    return created instanceof BrsInvalid ? new Node([], subtype) : created;
+}
+
 export function toSGNode(obj: any, type: string, subtype: string, child?: boolean, nodeMap?: Map<string, Node>): Node {
     // Initialize nodeMap on first call
     nodeMap ??= new Map<string, Node>();
@@ -500,20 +518,20 @@ export function toSGNode(obj: any, type: string, subtype: string, child?: boolea
         if (existingNode) {
             return existingNode;
         }
-        // If we don't have the node yet, this might be a forward reference
-        // Return invalid for now (should not happen in valid serialized data)
-        return BrsInvalid.Instance as any;
+        // The node this points at was not rebuilt on this thread: the pass reached it by a route
+        // it does not restore locally — a runtime-appended child of the task node, say, whose
+        // `_children_` the receiver does not replay. The owner still resolves the address (it was
+        // registered when the full copy was written), so stand in an address-only proxy and let
+        // reads rendezvous. Answering invalid here crashes the app's first dot access instead.
+        const stub = buildFlatNode(type, subtype);
+        stub.setAddress(obj["_address_"]);
+        stub.setOwner(0);
+        stub.setRemoteProxy(true);
+        nodeMap.set(obj["_address_"], stub);
+        sgRoot.registerCrossThreadNode(stub);
+        return stub;
     }
-    // Guard the construction so media nodes (Video/Audio) rebuilt as cross-thread proxies do not run
-    // their render-init (which would hijack the singleton sgRoot.video/audio and reset the real
-    // player). Restore the prior value to stay correct under nested/recursive deserialization.
-    const wasDeserializing = sgRoot.deserializing;
-    sgRoot.deserializing = true;
-    let newNode = createFlatNode(type, subtype);
-    sgRoot.deserializing = wasDeserializing;
-    if (newNode instanceof BrsInvalid) {
-        newNode = new Node([], subtype);
-    }
+    const newNode = buildFlatNode(type, subtype);
     // Store the node in the map using the original address for circular reference resolution
     // Use the address from serialized data if available, otherwise use the new node's address
     newNode.setAddress(obj["_address_"] || newNode.getAddress());

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1208,15 +1208,24 @@ describe.concurrent("cli", () => {
         });
         // `m.global` and `m.top` are serialized before the rest of `m`, so any other entry holding
         // the same nodes (a cache, or a transpiled class instance that stored `GetGlobalAA().global`
-        // in a field) crosses as a `_circular_` stub. The task-side restore deserialized those with
-        // an empty address map, so every such reference came back `invalid` and the first dot access
-        // on it crashed the task thread.
+        // in a field) crosses as a `_circular_` back-reference. The task-side restore rebuilt `m`'s
+        // other entries *first*, so those references had nothing to resolve against: they came back
+        // `invalid` and the first dot access on one crashed the task thread.
         const lines = stdout.split("\n").map((line) => line.trimEnd());
         expect(lines).toContain("HELPER GLOBAL TYPE: roSGNode");
         expect(lines).toContain("HELPER TOP TYPE: roSGNode");
         expect(lines).toContain("HELPER GLOBAL VERSION: 10.9.0");
         expect(lines).toContain("HELPER TOP LABEL: grid");
+        // The same shape one level deeper — references to nodes *inside* the `m.top` subtree.
+        // Both must resolve to the one real node, not to a detached copy.
+        expect(lines).toContain("FIELD REF TYPE: roSGNode");
+        expect(lines).toContain("FIELD REF TITLE: payload-from-init");
+        expect(lines).toContain("FIELD REF SAME: true");
+        expect(lines).toContain("CHILD REF TYPE: roSGNode");
+        expect(lines).toContain("CHILD REF TITLE: child-from-init");
+        expect(lines).toContain("CHILD REF SAME: true");
         expect(lines).toContain("TASK RESULT: ok");
+        expect(lines).toContain("RENDER SEES TITLE: changed-in-task");
         expect(lines).toContain("=== Task Script Scope Ref Repro Complete ===");
     }, 30000);
 

--- a/test/cli/resources/task-script-scope-ref-app/components/MainScene.xml
+++ b/test/cli/resources/task-script-scope-ref-app/components/MainScene.xml
@@ -13,6 +13,9 @@
 
     sub onResult(event as object)
         print "TASK RESULT: "; event.getData()
+        ' The task wrote through its script-scope reference; the render thread holds the real
+        ' node, so the change is only visible here if that reference reached it.
+        print "RENDER SEES TITLE: "; m.task.payloadNode.title
         m.top.done = true
     end sub
     ]]></script>

--- a/test/cli/resources/task-script-scope-ref-app/components/TaskTest.xml
+++ b/test/cli/resources/task-script-scope-ref-app/components/TaskTest.xml
@@ -2,6 +2,7 @@
 <component name="TaskTest" extends="Task">
     <interface>
         <field id="label" type="string" />
+        <field id="payloadNode" type="node" />
         <field id="result" type="string" />
     </interface>
     <script type="text/brightscript"><![CDATA[
@@ -11,6 +12,20 @@
         ' that cached the global/top nodes in its fields during construction. `m.global` and
         ' `m.top` are serialized before it, so its copies of them cross as circular references.
         m.helper = { global: GetGlobalAA().global, top: m.top }
+
+        ' The same shape one level deeper: references to nodes that live *inside* the `m.top`
+        ' subtree rather than being `m.top` itself — a node-valued field, and a child.
+        payload = CreateObject("roSGNode", "ContentNode")
+        payload.id = "PayloadNode"
+        payload.title = "payload-from-init"
+        m.top.payloadNode = payload
+
+        child = CreateObject("roSGNode", "ContentNode")
+        child.id = "ChildNode"
+        child.title = "child-from-init"
+        m.top.appendChild(child)
+
+        m.descendants = { field: payload, child: child }
     end sub
 
     sub runTask()
@@ -18,6 +33,18 @@
         print "HELPER TOP TYPE: "; type(m.helper.top)
         print "HELPER GLOBAL VERSION: "; m.helper.global.server.version
         print "HELPER TOP LABEL: "; m.helper.top.label
+
+        print "FIELD REF TYPE: "; type(m.descendants.field)
+        print "FIELD REF TITLE: "; m.descendants.field.title
+        print "FIELD REF SAME: "; m.descendants.field.isSameNode(m.top.payloadNode)
+
+        print "CHILD REF TYPE: "; type(m.descendants.child)
+        print "CHILD REF TITLE: "; m.descendants.child.title
+        print "CHILD REF SAME: "; m.descendants.child.isSameNode(m.top.getChild(0))
+
+        ' A write through the script-scope reference has to reach the one real node, so the
+        ' render thread sees it after the task finishes.
+        m.descendants.field.title = "changed-in-task"
         m.top.result = "ok"
     end sub
     ]]></script>


### PR DESCRIPTION
## Summary

Follow-up to #1123, which fixed a script-scope reference to `m.global`/`m.top` but not a reference
to anything *inside* those subtrees. An AA in `m` holding a node-valued field of `m.top` still
crossed into the task thread as `invalid`.

The behavior here is **measured on hardware**, not reasoned from the docs: a purpose-built probe
channel (`out/task-mref-probe`) covering five reference shapes, with the engine's output diffed
against the device log mechanically. All 41 lines now match the device exactly.

## The real root cause

`serializeTaskM` writes `m` in insertion order — `top` and `global` first, since they are set at
node creation — and any node it has already written is emitted again as a `_circular_`
back-reference carrying only an address.

`loadTaskData` restored that payload in the **opposite** order: `m`'s other entries first, then
`global`, then `top`. So every back-reference into one of those subtrees was a *forward* reference
with nothing to resolve against, and `toSGNode` fell through to:

```ts
// If we don't have the node yet, this might be a forward reference
// Return invalid for now (should not happen in valid serialized data)
return BrsInvalid.Instance as any;
```

#1123 seeded the address map with `top`/`global` themselves, which covered a reference *to* those
two nodes. A reference to a node *inside* them still had nothing to resolve against.

## The fix

**1. Restore `m` in the order the payload was written.** Replaying the serializer's order is what
makes back-references resolvable at all: each one points at a node an earlier entry has already
rebuilt. Observer reattachment splits into a second pass (`restoreNodeObservers`), because the port
it binds to is only discovered while restoring `m`'s other entries — that ordering constraint is
what forced the reversed order in the first place.

**2. An unresolvable back-reference becomes an address-only proxy, not `invalid`.** Some routes are
genuinely not replayed locally — a runtime-appended child of the task node, whose `_children_` the
receiver does not rebuild. The address is still registered on the owner (it was registered when the
full copy was written), so a proxy stub with `setRemoteProxy(true)` lets reads rendezvous there.
Strictly better than `invalid` under any ordering, and it is what carries Case C below.

The #1123 seeding stays as a guard against the payload's key order ever differing.

## Device results

Sideloaded `out/task-mref-probe.zip`, telnet 8085. Every case is a node reachable from a Task's `m`
at launch, by a different route.

| Case | Shape | Device | Engine before | Engine after |
| --- | --- | --- | --- | --- |
| A | AA in `m` holding `m.global` | SAME instance | SAME instance | SAME instance |
| B | AA in `m` holding a node-valued **field of `m.top`** | SAME instance | **invalid** | SAME instance |
| C | AA in `m` holding a **child of `m.top`** | SAME instance | **invalid** | SAME instance |
| D | one standalone node under two `m` entries | SAME instance | SAME instance | SAME instance |
| E | node held directly at `m`'s top level | SAME instance | SAME instance | SAME instance |

Two findings beyond the bug itself:

**`m` is copied to the task thread; `init()` does not re-run there.** The probe stores a random
stamp in both `m` and (mirrored) `m.top`, so the task can tell the three possibilities apart. The
device reports the same stamp on both — confirming the simulator's serialize-`m`-at-launch model is
the right one. Had `init()` re-run on the task thread, this fix would have been the wrong shape.

**There is no detached-copy tier.** Every route reaches one shared node, and a write through any
route is visible through every other *and* on the render thread after the task finishes. The
engine's proxy fallback reproduces this: a rendezvousing reference to the render-owned node is
exactly the device's shared-node semantics.

## Testing

`test/cli/resources/task-script-scope-ref-app` (added in #1123) extended with the two descendant
shapes, `isSameNode` identity assertions, and a render-side check that the task's write through the
script-scope reference actually landed.

- `npm test` — 2384 passed / 192 files
- `npm run lint`, `npm run prettier` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
