### PR TITLE
fix(scenegraph): normalize hex-string elements in colorarray fields

### DIFF
--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -35,6 +35,7 @@ import { RoSGNodeEvent } from "../events/RoSGNodeEvent";
 import { getValueKindFromFieldType } from "../factory/NodeFactory";
 import { fromAssociativeArray, toAssociativeArray, jsValueOf } from "../factory/Serializer";
 import { BrsCallback, FieldKind, isContentNode } from "../SGTypes";
+import { convertHexColor } from "../SGUtil";
 
 export class Field {
     // Observer collections are allocated lazily. A node like ContentNode registers ~100 default
@@ -584,6 +585,8 @@ export class Field {
             value = this.convertVector2D(value);
         } else if (this.type === FieldKind.Vector2DArray) {
             value = this.convertVector2DArray(value);
+        } else if (this.type === FieldKind.ColorArray && value instanceof RoArray) {
+            value = this.convertColorArray(value);
         } else if (this.type === FieldKind.String && isStringComp(value)) {
             value = new BrsString(value.getValue());
         }
@@ -677,6 +680,32 @@ export class Field {
             }
         }
         return vector2DArray;
+    }
+
+    /**
+     * Normalizes a `colorarray` so every element is stored as a packed `0xRRGGBBAA` integer.
+     *
+     * BrightScript apps routinely build color lists as hex STRINGS (e.g. an interpolator's
+     * `keyValue = [colorBlack + alpha60, colorBackgroundPrimary]`). Without this conversion the
+     * strings were stored verbatim, and consumers that do bitwise math on them (e.g.
+     * ColorFieldInterpolator's HSV blend, ArrayGrid.resolveColor) relied on JS `ToNumber`
+     * coercion instead: a 6-digit `"0x0D1117"` became `0x000D1117`, shifting every lane one byte
+     * right so the intended blue became the alpha (0x17, ~9% opaque) and the color was drawn
+     * nearly invisible. `convertHexColor` applies the implicit `FF` alpha a device assumes for a
+     * 6-digit color, and accepts the `#`/`0x`/`&h` prefixes interchangeably — matching the scalar
+     * `color` path (Group.setValue) and the XML attribute path (NodeFactory.parseColorArray).
+     */
+    private convertColorArray(value: RoArray): RoArray {
+        const colors: BrsType[] = [];
+        for (const element of value.elements) {
+            if (isBrsString(element)) {
+                colors.push(new Int32(convertHexColor(element.getValue())).box());
+            } else if (isAnyNumber(element)) {
+                const number = isBoxedNumber(element) ? element.unbox() : element;
+                colors.push(new Int32(number.getValue()).box());
+            }
+        }
+        return new RoArray(colors);
     }
 
     private isEqual(oldValue: BrsType, newValue: BrsType): boolean {

--- a/test/extensions/scenegraph/ColorInterpolator.test.js
+++ b/test/extensions/scenegraph/ColorInterpolator.test.js
@@ -1,0 +1,94 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { BrsString, Float, Int32, RoArray } = core;
+
+const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
+const stringArray = (strs) => new RoArray(strs.map((s) => new BrsString(s)));
+const intArray = (nums) => new RoArray(nums.map((n) => new Int32(n)));
+
+const channels = (rgba) => ({
+    r: (rgba >> 24) & 0xff,
+    g: (rgba >> 16) & 0xff,
+    b: (rgba >> 8) & 0xff,
+    a: rgba & 0xff,
+});
+
+/**
+ * `colorarray` fields (ColorFieldInterpolator.keyValue, ArrayGrid's rowTitleColor/rowCounterColor, ...)
+ * must normalize hex STRINGS to packed 0xRRGGBBAA integers the way the scalar `color` path and the XML
+ * attribute path already do. Apps build these lists from string constants
+ * (`keyValue = [colorBlack + alpha60, colorBackgroundPrimary]`), and the stored strings used to reach
+ * consumers that do bitwise math on them — JS `ToNumber` then read a 6-digit "0x0D1117" as 0x000D1117,
+ * shifting every lane one byte right so the intended blue (0x17) became the ALPHA. A panel animated to
+ * that color rendered ~9% opaque instead of solid, leaving everything painted behind it visible.
+ */
+describe("colorarray hex-string normalization", () => {
+    test("a 6-digit hex string gains the implicit FF alpha; an 8-digit one keeps its own", () => {
+        const interp = SGNodeFactory.createNode("ColorFieldInterpolator");
+        interp.setValue("keyValue", stringArray(["0x00000099", "0x0D1117"]));
+
+        expect(interp.getValueJS("keyValue")).toEqual([0x00000099, 0x0d1117ff]);
+    });
+
+    test("#, 0x and &h prefixes and an integer all normalize to the same value", () => {
+        const forms = ["0x0D1117", "#0D1117", "&h0D1117", "0x0D1117FF"];
+        for (const form of forms) {
+            const interp = SGNodeFactory.createNode("ColorFieldInterpolator");
+            interp.setValue("keyValue", stringArray([form]));
+            expect(interp.getValueJS("keyValue")).toEqual([0x0d1117ff]);
+        }
+
+        const numeric = SGNodeFactory.createNode("ColorFieldInterpolator");
+        numeric.setValue("keyValue", intArray([0x0d1117ff]));
+        expect(numeric.getValueJS("keyValue")).toEqual([0x0d1117ff]);
+    });
+
+    test("string keyframes drive the target to a FULLY OPAQUE color", () => {
+        // The app shape: a Rectangle panel whose own child Animation interpolates the panel's color
+        // from translucent black to an opaque theme background as it slides over the content below.
+        const panel = SGNodeFactory.createNode("Rectangle");
+        panel.setValue("id", new BrsString("extrasGrp"));
+        panel.setValue("color", new BrsString("0x00000099"));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.4));
+        const interp = SGNodeFactory.createNode("ColorFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("extrasGrp.color"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", stringArray(["0x00000099", "0x0D1117"]));
+        animation.appendChildToParent(interp);
+        panel.appendChildToParent(animation);
+
+        // Starts translucent (0x99 = 60% alpha), so the buttons behind it show through.
+        expect(channels(panel.getValueJS("color")).a).toBe(0x99);
+
+        animation.setValue("control", new BrsString("finish"));
+
+        // Ends opaque: the panel now hides everything painted before it.
+        const end = channels(panel.getValueJS("color"));
+        expect(end.a).toBe(0xff);
+        expect(end.r).toBeCloseTo(0x0d, -0.5);
+        expect(end.g).toBeCloseTo(0x11, -0.5);
+        expect(end.b).toBeCloseTo(0x17, -0.5);
+    });
+
+    test("numeric keyframes still interpolate unchanged", () => {
+        // Pins the XML/integer path, which already worked via NodeFactory.parseColorArray.
+        const panel = SGNodeFactory.createNode("Rectangle");
+        panel.setValue("id", new BrsString("panel"));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.4));
+        const interp = SGNodeFactory.createNode("ColorFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("panel.color"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", intArray([0x00000099, 0x0d1117ff]));
+        animation.appendChildToParent(interp);
+        panel.appendChildToParent(animation);
+
+        animation.setValue("control", new BrsString("finish"));
+        expect(channels(panel.getValueJS("color")).a).toBe(0xff);
+    });
+});


### PR DESCRIPTION
## Problem

A `Rectangle` animated to an opaque color stayed effectively transparent, so everything painted before it stayed visible through the "opaque" panel.

The app builds the interpolator's keyframes from string constants, which is the ordinary way to express colors in BrightScript:

```brightscript
extrasGrp.color = colorBlack + alpha60          ' "0x000000" + "99"  — scalar, works
colorSlider.keyValue = [startColor, endColor]   ' ["0x00000099", "0x0D1117"] — colorarray, broken
```

`ColorFieldInterpolator.keyValue` is a `colorarray`. Two gaps let the raw strings through:

- `Field.canAcceptValue` accepts **any** `roArray` for `FloatArray`/`IntArray`/`ColorArray`/`TimeArray` without inspecting element types (`Field.ts:415-419`).
- `Field.convertValue` has branches for `Rect2D`, `Vector2D` and `Vector2DArray` — but **none for `ColorArray`** (`Field.ts:567-594`).

So the `BrsString`s were stored verbatim. `ColorFieldInterpolator.interpolate` then reads them with a bare cast (`getValueJS("keyValue") as number[]`) and does bitwise math on them in `toHsv`, which quietly falls back to JS `ToNumber` coercion. That does **not** apply the implicit `FF` alpha a device assumes for a 6-digit color, so every lane shifts one byte right:

| keyframe | intended RGBA | engine computed |
| --- | --- | --- |
| `"0x00000099"` | R00 G00 B00 **A=0x99** | same — survives by luck (8 digits) |
| `"0x0D1117"` | R0D G11 B17 **A=0xFF** | R00 G0D B11 **A=0x17 (23/255, ≈9%)** |

The panel faded to ~9% opacity instead of solid. Verified by the new test failing on `master` with `expected 23 to be 255` — 23 is exactly `0x17`, the intended blue byte landing in the alpha slot.

Note what makes this a pure `colorarray` gap rather than a color-handling gap: the **scalar** path already works — `Group.setValue` routes a `BrsString` on a `FieldKind.Color` field through `convertHexColor` (`Group.ts:115-118`), which pads a 6-digit value with `FF` (`SGUtil.ts:179-193`). The **XML attribute** path works too, via `NodeFactory.parseColorArray`. Only a runtime assignment of a string *array* bypassed both, which is why `extrasGrp.color = "0x0D1117"` renders opaque while animating to the same literal does not.

Nothing about z-order, `clippingRect`, alpha compositing or focus drawing was involved — those were all investigated and are correct. `Node.renderChildren` paints in strict declaration order and `Rectangle` honors the alpha byte properly (`Rectangle.ts:34-38` → `IfDraw2D.ts:140-142`).

## Fix

Add the missing `ColorArray` branch to `Field.convertValue`, mirroring the existing `convertVector2DArray` shape: each element is normalized through `convertHexColor`, so a `colorarray` always stores packed `0xRRGGBBAA` integers regardless of how it was written.

Fixing it at this choke point repairs every consumer of the field type at once, not just the interpolator — notably `ArrayGrid.resolveColor` (`ArrayGrid.ts:952-960`, a plain `Number(values[index])`) backing `ZoomRowList`'s `rowTitleColor` / `rowCounterColor`.

`ColorFieldInterpolator` itself is untouched: once the field stores `Int32`s, its existing HSV blend is already correct.

**Deliberately out of scope:** a scalar `FieldKind.Color` assigned via `setValueSilent` bypasses `Group.setValue`'s conversion. `canAcceptValue` rejects a scalar string for a `Color` field *before* `convertValue` runs, so covering that needs a matching `canAcceptValue` change — a wider change with its own regression surface, and not what this bug needed.

## Testing

`test/extensions/scenegraph/ColorInterpolator.test.js` is new — there was **no `ColorFieldInterpolator` coverage at all** (`Animation.test.js` only exercises `FloatFieldInterpolator`), and none for string-valued `keyValue` anywhere. It covers:

- a 6-digit hex string gains the implicit `FF`; an 8-digit one keeps its own alpha
- `#`, `0x`, `&h` and an integer all normalize to the same value
- end-to-end through the real app shape (a `Rectangle` whose own child `Animation` targets it by id): starts at `0x99` alpha, finishes fully opaque
- numeric keyframes still interpolate unchanged, pinning the XML/integer path

Each of the first three fails on `master` for the right reason; the numeric-passthrough case passes on both, pinning what already worked.

Full suite green: **2401 passed / 194 files**. `npm run lint` and `npm run prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)