### PR TITLE
fix(scenegraph): bind observer callback parameters the way a device does

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -245,6 +245,24 @@ capture the **native JS stack** mid-recursion (a temporary depth tripwire dumpin
    > and all five counters. Regression: `init-focus-observer-app` (deferred delivery + no double-fire)
    > plus the cascade apps above.
 
+   > **Argument binding is device-measured — `Field.satisfiedByEvent` (do not "generalize" it).** An
+   > observer registered by *name* is invoked with the `roSGNodeEvent` **only when it declares exactly one
+   > parameter whose declared type accepts an object**; otherwise it is called with **no arguments** (every
+   > parameter taking its declared default), which requires that no parameter is required; otherwise it is
+   > **not invoked at all, silently**. There is no coercion and no partial binding, so a callback declaring
+   > more than one parameter *never* receives the event — not even when the extras are optional and the
+   > first is `as object`. A default on the single parameter is irrelevant: `sub cb(e = invalid as object)`
+   > still receives the event, not its default. This is not BrightScript's normal call-binding rule (which
+   > would happily fill trailing optionals), so it cannot be delegated to `Callable.call` /
+   > `getFirstSatisfiedSignature([event])` alone — that fallback matched the *zero-argument* satisfaction
+   > while the binding loop still assigned the event to parameter 0, which is how
+   > `sub cb(state = "update" as string)` observing a Timer `fire` got an object in `state` and raised a
+   > `Type Mismatch` on a later `state = "stop"` — a crash impossible on a device. Measured across 16
+   > signature shapes × `observeField` / `observeFieldScoped` / `Timer.fire` / a string-typed field on Roku
+   > OS 15.2 (all four identical); the probe app and its device trace are in
+   > `out/observer-signature-probe/`. Regression: "Binds an observer callback's parameters the way a device
+   > does" in `test/cli/cli.test.js` (`observer-signature-app`).
+
 2. **Re-entrant render — `Node.getBoundingRect`.** `localBoundingRect`/`boundingRect` refresh layout by
    rendering the whole tree from the root. If BrightScript queries a bounding rect *while a render is
    running* — e.g. an `ArrayGrid`/`RowList` lazily creating an item whose `init()` or observer measures a

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -821,6 +821,29 @@ export class Field {
         }
     }
 
+    /**
+     * Decides whether an observer callback receives the event as its argument.
+     *
+     * Device-measured on Roku OS 15.2: an observer registered by name is invoked with the event
+     * ONLY when it declares exactly ONE parameter whose declared type accepts an object. There is
+     * no coercion, and no partial binding — a callback declaring more than one parameter never
+     * receives the event, even when the extra parameters are optional and the first one is
+     * `as object`. A default on the single parameter is irrelevant: it still receives the event.
+     *
+     * When this returns undefined the caller falls back to a zero-argument call, which succeeds
+     * only when no parameter is required; otherwise the callback is not invoked at all (silently,
+     * as on device).
+     *
+     * @param observer the callable registered as the observer
+     * @param event the event to be delivered
+     * @returns the satisfied signature when the event is to be passed, otherwise undefined
+     */
+    private static satisfiedByEvent(observer: Callable, event: RoSGNodeEvent) {
+        return observer
+            .getAllSignatureMismatches([event])
+            .find((satisfaction) => satisfaction.mismatches.length === 0 && satisfaction.signature.args.length === 1);
+    }
+
     private invokeCallable(callback: BrsCallback, event: RoSGNodeEvent) {
         const { interpreter, observer, hostNode, environment } = callback;
         if (!(observer instanceof Callable)) {
@@ -831,8 +854,8 @@ export class Field {
             subInterpreter.environment.hostNode = hostNode;
             subInterpreter.environment.setRootM(hostNode.m);
             // Check whether the callback is expecting an event parameter.
-            const satisfiedSignature =
-                observer.getFirstSatisfiedSignature([event]) ?? observer.getFirstSatisfiedSignature([]);
+            const eventSatisfaction = Field.satisfiedByEvent(observer, event);
+            const satisfiedSignature = eventSatisfaction ?? observer.getFirstSatisfiedSignature([]);
             if (satisfiedSignature) {
                 const { signature, impl } = satisfiedSignature;
                 const originalLocation = interpreter.location;
@@ -844,25 +867,18 @@ export class Field {
                     signature: satisfiedSignature.signature,
                 });
                 try {
-                    if (signature.args.length > 0) {
-                        // Roku invokes an observer callback with only the event as its first
-                        // argument; any remaining declared parameters fall back to their default
-                        // values. Bind them all here — previously only the first parameter was
-                        // defined, leaving later ones <uninitialized> (e.g. a timer `fire`
-                        // callback declared as `sub cb(event, opt = true)` crashed reading `opt`).
-                        for (const [index, param] of signature.args.entries()) {
-                            let paramValue: BrsType;
-                            if (index === 0) {
-                                paramValue = event;
-                            } else if (param.defaultValue) {
-                                paramValue = subInterpreter.evaluate(param.defaultValue);
-                            } else {
-                                paramValue = Uninitialized.Instance;
-                            }
-                            subInterpreter.environment.define(Scope.Function, param.name.text, paramValue);
-                        }
+                    if (eventSatisfaction) {
+                        // The event is bound to the single declared parameter (see `satisfiedByEvent`).
+                        subInterpreter.environment.define(Scope.Function, signature.args[0].name.text, event);
                         impl(subInterpreter, event);
                     } else {
+                        // The event was not passed, so every declared parameter takes its default.
+                        for (const param of signature.args) {
+                            const paramValue: BrsType = param.defaultValue
+                                ? subInterpreter.evaluate(param.defaultValue)
+                                : Uninitialized.Instance;
+                            subInterpreter.environment.define(Scope.Function, param.name.text, paramValue);
+                        }
                         impl(subInterpreter);
                     }
                     interpreter.popFromStack();

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -580,6 +580,39 @@ describe.concurrent("cli", () => {
         ]);
     }, 30000);
 
+    it("Binds an observer callback's parameters the way a device does", async () => {
+        let command = ["node", brsCliPath, "-r observer-signature-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Device-measured on Roku OS 15.2 (see out/observer-signature-probe): an observer registered
+        // by name gets the event ONLY when it declares exactly one parameter whose type accepts an
+        // object; otherwise it is called with no arguments (every parameter taking its default),
+        // which requires that no parameter is required; otherwise it is not called at all. No
+        // coercion, and no partial binding. The `stringDefault`/`timerFire` rows are the shape that
+        // regressed: binding the event to a `as string` parameter made a later `state = "stop"`
+        // raise a Type Mismatch that cannot happen on a device.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Observer Signature Test ===",
+            "noargs: no parameters",
+            "untyped: p1=roSGNodeEvent",
+            "object: p1=roSGNodeEvent field=trigger",
+            "objectDefault: p1=roSGNodeEvent",
+            "stringRequired: not called",
+            "stringDefault: p1=String value=update isStop=false",
+            "integerDefault: p1=Integer value=42",
+            "twoParamsFirstRequired: not called",
+            "twoParamsAllDefaulted: p1=String value=update p2=Invalid",
+            "objectThenStringDefault: not called",
+            "timerFire: p1=String value=update isStop=false",
+            "=== Observer Signature Test Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     it("Reentrant field observers are deferred until the current handler returns", async () => {
         let command = ["node", brsCliPath, "-r deferred-observer-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/observer-signature-app/components/MainScene.xml
+++ b/test/cli/resources/observer-signature-app/components/MainScene.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <!--
+        How an observer registered by name binds the roSGNodeEvent to its declared parameters.
+
+        Device-measured on Roku OS 15.2 (out/observer-signature-probe covers 16 signature shapes
+        across observeField / observeFieldScoped / Timer.fire / a string-typed field, all identical).
+        Roku attempts exactly two calls, with no coercion and no partial binding:
+
+          1. with the event, only when the callback declares exactly ONE parameter whose declared
+             type accepts an object (a default on it is irrelevant - it still gets the event);
+          2. otherwise with no arguments, only when no parameter is required (each takes its default);
+          3. otherwise the callback is not invoked at all, silently.
+
+        The shape that motivated this is `sub cb(state = "update" as string)` observing a Timer
+        `fire`: the engine used to bind the event to `state`, so a later `state = "stop"` raised
+        `Type Mismatch. Operator "=" can't be applied to "Object" and "String"` - a crash impossible
+        on a real device, where `state` is simply "update".
+    -->
+    <interface>
+        <field id="testDone" type="boolean" value="false" />
+        <field id="trigger" type="integer" value="0" />
+    </interface>
+    <children>
+        <Timer id="fireTimer" duration="0.05" repeat="false" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+
+    sub init()
+        ' Each case: observe `trigger` with one callback, write the field, print what arrived.
+        probe("noargs", "cbNoArgs")
+        probe("untyped", "cbUntyped")
+        probe("object", "cbObject")
+        probe("objectDefault", "cbObjectDefault")
+        probe("stringRequired", "cbStringRequired")
+        probe("stringDefault", "cbStringDefault")
+        probe("integerDefault", "cbIntegerDefault")
+        probe("twoParamsFirstRequired", "cbTwoParamsFirstRequired")
+        probe("twoParamsAllDefaulted", "cbTwoParamsAllDefaulted")
+        probe("objectThenStringDefault", "cbObjectThenStringDefault")
+
+        ' The JellyRock trigger: the same optional-typed-string shape on a Timer `fire`.
+        m.fireTimer = m.top.findNode("fireTimer")
+        m.fireTimer.observeField("fire", "cbTimerStringDefault")
+        m.fireTimer.control = "start"
+    end sub
+
+    sub probe(label as string, callback as string)
+        m.label = label
+        m.called = false
+        m.top.unobserveField("trigger")
+        m.top.observeField("trigger", callback)
+        m.top.trigger = m.top.trigger + 1
+        m.top.unobserveField("trigger")
+        if not m.called then print label + ": not called"
+    end sub
+
+    sub say(text as string)
+        m.called = true
+        print m.label + ": " + text
+    end sub
+
+    function bstr(b as boolean) as string
+        if b then return "true"
+        return "false"
+    end function
+
+    ' --- callbacks, one per signature shape -------------------------------------------------
+
+    sub cbNoArgs()
+        say("no parameters")
+    end sub
+
+    sub cbUntyped(e)
+        say("p1=" + type(e))
+    end sub
+
+    sub cbObject(e as object)
+        say("p1=" + type(e) + " field=" + e.getField())
+    end sub
+
+    ' Optional but compatible: receives the event, NOT its default.
+    sub cbObjectDefault(e = invalid as object)
+        say("p1=" + type(e))
+    end sub
+
+    ' Required and unsatisfiable: never called.
+    sub cbStringRequired(s as string)
+        say("p1=" + type(s))
+    end sub
+
+    ' The JellyRock shape: called with the default, so a string comparison is safe.
+    sub cbStringDefault(s = "update" as string)
+        say("p1=" + type(s) + " value=" + s + " isStop=" + bstr(s = "stop"))
+    end sub
+
+    sub cbIntegerDefault(n = 42 as integer)
+        say("p1=" + type(n) + " value=" + str(n).trim())
+    end sub
+
+    ' More than one declared parameter: the event is never passed, and the first parameter is
+    ' required, so there is no zero-argument call either. Never called.
+    sub cbTwoParamsFirstRequired(e, opt = true)
+        say("p1=" + type(e))
+    end sub
+
+    ' More than one declared parameter, but nothing is required: called with no arguments, so both
+    ' parameters take their defaults - the event does NOT go to the compatible second parameter.
+    sub cbTwoParamsAllDefaulted(s = "update" as string, e = invalid as object)
+        say("p1=" + type(s) + " value=" + s + " p2=" + type(e))
+    end sub
+
+    ' First parameter would accept the event and the second is optional, but two declared
+    ' parameters disqualify the event, and the required first one disqualifies the empty call.
+    sub cbObjectThenStringDefault(e as object, s = "update" as string)
+        say("p1=" + type(e) + " p2=" + s)
+    end sub
+
+    sub cbTimerStringDefault(state = "update" as string)
+        print "timerFire: p1=" + type(state) + " value=" + state + " isStop=" + bstr(state = "stop")
+        m.top.testDone = true
+    end sub
+
+    ]]></script>
+</component>

--- a/test/cli/resources/observer-signature-app/manifest
+++ b/test/cli/resources/observer-signature-app/manifest
@@ -1,0 +1,4 @@
+title=Observer Signature Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/observer-signature-app/source/main.brs
+++ b/test/cli/resources/observer-signature-app/source/main.brs
@@ -1,0 +1,14 @@
+sub Main()
+    print "=== Observer Signature Test ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' The synchronous cases all run from init(); the Timer `fire` case needs the message loop.
+    for i = 0 to 50
+        msg = wait(20, port)
+        if scene.testDone then exit for
+    end for
+    print "=== Observer Signature Test Complete ==="
+end sub


### PR DESCRIPTION
## Problem

An observer registered by name (`observeField(field, "funcName")`) could be handed the `roSGNodeEvent` in a parameter whose declared type cannot hold one. A callback declared

```brightscript
sub reportPlayback(state = "update" as string)
```

and registered on a Timer's `fire` received the event object in `state`, so a later `state = "stop"` raised `Type Mismatch. Operator "=" can't be applied to "Object" and "String"` and took the app down. The same function called directly with a string worked, so the crash only showed up on the timer path — and never on a real device.

`invokeCallable` already tried `getFirstSatisfiedSignature([event])` and fell back to `getFirstSatisfiedSignature([])`, but the binding loop afterwards keyed off `signature.args.length > 0`. When the event had been rejected on type grounds and the **zero-argument** satisfaction was what matched, the event was still assigned to parameter 0 instead of its default.

## What a device actually does

Measured on a Roku Streaming Stick, **Roku OS 15.2**, across 16 signature shapes, each against `observeField`, `observeFieldScoped`, a `Timer.fire` and a string-typed field — **all four axes identical**. Roku makes exactly two attempts, with no coercion and no partial binding:

1. **Call with the event** — only when the callback declares **exactly one** parameter whose declared type accepts an object. A default on that parameter is irrelevant: it still receives the event, not the default.
2. **Otherwise call with no arguments** — only when no parameter is required; each parameter takes its declared default.
3. **Otherwise do not invoke the callback at all**, silently — no error, nothing on the debug console.

So a callback declaring **more than one** parameter never receives the event, even when the extras are optional and the first is `as object`. That is not BrightScript's normal call binding (which would happily fill trailing optionals), so it cannot be delegated to `Callable.call`.

| Signature | Device | Engine before |
| --- | --- | --- |
| `sub cb()` | called, 0 args | ✅ same |
| `sub cb(e)` / `(e as object)` / `(e as dynamic)` | event | ✅ same |
| `sub cb(e = invalid as object)` | event, not the default | ✅ same |
| `sub cb(s as string)` / `(n as integer)` / `(b as boolean)` / `(a, b)` | not called | ✅ same |
| `sub cb(s = "update" as string)` | default `"update"` | ❌ **event object** → `Type Mismatch` |
| `sub cb(n = 42 as integer)` | default `42` | ❌ **event object** |
| `sub cb(s = "update" as string, e = invalid as object)` | both defaults | ❌ event on param 1 |
| `sub cb(e, opt = true)` | not called | ❌ called with event + default |
| `sub cb(e as object, s = "update" as string)` | not called | ❌ called with event + default |

## Fix

Add `Field.satisfiedByEvent` to decide the argument count **before** any binding, and branch `invokeCallable` on it: either bind the event to the single declared parameter, or evaluate every parameter's default and call with no arguments.

**One deliberate behavior change:** `sub cb(event, opt = true)` used to be invoked with the event plus the default — added in #982 so `opt` would not read as `<uninitialized>`. A device never calls that shape at all, so it now silently does not fire. No test pinned the old behavior (only a code comment), and the full suite is green.

## Testing

- New `test/cli/resources/observer-signature-app` + **"Binds an observer callback's parameters the way a device does"** in `test/cli/cli.test.js` — the discriminating shapes, driven by both a field write and a `Timer.fire`, asserting the `isStop=false` comparison that used to crash.
- Full suite green: **2397 passed / 193 files**. `npm run lint` and `npm run prettier` clean.
- The probe app that measured the device, its raw device trace and the full 16-case table are in `out/observer-signature-probe/` (gitignored scratch, same as the existing `out/focus-probe*`).
- Invariant written up in `.claude/docs/scenegraph-invariants.md` under the observer-dispatch hot path, including why it cannot be delegated to normal call binding.

Unrelated divergence noticed while comparing traces, **not** addressed here: `type(invalid)` is reported as `Invalid` where the device says `roInvalid`, and vice versa (device says `roInvalid` for an evaluated `invalid` default and `Invalid` for `getData()` on a `Timer.fire`; the engine has the two swapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
