### PR TITLE
fix(scenegraph): stop a directional key on an empty RowList from crashing the app

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -428,7 +428,17 @@ export class ArrayGrid extends Group {
         return new ContentNode();
     }
 
-    protected getContentChildren(content: ContentNode): ContentNode[] {
+    /**
+     * Children of a content row/section, tolerating a missing node. Callers index into `this.content`
+     * (`this.content[row]`), which is empty while the app has not assigned `content` yet or assigned an
+     * empty tree — the focus cursor can still point at row 0, so the lookup yields `undefined`. A real
+     * device simply has nothing to navigate there; returning an empty list lets the caller report the
+     * key as unhandled (so it bubbles to the parent) instead of throwing.
+     */
+    protected getContentChildren(content?: ContentNode): ContentNode[] {
+        if (!(content instanceof ContentNode)) {
+            return [];
+        }
         return content.getNodeChildren().map((child) => {
             if (child instanceof ContentNode) {
                 return child;

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -359,6 +359,8 @@ export class RowList extends ArrayGrid {
         const cols = this.getContentChildren(this.content[currentRow]);
         const numCols = cols.length;
 
+        // No row under the cursor (content not assigned yet, or an empty content tree), or a single
+        // column: nothing to move to, so the key is unhandled and bubbles to the parent.
         if (numCols <= 1) {
             return false;
         }
@@ -381,7 +383,10 @@ export class RowList extends ArrayGrid {
     }
 
     protected handleOK(press: boolean) {
-        if (press && this.focusIndex >= 0 && this.focusIndex < this.rowFocus.length) {
+        // Bound by the content view, not by `rowFocus` — the latter is seeded with row 0 in the
+        // constructor, so an empty list would otherwise report row 0 as selected and consume the key.
+        // With no content there is no item to select, so the key stays unhandled (device behavior).
+        if (press && this.focusIndex >= 0 && this.focusIndex < this.content.length) {
             const currentRow = this.focusIndex;
             const currentCol = this.rowFocus[currentRow];
             if (currentCol >= 0) {

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -555,4 +555,27 @@ describe("RowList key handling", () => {
         expect(item0.getValueJS("itemHasFocus")).toBe(true);
         expect(item0.getValueJS("rowListHasFocus")).toBe(true);
     });
+
+    test("a focused list with no content does not consume (or crash on) directional keys", () => {
+        // Regression: pressing left/right on a focused RowList whose content is empty threw
+        // "Cannot read properties of undefined (reading 'getNodeChildren')" — handleLeftRight looked up
+        // this.content[focusIndex] (undefined, because the content view is empty while the focus cursor
+        // still reads 0) and passed it straight to getContentChildren. The exception escaped to the
+        // message loop and killed the app. A real device just leaves the key unhandled so it bubbles to
+        // the parent (which is how an empty screen still navigates back to its menu).
+        // Both empty shapes: content never assigned, and an assigned-but-empty tree (the app loaded an
+        // empty result set — e.g. a favorites screen with no entries).
+        const unassigned = SGNodeFactory.createNode("RowList");
+        const emptyTree = SGNodeFactory.createNode("RowList");
+        emptyTree.setValue("content", buildContent([]));
+
+        for (const list of [unassigned, emptyTree]) {
+            list.setNodeFocus(true);
+            for (const key of ["left", "right", "up", "down", "rewind", "fastforward", "OK"]) {
+                expect(list.handleKey(key, true)).toBe(false);
+                expect(list.handleKey(key, false)).toBe(false);
+            }
+            list.setNodeFocus(false);
+        }
+    });
 });


### PR DESCRIPTION
## Problem

Pressing left or right on a focused `RowList` whose content is empty threw an unhandled JavaScript exception that escaped to the message loop and terminated the app:

```
TypeError: Cannot read properties of undefined (reading 'getNodeChildren')
    at RowList.getContentChildren
    at RowList.handleLeftRight
    at RowList.handleKey
    at Scene.handleKeyByNode
    at Scene.handleOnKeyEvent
    at RoSGScreen.handleNextKey
    at RoMessagePort.wait
```

`handleLeftRight` looked up the focused row and passed it straight to `getContentChildren`:

```ts
const cols = this.getContentChildren(this.content[currentRow]);
```

While a list has no content the internal content view is empty, but the focus cursor still reads row 0 (the constructor seeds `focusIndex = 0` / `rowFocus[0] = 0`), so `this.content[0]` is `undefined`. `handleUpDown` and `setFocusedItem` already guarded that same lookup; this was the one navigation path that did not. It reproduces for both empty shapes: `content` never assigned, and an assigned-but-empty content tree (a screen whose result set came back empty).

## Fix

- `ArrayGrid.getContentChildren` now accepts a possibly-missing node and returns an empty list, mirroring the tolerance `getContentItem` already had — this covers every call site, not just the reported one.
- With zero columns `RowList.handleLeftRight` falls into its existing `numCols <= 1` early return, so the key is reported unhandled and bubbles to the parent. That matches a device, where an empty screen still navigates back to the menu that opened it.
- `RowList.handleOK` carried a related defect surfaced while writing the regression test: its bound was `rowFocus.length`, which is never zero because the constructor seeds row 0, so OK on an empty list emitted `rowItemSelected [0, 0]` + `itemSelected 0` and consumed the key — handing the app a selection for an item that does not exist. Bound by the content view instead, so with no content the key stays unhandled.

## Testing

- Confirmed the crash first with a repro reaching the identical stack frames, for both empty shapes.
- Added a regression test to `test/extensions/scenegraph/RowList.test.js` driving left/right/up/down/rewind/fastforward/OK (press and release) against a focused list in both empty shapes, asserting every key is unhandled and nothing throws.
- `npx vitest run test/extensions` — 69 files / 643 tests pass.
- `npm run lint` clean; prettier clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)