### PR TITLE
fix(scenegraph): commit a focus change before notifying, and ignore a re-grab from a focus-loss observer

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -276,3 +276,37 @@ crash). So `Node.setNodeParent` (the single chokepoint all append paths call) **
 attach**: if live `sgRoot.focused` is within the newly parented subtree, it re-points `focusedChild` from
 the root down. Each attach extends the chain one level. Don't remove that repair as "redundant".
 Regression: `test/extensions/scenegraph/FocusBeforeAttach.test.js`.
+
+### A focus transaction commits before it notifies, and a focus-loss observer can't re-grab
+
+Two rules, both **device-measured** on a Roku Express 4K+ (OS 15.3) with `out/focus-probe*`. They exist
+because an app that re-grabs focus from its own `focusedChild` observer (sgRouter's outlet, and the same
+`OnFocusedChildChange` shape in several media apps) behaves on a device and used to corrupt the chain here.
+
+1. **Commit, then notify.** `setNodeFocus` stages *every* `focusedChild` write (`stageFocusedChild`) and
+   dispatches the observers only afterwards (`notifyStagedFocus`), losing subtree first. An observer must
+   therefore read the **finished** chain. Writing-and-notifying node by node — what the code did before —
+   let the losing subtree's observer see a half-rewritten chain (`sceneFC` still pointing at the old
+   subtree). Dispatch is still **synchronous**, inside the `setFocus` call: Roku commits atomically, it
+   does not defer these to the message loop. (Init-time focus emissions are the one exception — see
+   `pendingInitFocusFields` above.)
+
+2. **A focus request raised from a focus-LOSS notification is dropped** (`isFocusRequestDropped`, keyed
+   off the `focusNotifyOwners` stack). A Roku honors `setFocus` from a `focusedChild` observer only while
+   the observed node is still in the focus chain — the "forward focus" pattern where a container that
+   just *gained* focus hands it to an inner widget. The mirror case, a node re-grabbing focus as it
+   *loses* it, leaves the chain and the remote with the node the in-flight transaction focused.
+
+   Don't "simplify" this to dropping all nested focus changes: forward focus is how every custom dialog
+   highlights its buttons (`dialog-buttongroup-focus-app`). And don't drop only the chain writes while
+   letting `sgRoot.focused` move — that hybrid (live focus on one node, `focusedChild` on another) is the
+   original bug: the remote drove the old subtree while the chain said otherwise, so a key handler
+   returned `true` (playing the "handled" navigation sound) without focus visibly moving, and a
+   `scene.dialog` drew unfocused with up/down/OK falling through to the scene behind it.
+
+   **Deliberately not modeled:** on a device the node that lost the race keeps reporting `hasFocus() =
+   true` until the next focus transaction, so two nodes report focus at once. Reproducing that would make
+   both render focused. We report `hasFocus()` only for the live focus.
+
+   Regression: `focus-steal-app` in `test/cli/`, which must stay green alongside
+   `dialog-buttongroup-focus-app` and `init-focus-observer-app`.

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -289,13 +289,27 @@ because an app that re-grabs focus from its own `focusedChild` observer (sgRoute
    let the losing subtree's observer see a half-rewritten chain (`sceneFC` still pointing at the old
    subtree). Dispatch is still **synchronous**, inside the `setFocus` call: Roku commits atomically, it
    does not defer these to the message loop. (Init-time focus emissions are the one exception — see
-   `pendingInitFocusFields` above.)
+   `pendingInitFocusFields` above.) `restoreFocusChainOnAttach` stages its repair the same way.
+
+   Staging holds back only the **notification**: the write itself goes through the regular virtual
+   `setValue` (suppressed via `focusStagingSink`), because subclasses override it — `Group.setValue`
+   marks the node dirty so focus visuals repaint, `ScrollableText.setValue` tracks its focused state.
+   Writing the `Field` directly instead silently freezes every focus visual (a `Button` keeps its
+   unfocused font, a `ScrollableText` its unfocused scrollbar thumb) while `hasFocus()` still reports
+   true.
 
 2. **A focus request raised from a focus-LOSS notification is dropped** (`isFocusRequestDropped`, keyed
    off the `focusNotifyOwners` stack). A Roku honors `setFocus` from a `focusedChild` observer only while
    the observed node is still in the focus chain — the "forward focus" pattern where a container that
    just *gained* focus hands it to an inner widget. The mirror case, a node re-grabbing focus as it
    *loses* it, leaves the chain and the remote with the node the in-flight transaction focused.
+
+   Scoped to transactions where a node is **taking** focus (`notifyStagedFocus`'s `gaining` flag). The
+   unfocus paths notify without classifying: with no competing target there is nothing to defend, and
+   swallowing an unfocus observer's restore would leave the app with **no focused node at all**. The
+   dropped path returns `false`, not `isFocusable()`, so a subclass override gated on
+   `super.setNodeFocus(...)` skips its own bookkeeping too (an `ArrayGrid` must not move `itemFocused`
+   for a grid that never took focus).
 
    Don't "simplify" this to dropping all nested focus changes: forward focus is how every custom dialog
    highlights its buttons (`dialog-buttongroup-focus-app`). And don't drop only the chain writes while

--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -31,6 +31,7 @@ import { loadComponentLibrary } from "./parser/ComponentLibrary";
 import { sgRoot } from "./SGRoot";
 import { Task } from "./nodes/Task";
 import { Field } from "./nodes/Field";
+import { Node } from "./nodes/Node";
 import { initializeTask, createNode, updateTypeDefHierarchy, getNodeType } from "./factory/NodeFactory";
 import { RoSGScreen } from "./components/RoSGScreen";
 import { getRenderThreadQueue } from "./components/RoRenderThreadQueue";
@@ -57,6 +58,7 @@ export class BrightScriptExtension implements BrsExtension {
     onInit() {
         // Reset per-thread deferred observer-dispatch state so nothing leaks across app runs.
         Field.resetDispatch();
+        Node.resetFocusDispatch();
         // Mirrors Roku's `logrendezvous`. Set per thread (the render thread and every Task worker
         // build their own extension instance), so a trace covers both ends of a rendezvous.
         sgRoot.logRendezvous = BrsDevice.deviceInfo.logRendezvous === true;

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -92,6 +92,11 @@ export class Node extends RoSGNode implements BrsValue {
      * focus onward) from a focus-loss one (whose focus requests a Roku ignores).
      */
     private static readonly focusNotifyOwners: Node[] = [];
+    /**
+     * Set while a focus transaction stages its `focusedChild` writes: `setValue` applies the value
+     * but routes the notification here instead of dispatching it — see `stageFocusedChild`.
+     */
+    private static focusStagingSink: StagedFocus[] | undefined;
     /** Field registry keyed by lowercase name. */
     protected readonly fields: Map<string, Field>;
     /** Alias definitions pointing to fields on child nodes. */
@@ -451,7 +456,13 @@ export class Node extends RoSGNode implements BrsValue {
                     errorMsg = `BRIGHTSCRIPT: ERROR: roSGNode.Set: Tried to set nonexistent field "${index}" of a "${this.nodeSubtype}" node:`;
                 }
             } else if (field.canAcceptValue(value)) {
-                this.notified = field.setValue(value, true);
+                // A `focusedChild` write made while a focus transaction is staging is applied now
+                // but notified later, once the whole chain is committed — see stageFocusedChild.
+                const sink = mapKey === "focusedchild" ? Node.focusStagingSink : undefined;
+                this.notified = field.setValue(value, sink === undefined);
+                if (sink) {
+                    sink.push({ node: this, field });
+                }
                 this.fields.set(mapKey, field);
                 const alias = this.aliases.get(mapKey);
                 if (alias) {
@@ -906,18 +917,15 @@ export class Node extends RoSGNode implements BrsValue {
             return;
         }
         const chain = this.createPath(focused); // [root, ..., focused]
-        // Engine-initiated focus emission: when this attach happens inside a component's init(),
-        // the notifications defer until init returns (see Field.enterInit / setNodeFocus).
-        Field.enterFocusEmission();
-        try {
-            for (let i = 0; i < chain.length - 1; i++) {
-                if (chain[i].getValue("focusedchild") !== chain[i + 1]) {
-                    chain[i].setValue("focusedchild", chain[i + 1], false);
-                }
+        // Repairing the chain is a focus transaction like any other: stage every write, then notify,
+        // so an observer never reads a half-repaired chain (see stageFocusedChild).
+        const staged: StagedFocus[] = [];
+        for (let i = 0; i < chain.length - 1; i++) {
+            if (chain[i].getValue("focusedchild") !== chain[i + 1]) {
+                chain[i].stageFocusedChild(chain[i + 1], staged);
             }
-        } finally {
-            Field.exitFocusEmission();
         }
+        Node.notifyStagedFocus(staged, true);
     }
 
     /**
@@ -1270,8 +1278,10 @@ export class Node extends RoSGNode implements BrsValue {
     setNodeFocus(focusOn: boolean): boolean {
         if (focusOn && Node.isFocusRequestDropped()) {
             // Device-measured: Roku ignores a focus request raised from a focus-LOSS notification
-            // (see stageFocusedChild / notifyStagedFocus). Report focusability as usual.
-            return this.isFocusable();
+            // (see notifyStagedFocus). Report the request as not applied, so a subclass override
+            // gated on `super.setNodeFocus(...)` skips its focus bookkeeping too (an ArrayGrid must
+            // not move `itemFocused` for a grid that never took focus).
+            return false;
         }
         if (focusOn) {
             if (!this.triedInitFocus) {
@@ -1336,7 +1346,7 @@ export class Node extends RoSGNode implements BrsValue {
             // Finally, set the focusedChild of the newly focused node to itself (to mimic RBI behavior).
             this.stageFocusedChild(this, staged);
 
-            Node.notifyStagedFocus(staged);
+            Node.notifyStagedFocus(staged, true);
         } else if (sgRoot.focused === this) {
             // If we're unsetting focus on ourself, we need to unset it on all ancestors as well.
             const currFocusedNode = sgRoot.focused;
@@ -1359,48 +1369,49 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
-     * Writes this node's `focusedChild` WITHOUT notifying, appending the field to `staged` so the
-     * caller can dispatch it once the whole focus transaction is committed. Mirrors `setValue`'s
-     * bookkeeping (container, freshness, dirty flag, cross-thread sync) minus the notification.
+     * Writes this node's `focusedChild` WITHOUT notifying, recording the field in `staged` so the
+     * caller can dispatch it once the whole focus transaction is committed.
+     *
+     * The write goes through the regular (virtual) `setValue`, so subclass overrides still run —
+     * `Group` marks itself dirty so focus visuals repaint, `ScrollableText` tracks its focused
+     * state. Only the notification is held back, via `focusStagingSink`.
      * @param value The new focusedChild value.
      * @param staged Accumulator the caller later hands to `notifyStagedFocus`.
      */
     private stageFocusedChild(value: BrsType, staged: StagedFocus[]) {
-        const mapKey = "focusedchild";
-        const field = this.resolveField(mapKey);
-        if (!field) {
-            return;
+        const previousSink = Node.focusStagingSink;
+        Node.focusStagingSink = staged;
+        try {
+            this.setValue("focusedchild", value, false);
+        } finally {
+            Node.focusStagingSink = previousSink;
         }
-        field.setValue(value, false);
-        this.fields.set(mapKey, field);
-        this.markFieldFresh(mapKey);
-        field.setContainer(this);
-        this.makeDirty();
-        if (this.syncType !== "task") {
-            this.rendezvousSet(mapKey, field);
-        }
-        staged.push({ node: this, field });
     }
 
     /**
      * Dispatches the staged `focusedChild` notifications for a committed focus transaction, in
      * chain order (the subtree losing focus first, then the one gaining it).
-     *
-     * Each dispatch records its owning node so a `setFocus` raised from inside the callback can be
-     * classified — see `isFocusRequestDropped`.
      * @param staged Fields staged by `stageFocusedChild`.
+     * @param gaining True when a node is taking focus, so a competing request raised from one of
+     *   these callbacks can be classified — see `isFocusRequestDropped`. False for the unfocus
+     *   paths: with no node taking focus there is nothing to defend, and dropping an observer's
+     *   restore there would leave the app with no focused node at all.
      */
-    private static notifyStagedFocus(staged: StagedFocus[]) {
+    private static notifyStagedFocus(staged: StagedFocus[], gaining = false) {
         // Marks these as an engine-initiated focus emission, so notifications raised during a
         // component's init() defer until init returns (see Field.enterInit).
         Field.enterFocusEmission();
         try {
             for (const entry of staged) {
-                Node.focusNotifyOwners.push(entry.node);
+                if (gaining) {
+                    Node.focusNotifyOwners.push(entry.node);
+                }
                 try {
                     entry.field.notifyObservers();
                 } finally {
-                    Node.focusNotifyOwners.pop();
+                    if (gaining) {
+                        Node.focusNotifyOwners.pop();
+                    }
                 }
             }
         } finally {
@@ -1430,10 +1441,18 @@ export class Node extends RoSGNode implements BrsValue {
      */
     private static isFocusRequestDropped(): boolean {
         const owner = Node.focusNotifyOwners.at(-1);
-        if (!owner) {
+        const focused = sgRoot.focused;
+        if (!owner || !(focused instanceof Node)) {
             return false;
         }
-        return sgRoot.focused !== owner && !owner.isChildrenFocused();
+        // Is the owner still in the focus chain? Cheap upward walk from the focused node, the same
+        // shape restoreFocusChainOnAttach uses — an O(subtree) descent would be walked on every
+        // focus request made from inside a notification.
+        let ancestor: BrsType = focused;
+        while (ancestor instanceof Node && ancestor !== owner) {
+            ancestor = ancestor.parent;
+        }
+        return ancestor !== owner;
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -55,6 +55,9 @@ import { convertHexColor } from "../SGUtil";
 
 type ChangeOperation = "none" | "insert" | "add" | "remove" | "set" | "clear" | "move" | "setall" | "modify";
 
+/** A `focusedChild` write held back until its focus transaction is fully committed. */
+type StagedFocus = { node: Node; field: Field };
+
 /** Reads the RSGPalette `colors` set held directly on `node` (an RSGPalette in its `palette` field). */
 function paletteColorsOf(node: Node): RoAssociativeArray | undefined {
     const palette = node.getValue("palette");
@@ -83,6 +86,12 @@ export class Node extends RoSGNode implements BrsValue {
     private static readonly hiddenSpecCache = new WeakMap<Function, Map<string, FieldModel>>();
     /** Reference to this instance's class spec (see hiddenSpecCache). */
     private hiddenFieldSpec?: Map<string, FieldModel>;
+    /**
+     * Stack of nodes whose `focusedChild` observers are currently dispatching, innermost last.
+     * Read by `isFocusRequestDropped` to tell a focus-gain notification (whose observer may move
+     * focus onward) from a focus-loss one (whose focus requests a Roku ignores).
+     */
+    private static readonly focusNotifyOwners: Node[] = [];
     /** Field registry keyed by lowercase name. */
     protected readonly fields: Map<string, Field>;
     /** Alias definitions pointing to fields on child nodes. */
@@ -1259,7 +1268,11 @@ export class Node extends RoSGNode implements BrsValue {
      * @returns Whether the node is focusable.
      */
     setNodeFocus(focusOn: boolean): boolean {
-        const focusedChild = "focusedchild";
+        if (focusOn && Node.isFocusRequestDropped()) {
+            // Device-measured: Roku ignores a focus request raised from a focus-LOSS notification
+            // (see stageFocusedChild / notifyStagedFocus). Report focusability as usual.
+            return this.isFocusable();
+        }
         if (focusOn) {
             if (!this.triedInitFocus) {
                 // Only try initial focus once
@@ -1289,67 +1302,138 @@ export class Node extends RoSGNode implements BrsValue {
             const prevFocused = sgRoot.focused;
             sgRoot.setFocused(this);
 
-            // The focusedChild writes below are an engine-initiated focus emission. Marking them so
-            // that, when they happen during a component's init(), their observers defer until init
-            // returns (Roku dispatches focus notifications from the message loop) — see Field.enterInit.
-            Field.enterFocusEmission();
-            try {
-                // If there was already a focused node somewhere, we need to remove focus
-                // from it and its ancestors.
-                if (prevFocused instanceof Node) {
-                    // Get the focus chain, with root-most ancestor first.
-                    let currFocusChain = this.createPath(prevFocused);
+            // Stage every focusedChild write first, then notify. A Roku commits the whole focus
+            // transaction before it dispatches any focusedChild observer, so an observer always
+            // reads the FINISHED chain — never a half-rewritten one (device-measured).
+            const staged: StagedFocus[] = [];
 
-                    // Find the lowest common ancestor (LCA) between the newly focused node
-                    // and the current focused node.
-                    let lcaIndex = 0;
-                    while (lcaIndex < newFocusChain.length && lcaIndex < currFocusChain.length) {
-                        if (currFocusChain[lcaIndex] !== newFocusChain[lcaIndex]) break;
-                        lcaIndex++;
-                    }
+            // If there was already a focused node somewhere, we need to remove focus
+            // from it and its ancestors.
+            if (prevFocused instanceof Node) {
+                // Get the focus chain, with root-most ancestor first.
+                let currFocusChain = this.createPath(prevFocused);
 
-                    // Unset all of the not-common ancestors of the current focused node.
-                    for (let i = lcaIndex; i < currFocusChain.length; i++) {
-                        currFocusChain[i].setValue(focusedChild, BrsInvalid.Instance, false);
-                    }
+                // Find the lowest common ancestor (LCA) between the newly focused node
+                // and the current focused node.
+                let lcaIndex = 0;
+                while (lcaIndex < newFocusChain.length && lcaIndex < currFocusChain.length) {
+                    if (currFocusChain[lcaIndex] !== newFocusChain[lcaIndex]) break;
+                    lcaIndex++;
                 }
 
-                // Set the focusedChild for each ancestor to the next node in the chain,
-                // which is the current node's child.
-                for (let i = 0; i < newFocusChain.length - 1; i++) {
-                    newFocusChain[i].setValue(focusedChild, newFocusChain[i + 1], false);
+                // Unset all of the not-common ancestors of the current focused node.
+                for (let i = lcaIndex; i < currFocusChain.length; i++) {
+                    currFocusChain[i].stageFocusedChild(BrsInvalid.Instance, staged);
                 }
-
-                // Finally, set the focusedChild of the newly focused node to itself (to mimic RBI behavior).
-                this.setValue(focusedChild, this, false);
-            } finally {
-                Field.exitFocusEmission();
             }
+
+            // Set the focusedChild for each ancestor to the next node in the chain,
+            // which is the current node's child.
+            for (let i = 0; i < newFocusChain.length - 1; i++) {
+                newFocusChain[i].stageFocusedChild(newFocusChain[i + 1], staged);
+            }
+
+            // Finally, set the focusedChild of the newly focused node to itself (to mimic RBI behavior).
+            this.stageFocusedChild(this, staged);
+
+            Node.notifyStagedFocus(staged);
         } else if (sgRoot.focused === this) {
             // If we're unsetting focus on ourself, we need to unset it on all ancestors as well.
             const currFocusedNode = sgRoot.focused;
             sgRoot.setFocused();
             // Get the focus chain, with root-most ancestor first.
             let currFocusChain = this.createPath(currFocusedNode as Node);
-            Field.enterFocusEmission();
-            try {
-                for (const node of currFocusChain) {
-                    node.setValue(focusedChild, BrsInvalid.Instance, false);
-                }
-            } finally {
-                Field.exitFocusEmission();
+            const staged: StagedFocus[] = [];
+            for (const node of currFocusChain) {
+                node.stageFocusedChild(BrsInvalid.Instance, staged);
             }
+            Node.notifyStagedFocus(staged);
         } else {
             // If the node doesn't have focus already, and it's not gaining focus,
             // we don't need to notify any ancestors.
-            Field.enterFocusEmission();
-            try {
-                this.setValue(focusedChild, BrsInvalid.Instance, false);
-            } finally {
-                Field.exitFocusEmission();
-            }
+            const staged: StagedFocus[] = [];
+            this.stageFocusedChild(BrsInvalid.Instance, staged);
+            Node.notifyStagedFocus(staged);
         }
         return this.isFocusable();
+    }
+
+    /**
+     * Writes this node's `focusedChild` WITHOUT notifying, appending the field to `staged` so the
+     * caller can dispatch it once the whole focus transaction is committed. Mirrors `setValue`'s
+     * bookkeeping (container, freshness, dirty flag, cross-thread sync) minus the notification.
+     * @param value The new focusedChild value.
+     * @param staged Accumulator the caller later hands to `notifyStagedFocus`.
+     */
+    private stageFocusedChild(value: BrsType, staged: StagedFocus[]) {
+        const mapKey = "focusedchild";
+        const field = this.resolveField(mapKey);
+        if (!field) {
+            return;
+        }
+        field.setValue(value, false);
+        this.fields.set(mapKey, field);
+        this.markFieldFresh(mapKey);
+        field.setContainer(this);
+        this.makeDirty();
+        if (this.syncType !== "task") {
+            this.rendezvousSet(mapKey, field);
+        }
+        staged.push({ node: this, field });
+    }
+
+    /**
+     * Dispatches the staged `focusedChild` notifications for a committed focus transaction, in
+     * chain order (the subtree losing focus first, then the one gaining it).
+     *
+     * Each dispatch records its owning node so a `setFocus` raised from inside the callback can be
+     * classified — see `isFocusRequestDropped`.
+     * @param staged Fields staged by `stageFocusedChild`.
+     */
+    private static notifyStagedFocus(staged: StagedFocus[]) {
+        // Marks these as an engine-initiated focus emission, so notifications raised during a
+        // component's init() defer until init returns (see Field.enterInit).
+        Field.enterFocusEmission();
+        try {
+            for (const entry of staged) {
+                Node.focusNotifyOwners.push(entry.node);
+                try {
+                    entry.field.notifyObservers();
+                } finally {
+                    Node.focusNotifyOwners.pop();
+                }
+            }
+        } finally {
+            Field.exitFocusEmission();
+        }
+    }
+
+    /** Resets focus-dispatch state between app runs so nothing leaks across setups. */
+    static resetFocusDispatch() {
+        Node.focusNotifyOwners.length = 0;
+    }
+
+    /**
+     * Whether a `setFocus(true)` issued right now must be ignored.
+     *
+     * Device-measured: a Roku honors a focus request raised from a `focusedChild` observer only when
+     * the observed node is still in the focus chain — the "forward focus" pattern where a container
+     * that just GAINED focus hands it to an inner widget. A request raised from the mirror-image
+     * notification, by a node that just LOST focus, is dropped: the chain and the remote stay with
+     * the node the in-flight transaction focused.
+     *
+     * That asymmetry is what makes an app which re-grabs focus from its own focus-loss observer
+     * behave on a device and not here: the engine used to let the re-grab win the live focus while
+     * the outer transaction still wrote its own chain, leaving `sgRoot.focused` and `focusedChild`
+     * pointing at different nodes.
+     * @returns True when the in-flight notification is a focus loss, so the request is ignored.
+     */
+    private static isFocusRequestDropped(): boolean {
+        const owner = Node.focusNotifyOwners.at(-1);
+        if (!owner) {
+            return false;
+        }
+        return sgRoot.focused !== owner && !owner.isChildrenFocused();
     }
 
     /**

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1327,6 +1327,37 @@ describe.concurrent("cli", () => {
         ]);
     }, 30000);
 
+    it("Ignores a focus re-grab raised from a focus-loss observer, but honors a forward one", async () => {
+        let command = ["node", brsCliPath, "-r focus-steal-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Repro of the sgRouter/JellyRock shape, pinned against a Roku Express 4K+ (OS 15.3) capture
+        // from the focus-probe apps. Two invariants, both device-measured:
+        //   1. A focusedChild observer reads the COMMITTED chain - the whole focus transaction lands
+        //      before any notification goes out ("outlet lost focus" already sees sceneFC = overhang).
+        //   2. A setFocus raised from a focus-LOSS notification is dropped, so the chain and the
+        //      remote stay with the node the in-flight transaction focused; the mirror-image FORWARD
+        //      case (a container handing focus onward after gaining it) is still honored.
+        // Before the fix the re-grab won live focus while the outer transaction wrote its own chain,
+        // so sgRoot.focused and focusedChild disagreed: the app kept the remote on the grid while the
+        // chain said "menu".
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Focus Steal Repro ===",
+            "  outlet lost focus: sceneFC = overhang, overhangFC = menuA",
+            "after steal: menuA = true, gridA = false",
+            "after steal: sceneFC = overhang, outletFC = invalid, overhangFC = menuA",
+            "  outlet lost focus: sceneFC = overhang, overhangFC = menuA",
+            "after forward: menuB = true, overhangFC = menuB",
+            "after recover: gridB = true, pageFC = gridB, sceneFC = outlet",
+            "=== Focus Steal Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     it("ButtonGroup leaves custom (non-Button) children unmanaged", async () => {
         let command = ["node", brsCliPath, "-r buttongroup-custom-children-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1343,6 +1343,11 @@ describe.concurrent("cli", () => {
         // Before the fix the re-grab won live focus while the outer transaction wrote its own chain,
         // so sgRoot.focused and focusedChild disagreed: the app kept the remote on the grid while the
         // chain said "menu".
+        // Two further guards on the mechanism itself: the drop applies only while a node is TAKING
+        // focus (an unfocus observer's restore has no competing target, and swallowing it would
+        // leave nothing focused at all), and staging the chain must still run the subclass setValue
+        // overrides - a Button that bypasses Group.setValue never marks itself dirty, so its focused
+        // font is never applied and the button stays at its unfocused width.
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== Focus Steal Repro ===",
             "  outlet lost focus: sceneFC = overhang, overhangFC = menuA",
@@ -1351,6 +1356,11 @@ describe.concurrent("cli", () => {
             "  outlet lost focus: sceneFC = overhang, overhangFC = menuA",
             "after forward: menuB = true, overhangFC = menuB",
             "after recover: gridB = true, pageFC = gridB, sceneFC = outlet",
+            "  outlet lost focus: sceneFC = invalid, overhangFC = invalid",
+            "after unfocus restore: gridB = true, sceneFC = outlet",
+            "button width before:  179",
+            "  outlet lost focus: sceneFC = btn, overhangFC = invalid",
+            "button width after:  250",
             "=== Focus Steal Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
             "",

--- a/test/cli/resources/focus-steal-app/components/MainScene.xml
+++ b/test/cli/resources/focus-steal-app/components/MainScene.xml
@@ -23,8 +23,14 @@
 <component name="MainScene" extends="Scene">
     <interface>
         <function name="runScenarios" />
+        <function name="measureButton" />
+        <function name="focusButton" />
     </interface>
     <children>
+        <!-- Focusing must still run Group.setValue (which marks the node dirty), so the focused
+             font is applied on the next paint and the button grows. A focus write that bypasses the
+             subclass override leaves every focus visual stale. -->
+        <Button id="btn" text="Hello World" minWidth="0" textFont="font:SmallestSystemFont" focusedTextFont="font:LargeBoldSystemFont" />
         <Group id="outlet">
             <Group id="page">
                 <Rectangle id="gridA" width="300" height="200" focusable="true" />
@@ -40,6 +46,8 @@
     sub init()
         m.stealArmed = false
         m.forwardArmed = false
+        m.restoreArmed = false
+        m.btn = m.top.findNode("btn")
 
         m.outlet = m.top.findNode("outlet")
         m.page = m.top.findNode("page")
@@ -67,6 +75,12 @@
         if m.stealArmed
             m.stealArmed = false
             m.gridA.setFocus(true)
+        end if
+        if m.restoreArmed
+            ' Nothing is taking focus here (the outlet was UNFOCUSED), so this restore is the app's
+            ' only path back to a focused node - it must NOT be treated as a competing steal.
+            m.restoreArmed = false
+            m.gridB.setFocus(true)
         end if
     end sub
 
@@ -97,6 +111,20 @@
         ' 3. A plain focus move still works after a dropped steal.
         m.gridB.setFocus(true)
         print "after recover: gridB = "; m.gridB.hasFocus(); ", pageFC = "; fcId(m.page); ", sceneFC = "; fcId(m.top)
+
+        ' 4. A restore issued from an UNFOCUS observer is honored (no competing focus gain).
+        m.gridA.setFocus(true)
+        m.restoreArmed = true
+        m.gridA.setFocus(false)
+        print "after unfocus restore: gridB = "; m.gridB.hasFocus(); ", sceneFC = "; fcId(m.top)
+    end sub
+
+    sub measureButton(label as string)
+        print "button width "; label; ": "; m.btn.boundingRect().width
+    end sub
+
+    sub focusButton()
+        m.btn.setFocus(true)
     end sub
     ]]></script>
 </component>

--- a/test/cli/resources/focus-steal-app/components/MainScene.xml
+++ b/test/cli/resources/focus-steal-app/components/MainScene.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models the sgRouter/JellyRock shape: two SIBLING subtrees under the Scene (an "outlet" holding
+    the content, an "overhang" holding the top menu), where the outlet observes its own
+    `focusedChild` and re-grabs focus whenever focus leaves it.
+
+    Device-measured on a Roku Express 4K+ (OS 15.3) with the focus-probe apps:
+
+    1. The whole focus transaction is COMMITTED before any focusedChild observer runs, so an
+       observer reads the finished chain - never a half-rewritten one. Before the fix the outlet's
+       loss observer still saw `sceneFC=outlet` while focus had already moved to the overhang.
+
+    2. A `setFocus` raised from a focus-LOSS notification is IGNORED: the chain and the remote stay
+       with the node the in-flight transaction focused. Before the fix the re-grab won `sgRoot.focused`
+       while the outer transaction went on to write its own chain, leaving live focus and
+       `focusedChild` pointing at different nodes - the app kept the remote on the grid while the
+       chain said "tab bar", so the first UP press played the nav sound without moving focus (and a
+       dialog drew unfocused, with up/down/OK falling through to the scene behind it).
+
+    3. The mirror case must keep working: a container that just GAINED focus may hand it onward from
+       its own focusedChild observer (the "forward focus" pattern every custom dialog uses).
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <function name="runScenarios" />
+    </interface>
+    <children>
+        <Group id="outlet">
+            <Group id="page">
+                <Rectangle id="gridA" width="300" height="200" focusable="true" />
+                <Rectangle id="gridB" width="300" height="200" focusable="true" />
+            </Group>
+        </Group>
+        <Group id="overhang">
+            <Rectangle id="menuA" width="300" height="80" focusable="true" />
+            <Rectangle id="menuB" width="300" height="80" focusable="true" />
+        </Group>
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.stealArmed = false
+        m.forwardArmed = false
+
+        m.outlet = m.top.findNode("outlet")
+        m.page = m.top.findNode("page")
+        m.gridA = m.top.findNode("gridA")
+        m.gridB = m.top.findNode("gridB")
+        m.overhang = m.top.findNode("overhang")
+        m.menuA = m.top.findNode("menuA")
+        m.menuB = m.top.findNode("menuB")
+
+        m.outlet.observeField("focusedChild", "onOutletFocus")
+        m.overhang.observeField("focusedChild", "onOverhangFocus")
+    end sub
+
+    function fcId(node as object) as string
+        fc = node.focusedChild
+        if fc = invalid then return "invalid"
+        return fc.id
+    end function
+
+    sub onOutletFocus()
+        if m.outlet.isInFocusChain() then return
+        ' The outlet just LOST focus. Report the chain the observer can see: on a device the whole
+        ' transaction is already committed by now.
+        print "  outlet lost focus: sceneFC = "; fcId(m.top); ", overhangFC = "; fcId(m.overhang)
+        if m.stealArmed
+            m.stealArmed = false
+            m.gridA.setFocus(true)
+        end if
+    end sub
+
+    sub onOverhangFocus()
+        if not m.overhang.isInFocusChain() then return
+        if m.forwardArmed
+            m.forwardArmed = false
+            ' Forward focus onward from the container that just gained it.
+            m.menuB.setFocus(true)
+        end if
+    end sub
+
+    sub runScenarios()
+        m.gridA.setFocus(true)
+
+        ' 1. Backwards steal from the loss observer: ignored.
+        m.stealArmed = true
+        m.menuA.setFocus(true)
+        print "after steal: menuA = "; m.menuA.hasFocus(); ", gridA = "; m.gridA.hasFocus()
+        print "after steal: sceneFC = "; fcId(m.top); ", outletFC = "; fcId(m.outlet); ", overhangFC = "; fcId(m.overhang)
+
+        ' 2. Forward focus from the gain observer: honored.
+        m.gridA.setFocus(true)
+        m.forwardArmed = true
+        m.menuA.setFocus(true)
+        print "after forward: menuB = "; m.menuB.hasFocus(); ", overhangFC = "; fcId(m.overhang)
+
+        ' 3. A plain focus move still works after a dropped steal.
+        m.gridB.setFocus(true)
+        print "after recover: gridB = "; m.gridB.hasFocus(); ", pageFC = "; fcId(m.page); ", sceneFC = "; fcId(m.top)
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/focus-steal-app/manifest
+++ b/test/cli/resources/focus-steal-app/manifest
@@ -1,0 +1,4 @@
+title=Focus Steal Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/focus-steal-app/source/main.brs
+++ b/test/cli/resources/focus-steal-app/source/main.brs
@@ -8,6 +8,15 @@ sub Main()
     ' Drive the scenarios from OUTSIDE init(): focus notifications raised during init() are deferred
     ' to the message loop, which is a separate code path (see init-focus-observer-app).
     scene.callFunc("runScenarios")
+
+    ' The button's focused font only takes effect on a paint pass, so measure across frames.
+    scene.callFunc("measureButton", "before")
+    scene.callFunc("focusButton")
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    scene.callFunc("measureButton", "after")
+
     for i = 0 to 5
         msg = wait(20, port)
     end for

--- a/test/cli/resources/focus-steal-app/source/main.brs
+++ b/test/cli/resources/focus-steal-app/source/main.brs
@@ -1,0 +1,15 @@
+sub Main()
+    print "=== Focus Steal Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Drive the scenarios from OUTSIDE init(): focus notifications raised during init() are deferred
+    ' to the message loop, which is a separate code path (see init-focus-observer-app).
+    scene.callFunc("runScenarios")
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== Focus Steal Repro Complete ==="
+end sub


### PR DESCRIPTION
## Problem

`Node.setNodeFocus` wrote each `focusedChild` in the chain and notified its observers inline, one node at a time. Two consequences:

1. An observer ran while the chain was still half rewritten — the subtree losing focus saw ancestors still pointing at the old chain.
2. A `setFocus` issued from that observer re-entered `setNodeFocus`, moved `sgRoot.focused`, and returned into an outer call that went on to write its own chain over the top.

The result was a state that matched neither intent: live focus on one node, `focusedChild` on another. The remote kept driving the subtree that was losing focus while the chain said otherwise, so a key handler could return `true` — playing the "handled" navigation sound — without focus visibly moving, and a `scene.dialog` could draw unfocused with up/down/OK falling through to the scene behind it. Any app that re-grabs focus from its own `focusedChild` observer hit this on every focus move out of the observed subtree, which is a common shape (a router outlet, a media view re-asserting focus on its player).

## Measurement

Behavior was captured on a **Roku Express 4K+ (OS 15.3)** with a pair of throwaway probe apps that print a diffable trace of the focus chain around each transition, then compared against the same apps run under `brs-cli`. Two rules came out of it:

1. **Commit, then notify.** A device commits the whole focus transaction before dispatching any `focusedChild` observer, so an observer always reads the finished chain. Dispatch is still *synchronous*, inside the `setFocus` call — a device commits atomically rather than deferring to the message loop.
2. **A focus request raised from a focus-LOSS notification is ignored.** `setFocus` from a `focusedChild` observer is honored only while the observed node is still in the focus chain — the "forward focus" pattern a container uses to hand focus to an inner widget. The mirror case, a node re-grabbing focus as it loses it, leaves the chain and the remote with the node the in-flight transaction focused.

## Change

- `stageFocusedChild` writes a `focusedChild` without notifying, mirroring `setValue`'s bookkeeping (container, freshness, dirty flag, cross-thread sync).
- `notifyStagedFocus` dispatches the staged fields once the transaction is committed, losing subtree first, recording each field's owner on a `focusNotifyOwners` stack.
- `isFocusRequestDropped` consults that stack so `setNodeFocus` can ignore a request raised from a focus-loss notification.
- The init-time deferral path (`Field.enterFocusEmission` / `pendingInitFocusFields`) is unchanged — it now wraps the notify phase instead of the write phase.

## Not modeled

A device also leaves the node that lost the race reporting `hasFocus() = true` until the next focus transaction, so two nodes report focus at once. Reproducing that would make both render focused, so `hasFocus()` continues to report only the live focus.

## Still open

The probes surfaced two further divergences in dialog focus, left for a separate change because they are a larger refactor and are masked by the fixes here:

- `scene.dialog` should be its own focus layer — on a device, showing a dialog leaves the scene's focus chain completely untouched while `dialog.isInFocusChain()` is true. `StandardDialog.renderNode` still claims scene focus.
- A visible dialog should be modal — on a device, Down/OK reach it even when the app re-focuses a node behind it, and the scene's `onKeyEvent` never sees them. `RoSGScreen.handleNextKey` still falls through to `scene.handleOnKeyEvent`.

## Testing

- New `focus-steal-app` + `test/cli/cli.test.js` case pins both rules together: a loss observer reads the committed chain, its re-grab is dropped, a forward re-focus is honored, and a plain move still works afterwards.
- Full suite green — 2386 passed. `dialog-buttongroup-focus-app` (forward focus) and `init-focus-observer-app` (deferred init focus) stay green alongside it.
- Both probe apps now match the device capture on every scenario's chain state.
- Verified end to end in a real SceneGraph app whose two focus bugs (a confirmation dialog drawn but unfocused; a directional key needing two presses to leave a grid) both came from this.
- `.claude/docs/scenegraph-invariants.md` documents both rules and the deliberate `hasFocus()` divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
