### PR TITLE
fix: three 9-patch sizing bugs (Poster display modes, marker parsing, mid-render re-measure)

### DIFF
--- a/src/core/brsTypes/components/RoBitmap.ts
+++ b/src/core/brsTypes/components/RoBitmap.ts
@@ -352,16 +352,30 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
 
         const isBlack = (x: number, y: number) => {
             const i = (x + y * width) * 4;
-            // Marker pixels are opaque black (0, 0, 0, 255)
-            return data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 0 && data[i + 3] === 255;
+            // Marker pixels are black and NOT transparent. The alpha test is `> 0`, not `=== 255`:
+            // real-world `.9.png`s ship semi-transparent markers (a palette entry of
+            // rgba(0,0,0,128) is common — some authoring/optimization tools quantize the 1px border
+            // that way), and requiring full opacity mis-parsed them. Because the scan then found the
+            // marker on only part of an edge — or missed an edge entirely — the insets came out wrong
+            // or negative, and `drawNinePatch` stretched the center band over the fixed corners: the
+            // asset rendered pinched at the ends and bulging in the middle instead of as a uniform bar.
+            // Only the fully transparent border pixels of an unmarked edge must read false.
+            return data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 0 && data[i + 3] > 0;
         };
 
         // Scans an edge line and returns the [first, last] indices of its contiguous marker, or
         // undefined when no marker pixel is found.
+        //
+        // The four CORNER pixels are skipped (the scan runs 1..length-2). A marker only ever spans
+        // the content range, so a black corner belongs to no edge — but counting one dragged the
+        // marker's first/last index onto the border and produced a NEGATIVE inset (`before = -1` or
+        // `after = -1`), which `drawNinePatch` turned into an oversized center band overlapping the
+        // fixed corners. Assets that mark two adjacent edges commonly share the corner pixel between
+        // them, so this is not a malformed-asset case.
         const scanMarker = (length: number, sample: (i: number) => boolean) => {
             let first = -1;
             let last = -1;
-            for (let i = 0; i < length; i++) {
+            for (let i = 1; i < length - 1; i++) {
                 if (sample(i)) {
                     if (first < 0) {
                         first = i;

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -703,6 +703,7 @@ export class Group extends Node {
         // yet). Paint passes don't participate in pruning at all.
         if (sgRoot.pruneLayout) {
             this.subtreeStale = false;
+            this.measureStale = false;
             this.lastLayoutContext = { x: origin[0], y: origin[1], angle, opacity };
         }
         this.layoutPassCount++;

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -140,6 +140,23 @@ export class Node extends RoSGNode implements BrsValue {
      * must survive for the next refresh. Starts true so everything lays out on first pass.
      */
     subtreeStale: boolean = true;
+    /**
+     * True when this node or anything below it was WRITTEN since its subtree last completed any
+     * layout pass — a full one or a scoped mid-render measurement. Set alongside `subtreeStale` by
+     * `markSubtreeStale()`, but cleared independently, because the two answer different questions:
+     *
+     * - `subtreeStale` — "may a pruned full refresh skip this subtree?" A scoped measurement at
+     *   origin [0,0] must LEAVE it set (`markSubtreeStaleDeep`), since it clobbered the subtree's
+     *   `rectToScene` with origin-less values that only a full refresh can re-establish.
+     * - `measureStale` — "would re-measuring this subtree produce a different size?" Sizes are
+     *   translation-invariant, so the scoped measurement fully answers it and CLEARS this flag.
+     *
+     * Sharing one flag forced a bad trade: keyed on `subtreeStale`, every repeat mid-render query
+     * re-rendered the subtree (the deep mark it just set made itself look stale again); keyed on a
+     * degenerate rect alone, a repeat query returned a stale cached size after the app changed
+     * something. This flag lets a changed subtree re-measure while an unchanged repeat hits the cache.
+     */
+    measureStale: boolean = true;
 
     /** Node bounds in local coordinates. */
     rectLocal: Rect = { x: 0, y: 0, width: 0, height: 0 };
@@ -1090,15 +1107,25 @@ export class Node extends RoSGNode implements BrsValue {
             interpreter &&
             sgRoot.rendering &&
             !sgRoot.measuring &&
-            (this.rectLocal.width <= 0 || this.rectLocal.height <= 0)
+            (this.rectLocal.width <= 0 || this.rectLocal.height <= 0 || this.measureStale)
         ) {
-            // Mid-render query on a node this pass hasn't laid out yet (its local rect is degenerate).
+            // Mid-render query on a node this pass hasn't laid out yet (its local rect is degenerate),
+            // or one whose subtree was written since its last measurement (`measureStale`).
             // A full refresh is unavailable (it would re-enter the owning grid's item creation and
             // recurse), so render just this node's own subtree to populate its rects. Either dimension
             // zero signals "not measured" — a label first measured with empty text caches width 0 but
             // a non-zero line height, so requiring both zero would skip the refresh and return a stale
             // width. Measuring at origin [0,0] is fine: width/height are translation-invariant and the
             // true origin is recomputed when the pass reaches the node. `measuring` bounds nested queries.
+            //
+            // `measureStale` is what makes REPEATED mid-render queries correct. A degenerate-rect test
+            // alone measures only the FIRST query of a render: once a rect is cached, every later query
+            // in that same render returns it verbatim, even after the app changed something. Apps size a
+            // background from a measured child in exactly that shape — set an icon, measure, set the
+            // text, measure again — and the second measurement silently returned the pre-text size, so
+            // the background fit the icon alone and the text overflowed it. The mark is set by
+            // `makeDirty()` (every field write), so this re-measures only when something actually
+            // changed; it is cleared below, so an unchanged repeat query still hits the cache.
             //
             // The subtree render's updateParentRects would union this child into its parent's cached
             // bounds, but the parent hasn't been laid out this pass — unioning one child pollutes it
@@ -1130,6 +1157,11 @@ export class Node extends RoSGNode implements BrsValue {
                 // values; deep-mark it so the next pruned refresh re-descends and re-establishes
                 // in-tree rects instead of skipping the settled subtree.
                 this.markSubtreeStaleDeep();
+                // ...but the SIZES this pass just computed are current (width/height are
+                // translation-invariant), so clear the measurement mark that the deep mark above
+                // re-set. Without this, the flag the fallback keys on is left set by the very pass
+                // meant to satisfy it, and every repeat query re-renders the subtree.
+                this.clearSubtreeMeasureStale();
             }
         }
         switch (type) {
@@ -2213,9 +2245,11 @@ export class Node extends RoSGNode implements BrsValue {
      */
     markSubtreeStale() {
         this.subtreeStale = true;
+        this.measureStale = true;
         let ancestor = this.parent instanceof Node ? this.parent : undefined;
         while (ancestor) {
             ancestor.subtreeStale = true;
+            ancestor.measureStale = true;
             ancestor = ancestor.parent instanceof Node ? ancestor.parent : undefined;
         }
     }
@@ -2235,6 +2269,26 @@ export class Node extends RoSGNode implements BrsValue {
         while (stack.length > 0) {
             const node = stack.pop()!;
             node.subtreeStale = true;
+            for (const child of node.children) {
+                if (child instanceof Node) {
+                    stack.push(child);
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears `measureStale` on this node and every descendant after a scoped measurement pass
+     * computed their sizes. Only the sizes are guaranteed current — `subtreeStale` deliberately
+     * stays set, because the pass ran at origin [0,0] and left the subtree's scene-space origins
+     * wrong for anything but a full refresh. Ancestors are NOT cleared: they were not measured, so
+     * a later query on one must still re-measure to pick this subtree's new size up.
+     */
+    private clearSubtreeMeasureStale() {
+        const stack: Node[] = [this];
+        while (stack.length > 0) {
+            const node = stack.pop()!;
+            node.measureStale = false;
             for (const child of node.children) {
                 if (child instanceof Node) {
                     stack.push(child);

--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -119,9 +119,17 @@ export class Poster extends Group {
                 alpha = opacity * this.getValueJS("loadingBitmapOpacity");
             }
             this.bitmap.scaleMode = 1;
-            if (displayMode.trim().toLowerCase() === "scaletofit") {
+            // The aspect-preserving display modes do not apply to a 9-patch: its marker border is
+            // what declares which regions stretch (fixed corners are blitted 1:1), so the target
+            // rect is authoritative and the source aspect ratio is meaningless. Letterboxing it to
+            // the source ratio collapses a wide pill drawn from a square asset to a square the
+            // height of the rect — the app-assigned width is simply lost — and cropping it
+            // (scaleToZoom) slices through the markers. Same rationale as loadUri skipping
+            // loadWidth/loadHeight for 9-patches: the bitmap must reach drawNinePatch intact.
+            const mode = this.bitmap.ninePatch ? "noscale" : displayMode.trim().toLowerCase();
+            if (mode === "scaletofit") {
                 this.drawImage(this.bitmap, this.scaleToFit(rect), rotation, alpha, draw2D, rgba);
-            } else if (displayMode.trim().toLowerCase() === "scaletozoom") {
+            } else if (mode === "scaletozoom") {
                 draw2D?.doDrawCroppedBitmap(this.bitmap, this.scaleToZoom(rect), rect, rgba, alpha);
             } else {
                 this.drawImage(this.bitmap, rect, rotation, alpha, draw2D, rgba);

--- a/test/brsTypes/components/RoBitmap.test.js
+++ b/test/brsTypes/components/RoBitmap.test.js
@@ -87,4 +87,116 @@ describe("RoBitmap 9-patch parsing", () => {
             margins: { left: 0, right: 0, top: 0, bottom: 0 },
         });
     });
+
+    it("accepts semi-transparent marker pixels", () => {
+        // Authored `.9.png`s ship semi-transparent markers — a palette entry of rgba(0,0,0,128) is
+        // common, since some optimizers quantize the 1px border. Requiring fully opaque black made
+        // the scan miss those edges, so the insets came out wrong and the asset drew pinched at the
+        // ends with a bulging middle instead of a uniform bar.
+        const size = 10;
+        const canvas = createCanvas(size, size);
+        const ctx = canvas.getContext("2d");
+        ctx.fillStyle = "rgba(255, 255, 255, 1)";
+        ctx.fillRect(1, 1, size - 2, size - 2);
+        ctx.fillStyle = "rgba(0, 0, 0, 0.5)"; // 50% alpha markers, not opaque
+        ctx.fillRect(4, 0, 2, 1); // top stretch marker
+        ctx.fillRect(0, 4, 1, 2); // left stretch marker
+
+        const bitmap = new RoBitmap(canvas.toBuffer("image/png"), "pkg:/images/faint.9.png");
+
+        expect(bitmap.ninePatch).toBe(true);
+        // Content spans 1..8; marker at 4..5 => fixed insets of 3 on every side.
+        expect(bitmap.getPatchSizes()).toEqual({
+            left: 3,
+            right: 3,
+            top: 3,
+            bottom: 3,
+            margins: { left: 0, right: 0, top: 0, bottom: 0 },
+        });
+    });
+
+    it("ignores black corner pixels shared between two edge markers", () => {
+        // A marker only ever spans the content range, so a black CORNER belongs to no edge. Counting
+        // one dragged the marker's first/last index onto the border and yielded a NEGATIVE inset,
+        // which drawNinePatch turned into a center band overlapping the fixed corners. Assets that
+        // mark two adjacent edges commonly share the corner pixel, so this is not a malformed asset.
+        const size = 10;
+        const canvas = createCanvas(size, size);
+        const ctx = canvas.getContext("2d");
+        ctx.fillStyle = "rgba(255, 255, 255, 1)";
+        ctx.fillRect(1, 1, size - 2, size - 2);
+        ctx.fillStyle = "rgba(0, 0, 0, 1)";
+        ctx.fillRect(4, 0, 2, 1); // top stretch marker
+        ctx.fillRect(0, 4, 1, 2); // left stretch marker
+        // Bottom padding marker running into BOTH bottom corners, and a right marker into the
+        // bottom-right corner — the shared-corner case.
+        ctx.fillRect(0, size - 1, size, 1);
+        ctx.fillRect(size - 1, 1, 1, size - 1);
+
+        const bitmap = new RoBitmap(canvas.toBuffer("image/png"), "pkg:/images/corners.9.png");
+
+        expect(bitmap.ninePatch).toBe(true);
+        const sizes = bitmap.getPatchSizes();
+        // Every inset must be >= 0: a negative one is what produced the deformed render.
+        for (const key of ["left", "right", "top", "bottom"]) {
+            expect(sizes[key]).toBeGreaterThanOrEqual(0);
+        }
+        for (const key of ["left", "right", "top", "bottom"]) {
+            expect(sizes.margins[key]).toBeGreaterThanOrEqual(0);
+        }
+        expect(sizes).toEqual({
+            left: 3,
+            right: 3,
+            top: 3,
+            bottom: 3,
+            margins: { left: 0, right: 0, top: 0, bottom: 0 },
+        });
+    });
+
+    it("draws a wide bar from a small 9-patch at uniform height", () => {
+        // End-to-end shape of the deformed-progress-bar report: a small rounded-bar asset drawn much
+        // wider than its source must paint a CONSTANT height across its stretched middle. Wrong
+        // insets made the center band taller than the fixed ends — thin at the borders, bulging in
+        // the middle.
+        const size = 10;
+        const src = createCanvas(size, size);
+        const sctx = src.getContext("2d");
+        sctx.fillStyle = "rgba(255, 255, 255, 1)";
+        sctx.fillRect(1, 1, size - 2, size - 2);
+        sctx.fillStyle = "rgba(0, 0, 0, 0.5)";
+        sctx.fillRect(4, 0, 2, 1);
+        sctx.fillRect(0, 4, 1, 2);
+        sctx.fillStyle = "rgba(0, 0, 0, 1)";
+        sctx.fillRect(0, size - 1, size, 1); // bottom marker through both corners
+        const bitmap = new RoBitmap(src.toBuffer("image/png"), "pkg:/images/bar.9.png");
+        expect(bitmap.ninePatch).toBe(true);
+
+        const { RoAssociativeArray, BrsString, Int32, BrsBoolean, IfDraw2D } = brs.types;
+        const target = new RoBitmap(
+            new RoAssociativeArray([
+                { name: new BrsString("width"), value: new Int32(60) },
+                { name: new BrsString("height"), value: new Int32(30) },
+                { name: new BrsString("alphaEnable"), value: BrsBoolean.True },
+            ])
+        );
+        const barHeight = 6;
+        new IfDraw2D(target).drawNinePatch(bitmap, { x: 0, y: 0, width: 40, height: barHeight }, undefined, 1);
+
+        const data = target.getContext().getImageData(0, 0, 60, 30).data;
+        const paintedHeight = (x) => {
+            let count = 0;
+            for (let y = 0; y < 30; y++) {
+                if (data[(x + y * 60) * 4 + 3] > 8) {
+                    count++;
+                }
+            }
+            return count;
+        };
+        // Sample across the stretched middle (past the 3px fixed caps on each end).
+        for (let x = 4; x < 36; x++) {
+            expect(paintedHeight(x)).toBe(barHeight);
+        }
+        // Nothing painted beyond the requested width.
+        expect(paintedHeight(41)).toBe(0);
+    });
 });

--- a/test/extensions/scenegraph/MidRenderRemeasure.test.js
+++ b/test/extensions/scenegraph/MidRenderRemeasure.test.js
@@ -1,0 +1,127 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float, RoArray, Interpreter } = core;
+
+/**
+ * Regression: a mid-render boundingRect() query only re-measured when the node's cached rect was
+ * DEGENERATE. That makes the first query of a render correct and every later one stale — once a rect
+ * is cached, a repeat query returns it verbatim even after the app changed something in the subtree.
+ *
+ * Apps size a background from a measured child in exactly that shape, from a field observer (so,
+ * mid-render): set an icon, measure the row, set the text, measure again, then size a 9-patch
+ * background to the result. The second measurement returned the pre-text width, so the background
+ * was sized for the icon alone and the text spilled past it — while the SAME component with no icon
+ * (a single measurement) came out right, making it look asset-specific rather than order-specific.
+ *
+ * The fix adds `subtreeStale` to the fallback condition: the mark is set by makeDirty() on every
+ * field write and cleared at the start of a layout pass, so a repeat query re-measures only when
+ * something actually changed.
+ */
+describe("repeated mid-render measurements pick up subtree changes", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        // Label font-typed defaults need the common: fonts; mount once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.rendering = false;
+        sgRoot.setFocused();
+    });
+
+    /**
+     * Scene > badge(Group) > [ background(Rectangle), row(horiz LayoutGroup > [icon(Rectangle),
+     * label(Label)]) ]. Mirrors an icon+text pill whose background is sized from the measured row.
+     */
+    function buildBadge() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const badge = SGNodeFactory.createNode("Group");
+        const background = SGNodeFactory.createNode("Rectangle");
+        background.setValue("width", new Float(0));
+        background.setValue("height", new Float(40));
+        const row = SGNodeFactory.createNode("LayoutGroup");
+        row.setValue("layoutDirection", new BrsString("horiz"));
+        const icon = SGNodeFactory.createNode("Rectangle");
+        icon.setValue("height", new Float(21));
+        icon.setValue("width", new Float(0));
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("height", new Float(24));
+        row.appendChildToParent(icon);
+        row.appendChildToParent(label);
+        badge.appendChildToParent(background);
+        badge.appendChildToParent(row);
+        scene.appendChildToParent(badge);
+        return { scene, badge, background, row, icon, label };
+    }
+
+    test("a second query after a text change reports the wider row, not the cached width", () => {
+        const { row, icon, label } = buildBadge();
+
+        sgRoot.rendering = true;
+        // Observer 1 (icon): give the icon a size, then measure the row.
+        icon.setValue("width", new Float(24));
+        row.setValue("itemSpacings", new RoArray([new Float(8)]));
+        const iconOnly = row.getBoundingRect("toParent", interpreter).width;
+
+        // Observer 2 (text): set the label text, then measure the row AGAIN.
+        label.setValue("text", new BrsString("LIVE"));
+        const withText = row.getBoundingRect("toParent", interpreter).width;
+        sgRoot.rendering = false;
+
+        // The icon-only row is the icon plus its trailing spacing; the text must widen it.
+        expect(iconOnly).toBeGreaterThan(0);
+        expect(withText).toBeGreaterThan(iconOnly);
+        // It must equal icon + spacing + the label's own measured width.
+        const labelWidth = label.getBoundingRect("local", interpreter).width;
+        expect(labelWidth).toBeGreaterThan(0);
+        expect(withText).toBeCloseTo(24 + 8 + labelWidth, 1);
+    });
+
+    test("the same component measured without the icon step agrees with the icon path", () => {
+        // The no-icon variant only ever measures once, so it was already correct — pin that the two
+        // paths now agree on the label's contribution.
+        const noIcon = buildBadge();
+        sgRoot.rendering = true;
+        noIcon.label.setValue("text", new BrsString("LIVE"));
+        const plain = noIcon.row.getBoundingRect("toParent", interpreter).width;
+        sgRoot.rendering = false;
+
+        const withIcon = buildBadge();
+        sgRoot.rendering = true;
+        withIcon.icon.setValue("width", new Float(24));
+        withIcon.row.setValue("itemSpacings", new RoArray([new Float(8)]));
+        withIcon.row.getBoundingRect("toParent", interpreter);
+        withIcon.label.setValue("text", new BrsString("LIVE"));
+        const iconRow = withIcon.row.getBoundingRect("toParent", interpreter).width;
+        sgRoot.rendering = false;
+
+        expect(plain).toBeGreaterThan(0);
+        expect(iconRow - plain).toBeCloseTo(32, 1); // exactly the icon (24) + spacing (8)
+    });
+
+    test("an unchanged repeat query still returns the cached rect", () => {
+        // The stale mark is what triggers a re-measure, so a query with nothing written in between
+        // must NOT re-render the subtree — otherwise every measurement in a render pass re-descends.
+        const { row, label } = buildBadge();
+
+        sgRoot.rendering = true;
+        label.setValue("text", new BrsString("LIVE"));
+        const first = row.getBoundingRect("toParent", interpreter).width;
+        const passesAfterFirst = row.layoutPassCount;
+        const second = row.getBoundingRect("toParent", interpreter).width;
+        sgRoot.rendering = false;
+
+        expect(second).toBe(first);
+        expect(row.layoutPassCount).toBe(passesAfterFirst);
+    });
+});

--- a/test/extensions/scenegraph/Poster.test.js
+++ b/test/extensions/scenegraph/Poster.test.js
@@ -4,12 +4,18 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory } = scenegraph;
-const { BrsDevice, BrsString, Float, RoMessagePort } = core;
+const { BrsDevice, BrsBoolean, BrsString, Float, Int32, IfDraw2D, RoAssociativeArray, RoBitmap, RoMessagePort } = core;
 
 /**
  * Minimal fake interpreter accepted by Node.addObserver for a port observer (mirrors HiddenFields.test.js).
  */
 const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+/** Mounts the common: volume (fonts, 9-patch images) that Poster loads its bitmaps from. */
+function mountCommonVolume() {
+    const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+    BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+}
 
 /**
  * Poster load notifications: on a real device bitmapWidth/bitmapHeight read 0 until an image finishes
@@ -19,11 +25,7 @@ const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
  * cross-fade pattern (observe bitmapWidth to start a fade-in when the next background finishes loading).
  */
 describe("Poster bitmap load notifications", () => {
-    beforeAll(() => {
-        // Poster loads images from the common: volume; mount it once.
-        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
-        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
-    });
+    beforeAll(mountCommonVolume);
 
     test("bitmapWidth re-notifies on every load, even when the new image has identical dimensions", () => {
         const poster = SGNodeFactory.createNode("Poster");
@@ -49,5 +51,103 @@ describe("Poster bitmap load notifications", () => {
         poster.setValue("uri", new BrsString("common:/images/icon_options_off.png"));
         expect(poster.getValueJS("bitmapWidth")).toBe(firstWidth);
         expect(received.length).toBe(2);
+    });
+});
+
+/**
+ * A 9-patch's marker border is what declares which regions stretch (its fixed corners are blitted
+ * 1:1), so the Poster's width/height are authoritative and the SOURCE aspect ratio is meaningless.
+ * The aspect-preserving loadDisplayMode values must therefore not apply to a 9-patch. They used to:
+ * a pill sized from a measured label (a very common pattern — `background.width =
+ * label.boundingRect().width + padding`) whose asset is square then letterboxed down to a square the
+ * height of the rect, so every pill rendered at the same small size no matter how wide its text was,
+ * while boundingRect() still reported the assigned width (drawn and measured sizes disagreeing).
+ */
+describe("Poster 9-patch display modes", () => {
+    beforeAll(mountCommonVolume);
+
+    // A 75x75 9-patch (insets 11/10/12/12 — pinned in test/brsTypes/components/RoBitmap.test.js).
+    const ninePatchUri = "common:/images/inputField.9.png";
+    const plainUri = "common:/images/icon_options.png";
+
+    /** Renders `poster` onto a scratch canvas, capturing the rects handed to the draw primitives. */
+    function renderCapturing(poster) {
+        const target = new RoBitmap(
+            new RoAssociativeArray([
+                { name: new BrsString("width"), value: new Int32(400) },
+                { name: new BrsString("height"), value: new Int32(200) },
+                { name: new BrsString("alphaEnable"), value: BrsBoolean.True },
+            ])
+        );
+        const draw2D = new IfDraw2D(target);
+        const ninePatchRects = [];
+        const croppedRects = [];
+        const drawNinePatch = draw2D.drawNinePatch.bind(draw2D);
+        draw2D.drawNinePatch = (bitmap, rect, rgba, opacity) => {
+            ninePatchRects.push({ ...rect });
+            return drawNinePatch(bitmap, rect, rgba, opacity);
+        };
+        const doDrawCroppedBitmap = draw2D.doDrawCroppedBitmap.bind(draw2D);
+        draw2D.doDrawCroppedBitmap = (bitmap, source, dest, rgba, opacity) => {
+            croppedRects.push({ ...dest });
+            return doDrawCroppedBitmap(bitmap, source, dest, rgba, opacity);
+        };
+        const scaledRects = [];
+        const doDrawScaledObject = draw2D.doDrawScaledObject.bind(draw2D);
+        draw2D.doDrawScaledObject = (x, y, scaleX, scaleY, bitmap, rgba, opacity) => {
+            scaledRects.push({ x, y, width: scaleX * bitmap.width, height: scaleY * bitmap.height });
+            return doDrawScaledObject(x, y, scaleX, scaleY, bitmap, rgba, opacity);
+        };
+        poster.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+        return { ninePatchRects, croppedRects, scaledRects };
+    }
+
+    /** A Poster sized like a text pill: much wider than tall, from a square-ish source asset. */
+    function createPillPoster(uri, displayMode) {
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("loadDisplayMode", new BrsString(displayMode));
+        poster.setValue("width", new Float(200));
+        poster.setValue("height", new Float(40));
+        poster.setValue("uri", new BrsString(uri));
+        expect(poster.getValueJS("loadStatus")).toBe("ready");
+        return poster;
+    }
+
+    test("scaleToFit stretches a 9-patch to the full assigned rect instead of letterboxing it", () => {
+        const poster = createPillPoster(ninePatchUri, "scaleToFit");
+        const { ninePatchRects, croppedRects } = renderCapturing(poster);
+
+        expect(croppedRects).toEqual([]);
+        // Letterboxing a 75x75 source into 200x40 would give a 40x40 square centered at x=80.
+        expect(ninePatchRects).toEqual([{ x: 0, y: 0, width: 200, height: 40 }]);
+    });
+
+    test("scaleToZoom draws a 9-patch through drawNinePatch, uncropped", () => {
+        const poster = createPillPoster(ninePatchUri, "scaleToZoom");
+        const { ninePatchRects, croppedRects } = renderCapturing(poster);
+
+        // Cropping would slice through the marker border and the fixed corners.
+        expect(croppedRects).toEqual([]);
+        expect(ninePatchRects).toEqual([{ x: 0, y: 0, width: 200, height: 40 }]);
+    });
+
+    test("the drawn rect matches the reported bounding rect", () => {
+        const poster = createPillPoster(ninePatchUri, "scaleToFit");
+        renderCapturing(poster);
+
+        expect(poster.rectLocal).toEqual({ x: 0, y: 0, width: 200, height: 40 });
+        expect(poster.rectToParent).toEqual({ x: 0, y: 0, width: 200, height: 40 });
+    });
+
+    test("a plain (non 9-patch) bitmap still letterboxes under scaleToFit", () => {
+        const poster = createPillPoster(plainUri, "scaleToFit");
+        const { ninePatchRects, scaledRects } = renderCapturing(poster);
+
+        expect(ninePatchRects).toEqual([]);
+        expect(scaledRects.length).toBe(1);
+        // A square source pillarboxed into 200x40: 40x40, centered horizontally.
+        expect(scaledRects[0].width).toBeCloseTo(40);
+        expect(scaledRects[0].height).toBeCloseTo(40);
+        expect(scaledRects[0].x).toBeCloseTo(80);
     });
 });

--- a/test/extensions/scenegraph/SubBoundingRect.test.js
+++ b/test/extensions/scenegraph/SubBoundingRect.test.js
@@ -181,6 +181,12 @@ describe("ancestorSubBoundingRect", () => {
         grid.rectToParent = { x: 10, y: 20, width: 438, height: 800 };
         grid.rectLocal = { x: 0, y: 0, width: 438, height: 800 };
         grid.rectToScene = { x: 100, y: 200, width: 438, height: 800 };
+        // A real laid-out node also has `measureStale` clear; the tree above was assembled by field
+        // writes (which set it) and never rendered, so clear it too. Leaving it set makes the
+        // mid-render fallback re-measure these nodes at origin [0,0] and discard the injected rects.
+        for (const node of [scene, group, grid]) {
+            node.measureStale = false;
+        }
 
         const item1 = new Group([], "Group");
         item1.rectToScene = { x: 100, y: 284, width: 438, height: 72 };


### PR DESCRIPTION
Three independent root causes, each of which made a `.9.png` render at the wrong size. All were reproduced and measured, not inferred; one commit each, so they stay bisectable.

### 1. Aspect-preserving display modes were applied to a 9-patch `Poster`

`Poster.renderNode` applied `scaleToFit`/`scaleToZoom` **before** dispatching to the 9-patch draw, so a rect derived from the source PNG's aspect ratio replaced the app-assigned one. Drawn from a square asset, a pill the app sized 87x32 collapsed to a 32x32 letterboxed square — the assigned width was lost, and every such badge rendered at the same small fixed size regardless of its text width. `boundingRect()` still reported 87x32, so measured and drawn sizes disagreed. `scaleToZoom` additionally cropped through the marker border.

Aspect preservation is meaningless for a 9-patch: the marker border declares what stretches, fixed corners are blitted 1:1, so the target rect is authoritative. The engine already applies this one layer up — `loadUri` skips the `loadWidth`/`loadHeight` `resizeTexture` for 9-patches because resizing destroys the markers — but the `renderNode` display-mode branch never got the same guard. Gated on the parsed `ninePatch` flag, so ordinary posters keep letterboxing.

### 2. `parsePatchSizes` mis-parsed semi-transparent and corner-sharing markers

- `isBlack` required alpha 255, but authored `.9.png`s ship semi-transparent markers (a palette entry of `rgba(0,0,0,128)` is common — some optimizers quantize the 1px border), so the scan missed those edges. Now tests alpha `> 0`.
- `scanMarker` included the four corner pixels. A marker only spans the content range, so a black corner belongs to no edge, but counting one dragged the marker's first/last index onto the border and yielded a **negative** inset. Assets marking two adjacent edges commonly share the corner pixel, so this is not a malformed-asset case.

Either way `drawNinePatch` stretched the center band over the fixed corners. On the affected asset, drawn 40x6:

```
before  {left:0, right:0, top:8, bottom:-1, margins:{left:-1,…}}
        painted height per column: 6,6,6,6,6,8,8,…,8,6,6,6,6,6   ← thin ends, bulging middle
after   {left:3, right:3, top:3, bottom:3, margins:{0,0,0,0}}
        painted height per column: 4,6,6,…,6,6,4                 ← uniform bar, rounded ends
```

### 3. A repeated mid-render `boundingRect()` returned a stale cached size

`getBoundingRect`'s mid-render scoped-measurement fallback only fired when the cached rect was **degenerate**. That makes the *first* query of a render correct and every later one stale — once a rect is cached, a repeat returns it verbatim even after the app wrote to the subtree.

Apps size a background from a measured child in exactly that shape, from field observers (so, mid-render): set an icon, measure the row, set the text, measure again, size a 9-patch background to the result. The second measurement returned the pre-text width, so the background fit the icon alone and the text spilled past it — while the same component without an icon takes a single-measurement path and was correct, making the bug look asset-specific rather than order-specific. Measured:

```
midRender=false: icon step=32 → text step=83 → background=107  ✅
midRender=true:  icon step=32 → text step=32 → background=56   ❌
```

Fixed by adding `measureStale`, set alongside `subtreeStale` by `markSubtreeStale()` but **cleared independently**, because the two answer different questions:

- `subtreeStale` — "may a pruned full refresh skip this subtree?" A scoped measurement at origin `[0,0]` must *leave it set*, having clobbered `rectToScene` with origin-less values only a full refresh can re-establish.
- `measureStale` — "would re-measuring produce a different size?" Sizes are translation-invariant, so the scoped pass fully answers it and clears it.

Sharing one flag forced a bad trade: keyed on `subtreeStale`, every repeat query re-rendered the subtree (the deep mark it had just set made itself look stale again); keyed on the degenerate rect alone, repeats went stale. The third new test pins both halves — a changed subtree re-measures, an unchanged repeat still hits the cache without bumping `layoutPassCount`.

## Tests

- `test/extensions/scenegraph/Poster.test.js` — new "Poster 9-patch display modes" block: `scaleToFit`/`scaleToZoom` must pass the **full** rect to `drawNinePatch` (not a letterboxed square, and not through `doDrawCroppedBitmap`); a non-9-patch poster still letterboxes; drawn size matches `rectLocal`.
- `test/brsTypes/components/RoBitmap.test.js` — semi-transparent markers, corner-shared markers (every inset `>= 0`), and end-to-end: a small asset drawn much wider than its source paints a constant height across its stretched middle.
- `test/extensions/scenegraph/MidRenderRemeasure.test.js` (new) — a second query after a text change reports the wider row; the no-icon path agrees with the icon path; an unchanged repeat still hits the cache.
- `test/extensions/scenegraph/SubBoundingRect.test.js` — its harness hand-injects rects to simulate an already-laid-out tree, so it now clears the new mark too (a real laid-out node has it clear; otherwise the fallback correctly re-measures and discards the injected values).

Each fix was reverted in turn to confirm it is load-bearing: reverting #1 fails the new Poster tests, #2 fails exactly the three new `RoBitmap` tests, #3 fails 2 of the 3 mid-render tests (the cache-hit test correctly still passes).

Full suite: **2396 passed**, lint and prettier clean. Verified end-to-end in brs-desktop against a large production SceneGraph app — the previously fixed-size badge now stretches to its text, and the tile progress bar renders as a uniform bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)