### PR TITLE
fix(scenegraph): RowList honors vertFocusAnimationStyle when scrolling rows

### DIFF
--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -110,8 +110,12 @@ export class RowList extends ArrayGrid {
         this.gap = 0;
         this.setValueSilent("focusBitmapUri", new BrsString(this.focusUri));
         this.setValueSilent("wrapDividerBitmapUri", new BrsString(this.dividerUri));
-        const vertStyle = this.getValueJS("vertFocusAnimationStyle") as string;
-        this.wrap = vertStyle.toLowerCase() === RowFocusStyle.Wrap;
+        // Re-derive the cached vertical focus style AFTER registerDefaultFields has installed RowList's
+        // own default (fixedFocus). ArrayGrid's constructor already ran applyVertFocusStyle(), but at
+        // that point the field still held ArrayGrid's floatingFocus default, and registerDefaultFields
+        // bypasses setValue — so the cache said "floatingfocus" while the field read "fixedFocus".
+        // renderContent branches on isFixedFocusMode(), so the two must agree.
+        this.applyVertFocusStyle();
         this.numRows = this.getValueJS("numRows") as number;
         this.numCols = this.getValueJS("numColumns") as number;
         this.rowFocus = [];
@@ -337,7 +341,6 @@ export class RowList extends ArrayGrid {
             }
 
             const rowItem = new RoArray([new Int32(nextRow), new Int32(targetColIndex)]);
-            this.currRow += this.wrap ? 0 : offset; // Update currRow before setFocusedItem
             // Publish the vertical scroll direction BEFORE the focus change so observers of the focus
             // fields see the correct direction, then reset it to "none" after (mirroring a real device,
             // where the direction is transient and settles back to none once scrolling completes).
@@ -634,7 +637,19 @@ export class RowList extends ArrayGrid {
             return;
         }
         const context = this.initializeRenderContext(rect, interpreter, rotation, opacity, draw2D);
-        this.currRow = this.focusIndex;
+        // `currRow` is the ABSOLUTE index of the first row drawn (see calculateActualRowIndex), so it
+        // is what decides how far the list has scrolled internally. Per Roku, fixedFocus/fixedFocusWrap
+        // pin the focused row at the list top and scroll the rows above it off screen; floatingFocus
+        // instead keeps rows at fixed positions and only scrolls "if there are rows that were not
+        // visible" — i.e. never once numRows covers the whole content. Applying the fixedFocus rule to
+        // every style made a floatingFocus list scroll a full row pitch per Up/Down even when all its
+        // rows fit, which compounds with any translation an app applies to the node itself.
+        if (this.isFixedFocusMode()) {
+            this.currRow = this.focusIndex;
+        } else {
+            this.updateListCurrRow(); // maintains this.topRow, the first visible row of the window
+            this.currRow = this.topRow;
+        }
 
         for (let r = 0; r < context.displayRows; r++) {
             const rowIndex = this.calculateActualRowIndex(r);

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -10,7 +10,6 @@ import {
     RoArray,
     IfDraw2D,
     Rect,
-    RectRect,
     RoFont,
 } from "brs-engine";
 import { sgRoot } from "../SGRoot";
@@ -797,7 +796,14 @@ export class RowList extends ArrayGrid {
         const rowSpacing = this.calculateRowSpacing(rowIndex, context.rowSpacings, context.globalSpacing);
         context.itemRect.y = rowTopY + rowHeight + (bandFits ? 0 : bandHeight) + rowSpacing;
 
-        return RectRect(this.sceneRect, context.itemRect);
+        // Stop only once the next row starts BELOW the viewport — everything after it is off screen.
+        // A row entirely ABOVE the viewport must not end the pass: this used to test the next row for
+        // intersection with the scene, which was safe only while rendering always began at the focused
+        // (on-screen) row. With floatingFocus the pass begins at the window's top row, so an app that
+        // scrolls by translating the list itself can park earlier rows off the top — and a full row of
+        // clearance up there would abort the pass before reaching the focused row, blanking it and
+        // every row below it.
+        return context.itemRect.y < this.sceneRect.y + this.sceneRect.height;
     }
 
     private getRowXOffset(rowIndex: number): number {

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -579,3 +579,160 @@ describe("RowList key handling", () => {
         }
     });
 });
+
+/**
+ * Vertical scrolling must follow `vertFocusAnimationStyle`. Per Roku, fixedFocus/fixedFocusWrap pin the
+ * focused row at the list top and scroll the rows above it off screen; floatingFocus keeps rows at fixed
+ * positions and only scrolls "if there are rows that were not visible" — so a list whose `numRows` covers
+ * the whole content never scrolls internally at all. RowList used to apply the fixedFocus rule to every
+ * style, shifting the whole grid up a full row pitch per Up/Down even when every row already fit. Apps
+ * that do their own scrolling by translating the RowList node (with numRows == rowCount precisely to
+ * disable internal scrolling) got double the intended travel, pushing the focused row off the top.
+ */
+describe("RowList vertical scrolling honors vertFocusAnimationStyle", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    // Rows small enough that all of them fit inside the default scene height, so a row that is missing
+    // from a render was genuinely scrolled away rather than merely off the bottom edge.
+    const ROW_HEIGHT = 80;
+    const ROW_SPACING = 20;
+    const PITCH = ROW_HEIGHT + ROW_SPACING;
+
+    /**
+     * A list of `rowCount` single-item rows (one item per row, so a row index maps to one title),
+     * instrumented to record the y-origin each row's item component is drawn at. Item components are
+     * cached across renders, so the recording wrapper is installed at creation time — before the list
+     * is focused, which itself builds the focused row's component.
+     */
+    function makeList(rowCount, style, numRows) {
+        const list = SGNodeFactory.createNode("RowList");
+        const rows = [];
+        for (let i = 0; i < rowCount; i++) {
+            rows.push(["R" + i]);
+        }
+        const drawn = {};
+        const original = list.createItemComponent.bind(list);
+        list.createItemComponent = (interp, itemRect, content) => {
+            const comp = original(interp, itemRect, content);
+            const render = comp.renderNode.bind(comp);
+            comp.renderNode = (i2, origin, angle, opacity, draw2D) => {
+                drawn[content.getValueJS("title")] = Math.round(origin[1]);
+                return render(i2, origin, angle, opacity, draw2D);
+            };
+            return comp;
+        };
+
+        list.setValue("vertFocusAnimationStyle", new BrsString(style));
+        list.setValue("content", buildContent(rows));
+        list.setValue("itemSize", new RoArray([new Int32(1280), new Int32(ROW_HEIGHT)]));
+        // Items narrower than the row (and the scene) so every row's single item fits without the
+        // horizontal scroll path kicking in — this suite is only about VERTICAL positioning.
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(300), new Int32(ROW_HEIGHT)])]));
+        list.setValue("itemSpacing", new RoArray([new Int32(0), new Int32(ROW_SPACING)]));
+        list.setValue("numRows", new Int32(numRows));
+        list.setNodeFocus(true);
+
+        list.renderRows = () => {
+            for (const key of Object.keys(drawn)) {
+                delete drawn[key];
+            }
+            list.renderNode({}, [0, 0], 0, 1);
+            return { ...drawn };
+        };
+        return list;
+    }
+
+    test("floatingFocus with numRows == rowCount never scrolls internally", () => {
+        // The shape an app uses when it scrolls by translating the RowList itself: every row is
+        // "visible", so the list must keep each row pinned at its own fixed position no matter which
+        // row holds focus. Row N stays at N * (rowHeight + itemSpacing.y).
+        const list = makeList(5, "floatingFocus", 5);
+        for (let row = 0; row < 5; row++) {
+            if (row > 0) {
+                expect(list.handleKey("down", true)).toBe(true);
+            }
+            expect(list.getValueJS("itemFocused")).toBe(row);
+
+            const drawn = list.renderRows();
+            // Every row is still drawn, each at its own unchanging position.
+            for (let i = 0; i < 5; i++) {
+                expect(drawn["R" + i]).toBe(i * PITCH);
+            }
+            expect(list.topRow).toBe(0);
+        }
+    });
+
+    test("floatingFocus with numRows < rowCount scrolls only once focus leaves the window", () => {
+        // 5 rows, a 3-row window: rows 0-2 need no scroll, then the window follows focus down and
+        // clamps at the bottom (topRow max = rowCount - numRows).
+        const list = makeList(5, "floatingFocus", 3);
+
+        expect(list.topRow).toBe(0);
+        list.renderRows();
+        expect(list.topRow).toBe(0);
+
+        // Down to rows 1 and 2 — still inside the window, so the top row does not move.
+        for (const expected of [1, 2]) {
+            list.handleKey("down", true);
+            list.renderRows();
+            expect(list.getValueJS("itemFocused")).toBe(expected);
+            expect(list.topRow).toBe(0);
+        }
+
+        // Row 3 falls past the last visible slot, so the window advances by exactly one row.
+        list.handleKey("down", true);
+        const drawn = list.renderRows();
+        expect(list.topRow).toBe(1);
+        expect(drawn["R0"]).toBeUndefined(); // row 0 scrolled off the top
+        expect(drawn["R1"]).toBe(0);
+
+        // Row 4 advances it once more, and there it clamps (5 rows - 3 visible).
+        list.handleKey("down", true);
+        list.renderRows();
+        expect(list.topRow).toBe(2);
+
+        // Coming back up, the window only moves once focus leaves it at the top.
+        list.handleKey("up", true);
+        list.renderRows();
+        expect(list.topRow).toBe(2);
+        list.handleKey("up", true);
+        list.renderRows();
+        expect(list.topRow).toBe(2);
+        list.handleKey("up", true);
+        list.renderRows();
+        expect(list.getValueJS("itemFocused")).toBe(1);
+        expect(list.topRow).toBe(1);
+    });
+
+    test("fixedFocus (the RowList default) still pins the focused row at the list top", () => {
+        // Pins the pre-existing behavior for every app that does not ask for floatingFocus.
+        const list = makeList(5, "fixedFocus", 5);
+
+        let drawn = list.renderRows();
+        expect(drawn["R0"]).toBe(0);
+
+        list.handleKey("down", true);
+        drawn = list.renderRows();
+        // The focused row is drawn at the list's top and the row above it is gone.
+        expect(drawn["R1"]).toBe(0);
+        expect(drawn["R0"]).toBeUndefined();
+    });
+
+    test("a fresh RowList's cached vertical focus style matches its fixedFocus field default", () => {
+        // ArrayGrid's constructor caches the style while the field still holds ArrayGrid's own
+        // floatingFocus default; RowList's fixedFocus default is installed afterwards via
+        // registerDefaultFields, which bypasses setValue. The two used to disagree, so a RowList that
+        // never touched the field reported floatingFocus internally while reading fixedFocus back.
+        const list = SGNodeFactory.createNode("RowList");
+        expect(list.getValueJS("vertFocusAnimationStyle")).toBe("fixedFocus");
+        expect(list.isFixedFocusMode()).toBe(true);
+        expect(list.wrap).toBe(false);
+    });
+});

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -725,6 +725,47 @@ describe("RowList vertical scrolling honors vertFocusAnimationStyle", () => {
         expect(drawn["R0"]).toBeUndefined();
     });
 
+    test("rows scrolled entirely above the viewport do not abort the pass", () => {
+        // An app that scrolls by translating the list itself parks the earlier rows off the TOP of the
+        // screen. The render loop used to stop at the first row that did not intersect the scene — safe
+        // only while the pass always began at the focused (on-screen) row. Starting at the window's top
+        // row instead, a full row of clearance above the viewport aborted the pass before reaching the
+        // focused row, blanking it and everything below it (the last row of a detail panel vanished
+        // while it still navigated normally).
+        const list = makeList(4, "floatingFocus", 4);
+        const bottomRow = 3;
+        list.setValue("jumpToRowItem", new RoArray([new Int32(bottomRow), new Int32(0)]));
+
+        // Translate so row 1 clears the top of the screen entirely, leaving the focused row on screen.
+        const listY = -(2 * PITCH + 10);
+        list.setValue("translation", new RoArray([new Int32(0), new Int32(listY)]));
+        expect(listY + PITCH + ROW_HEIGHT).toBeLessThan(0); // row 1 is fully above the viewport
+
+        const drawn = list.renderRows();
+        // Every row is still laid out at its own fixed position, focused row included.
+        for (let i = 0; i < 4; i++) {
+            expect(drawn["R" + i]).toBe(listY + i * PITCH);
+        }
+        expect(drawn["R" + bottomRow]).toBeGreaterThanOrEqual(0); // and it is genuinely on screen
+    });
+
+    test("the pass still stops at the first row below the viewport", () => {
+        // The early-out that keeps a long list from rendering rows nobody can see must survive: with the
+        // list at the top of the screen, only the rows that fit are drawn.
+        const list = makeList(40, "floatingFocus", 40);
+        list.setValue("translation", new RoArray([new Int32(0), new Int32(0)]));
+
+        const drawn = list.renderRows();
+        const sceneBottom = list.sceneRect.y + list.sceneRect.height;
+        const rendered = Object.keys(drawn).length;
+        expect(rendered).toBeGreaterThan(0);
+        expect(rendered).toBeLessThan(40);
+        // Nothing was drawn starting past the bottom edge.
+        for (const y of Object.values(drawn)) {
+            expect(y).toBeLessThan(sceneBottom);
+        }
+    });
+
     test("a fresh RowList's cached vertical focus style matches its fixedFocus field default", () => {
         // ArrayGrid's constructor caches the style while the field still holds ArrayGrid's own
         // floatingFocus default; RowList's fixedFocus default is installed afterwards via


### PR DESCRIPTION
Two commits, kept separate because the second fixes a latent bug that only becomes reachable once the first lands.

## 1. `RowList` ignored `vertFocusAnimationStyle` and `numRows`

`renderContent` set `currRow` unconditionally from the focus cursor:

```ts
// RowList.ts:637
this.currRow = this.focusIndex;
```

`currRow` is the **absolute index of the first row drawn** (see `calculateActualRowIndex`), so this is what decides how far the list has scrolled internally. Every `RowList` therefore behaved as `fixedFocus`, whatever the style and however many rows already fit: each Up/Down shifted the whole list by a full row pitch. `numRows` was only ever used as a *draw count* (`RowList.ts:676`) — there was no `numRows >= rowCount → don't scroll` check anywhere — and `vertFocusAnimationStyle` was consumed only to derive the `wrap` flag (`RowList.ts:113-114`).

Per the [RowList reference](https://developer.roku.com/docs/references/scenegraph/list-and-grid-nodes/rowlist.md), `floatingFocus` scrolls only *"if there are rows that were not visible"* — with `numRows >= rowCount` there are none, so the correct behavior is zero internal scroll.

That matters because it is exactly the configuration an app uses to take over scrolling itself: set `numRows` to the row count to disable internal scrolling, then translate the `RowList` node to position rows by hand. Instead the two shifts compounded, roughly doubling the travel, and the focused row kept climbing until it was clipped by whatever sits above the list.

**Fix.** Route the non-fixed styles through `ArrayGrid.updateListCurrRow` (`ArrayGrid.ts:813-847`) — the `topRow` window every other list node already uses (`PosterGrid.ts:210`, `MarkupList.ts:124`, `LabelList.ts:111`); `RowList` was the only one that opted out. It pins `topRow` at 0 whenever `numRows >= totalRows` and otherwise advances the window only when focus leaves it. `fixedFocus`/`fixedFocusWrap` keep pinning the focused row at the list top, unchanged.

Reusing the base helper is safe here because `RowList` forces `numColumns` to 1 and rejects writes to it (`RowList.ts:58`, `RowList.ts:144-147`), so its `focusIndex / numCols` division is an identity — for a `RowList`, `focusIndex` *is* the row index.

**Also repaired: a stale style cache that gates the whole change.** `ArrayGrid`'s constructor calls `applyVertFocusStyle()` (`ArrayGrid.ts:179`) while the field still holds *ArrayGrid's* `floatingFocus` default (`ArrayGrid.ts:77`). `RowList`'s own `fixedFocus` default (`RowList.ts:75`) is installed afterwards via `registerDefaultFields`, which bypasses `setValue` — so a freshly constructed `RowList` read `fixedFocus` from the field while the cached `vertFocusAnimationStyleName` said `floatingfocus`. Harmless while nothing consulted it; `renderContent` now branches on `isFixedFocusMode()`, so without this every default `RowList` would silently switch behavior. Calling `applyVertFocusStyle()` sets both the cache and `wrap` consistently and additionally resolves the `"fixed"` alias.

Since the default stays `fixedFocus`, existing apps and tests are unaffected — only a list that explicitly asks for `floatingFocus` gets the windowed behavior. The vestigial `this.currRow += ...` in `handleUpDown` is dropped; the next render pass overwrote it anyway.

## 2. Rows scrolled above the viewport aborted the render pass

Found during device testing of the first commit: on a 4-row panel, navigating down worked for the first three rows, then the **last row vanished** — it still navigated (focus and the app's translation were both correct) but never drew.

`renderSingleRow` ended the pass whenever the *next* row's rect failed to intersect the scene:

```ts
return RectRect(this.sceneRect, context.itemRect);
```

That was only ever safe because rendering began at the focused row, which is on screen by construction — so "doesn't intersect" could only mean "past the bottom". Now that a `floatingFocus` pass begins at the window's top row, and an app scrolling by translation parks the earlier rows off the **top**, the same test fires above the viewport: the moment one cleared the top edge by a full row, the pass aborted before reaching the focused row, blanking it and everything below it.

Reproduced directly — the list translated so row 1 spans `-449..-8`, with the focused row sitting at y=553, well on screen:

```
listY -900  row1 spans -399..42   => drawn {R0,R1,R2,R3}   row 1 straddles y=0, survives
listY -950  row1 spans -449..-8   => drawn {R0}            row 1 clears the top: pass aborts
```

Whether it triggers depends on the row pitch and how far the app scrolls, which is why only the bottom row's translation — the largest scroll — reached it on a panel with mixed row heights.

**Fix.** Stop on the real condition — the next row starts below the bottom edge:

```ts
return context.itemRect.y < this.sceneRect.y + this.sceneRect.height;
```

Rows above are laid out and drawn as usual (an app clips them with the `clippingRect` that is there for exactly this), and the early-out that keeps a long list from rendering rows nobody can see is unchanged.

## Testing

Six new tests in `test/extensions/scenegraph/RowList.test.js`, reusing the existing `createItemComponent` render harness to capture the y-origin each row is drawn at:

- `floatingFocus` with `numRows == rowCount` never scrolls — every row stays at its own fixed position through a full pass down the list
- `floatingFocus` with `numRows < rowCount` advances the window only once focus leaves it, and clamps at `rowCount - numRows`
- `fixedFocus` still pins the focused row at the list top
- a fresh `RowList`'s cached style matches its `fixedFocus` field default
- rows scrolled entirely above the viewport do not abort the pass
- the pass still stops at the first row below the viewport (a 40-row list renders only what fits) — a guard against over-correcting

Each new behavior was verified to fail on the parent commit for the right reason. The `fixedFocus` and below-viewport cases pass on both, pinning what already worked.

Full suite green: **2403 passed / 193 files**. `npm run lint` and `npm run prettier` clean.

Confirmed working on device across all four rows of the screen that surfaced it.

## Noted, not fixed here

Surfaced while investigating; neither caused the reported behavior:

- `ArrayGrid.updateRect` (`ArrayGrid.ts:881-896`) sizes `boundingRect().height` uniformly from `itemSize[1]`, ignoring `rowHeights` and per-row `rowSpacings`, so an app deriving layout from a `RowList`'s `boundingRect()` would drift.
- `clippingRect` is honored only by `Group.renderNode` and `ArrayGrid`; node types that override `renderNode` without delegating (`Rectangle`, `Poster`, `Label`, `Button`, `Video`, `Dialog`, …) ignore their own `clippingRect`, unlike a device where every Group-derived node inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)