### PR TITLE
fix(scenegraph): emit scrollingStatus on ArrayGrid key navigation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ like harmless simplifications.
 
 | Read this | Before changing |
 | --- | --- |
-| [`.claude/docs/scenegraph-invariants.md`](docs/scenegraph-invariants.md) | Node rendering / `renderNode`, visibility vs. measurement, `Field` observer dispatch & deferral, `getBoundingRect`, focus chain, `NodeFactory`/`addFields`, `Serializer.ts`, lazy fields/methods |
+| [`.claude/docs/scenegraph-invariants.md`](docs/scenegraph-invariants.md) | Node rendering / `renderNode`, visibility vs. measurement, `Field` observer dispatch & deferral, `getBoundingRect`, focus chain, `ArrayGrid` focus/`scrollingStatus` emission order, `NodeFactory`/`addFields`, `Serializer.ts`, lazy fields/methods |
 | [`.claude/docs/threading-and-rendezvous.md`](docs/threading-and-rendezvous.md) | `src/node/{host,task}.ts`, worker messaging, termination, `nodes/Task.ts` rendezvous, shared control array, debugger multi-thread halt |
 | [`.claude/docs/packaging-encryption.md`](docs/packaging-encryption.md) | `--pack`/`.bpk`, `packageEncryption.ts`, `src/{cli,api}/package.ts`, FileSystem source overlay |
 | [`.claude/docs/cli-terminal-rendering.md`](docs/cli-terminal-rendering.md) | `src/cli/display.ts`, terminal frame output (`-a`/`-u`/`-i`), `--log`, anything printing mid-run |
@@ -237,7 +237,8 @@ Key pieces:
 [`.claude/docs/scenegraph-invariants.md`](docs/scenegraph-invariants.md)** — it covers the `renderNode`
 contract and the visibility-vs-measurement rule, XML field redeclaration (system vs. XML-defined), the
 lazy-field/lazy-method memory design, the three stack-overflow hot paths (observer dispatch, re-entrant
-`getBoundingRect`, AA/array cycles), and focus-chain repair on attach.
+`getBoundingRect`, AA/array cycles), focus-chain repair on attach, and the `ArrayGrid`
+`scrollingStatus`-vs-focus-settle emission order.
 
 For the multi-threaded Task model (rendezvous transport, ownership, startup, cross-thread serialization
 rules, the silence-based timeout, and the all-thread debugger halt), read

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -283,6 +283,56 @@ capture the **native JS stack** mid-recursion (a temporary depth tripwire dumpin
    "simplify" to whole-pass tracking like nodes — that drops diamond-shaped shared data. Regression:
    "circular container references" in `test/extensions/scenegraph/NodeSerialization.test.js`.
 
+## `ArrayGrid.scrollingStatus` — a lazy pulse, ordered ahead of the focus settle
+
+Per `zoomrowlist.md` the field is "set to true whenever the list is scrolling the focus horizontally or
+vertically". It is documented only under `ZoomRowList` but exists on **every** `ArrayGrid`-derived node on
+a device, and apps alias it up from a plain `RowList`. On a device the scroll spans several frames: the
+field goes true, the focus fields pass through in-transit values, and it goes **false before the focus
+finally settles**. Our scroll is instant, so both edges land in one frame — which makes their **order
+relative to the focus fields the entire contract**, and the two rules below easy to get backwards. Both
+were regressed once each while this was being written.
+
+1. **The falling edge must precede the settled focus fields.** Apps depend on the interleave in both
+   directions: the falling edge is where they tear transient scroll state down (hiding a shared
+   overlay/preview container that belongs to the *outgoing* item), and the **settle** emission of the focus
+   fields (`itemFocused`/`rowItemFocused`/`currFocusRow`…) is what rebuilds it at the new position. Put the
+   pulse *after* the settle and the teardown runs last: the app is left with its overlay torn down and
+   nothing to restore it — the symptom is the focused item's poster **and** its preview player both
+   vanishing. The edges are therefore emitted **outside** the `Field.enterInternalUpdate()` bracket on
+   purpose: inside it, a reentrant falling edge would defer past the very settle it must precede.
+
+2. **A key that scrolls nothing must emit NOTHING.** Hence the pulse is *armed* by `handleKey`
+   (`armScrollPulse`) and only *emitted* by the settle paths (`emitScrollPulse`, idempotent per press),
+   rather than opened before the handler and closed after it. A boundary press on a non-wrapping list, or
+   any key while the grid is outside the focus chain, publishes **no** focus fields at all — so a pulse
+   there is a teardown with no settle behind it, the same failure as rule 1. (Reachable in practice:
+   `StandardDialog`/`Dialog`/`PanelSet` forward keys to children without checking focus.) It is not
+   `alwaysNotify`, so a device emits nothing on those paths; don't add `alwaysNotify` — the pulse always
+   changes value, so both edges notify without it, and adding it resurrects the spurious same-value
+   notification that `ZoomRowList`'s old redeclaration produced.
+
+`handleKey` arms **inside** its `try` and disarms in the `finally`: an exception from either edge's
+observers must not strand the field at `true`, which would silently suppress every later notification.
+
+Every path that publishes settled focus fields must call `emitScrollPulse()` first — `ArrayGrid`.
+`setFocusedItem`, `RowList.setFocusedItem` *and* `setRowItemFocused` (the horizontal handlers reach the
+latter directly, bypassing the former), `ZoomRowList.setFocusedItem` *and* its direct `rowItemFocused`
+write in `handleLeftRight`, and `TimeGrid.focusCell` *plus* the three paths that bypass it
+(entering/leaving the channel-info column, moving within it, panning the time window). Adding a new
+navigation path means adding the call. Programmatic focus writes (`jumpToItem`/`jumpToRowItem`/
+`animateToItem`) deliberately do **not** pulse: those are content-loading paths and don't scroll the focus
+on a device.
+
+Related trap in the same area: `ZoomRowList.handleUpDown` must **not** pre-assign `this.focusIndex` before
+calling `setFocusedItem`, which reads it as the *outgoing* row to emit `rowUnfocused` (and assigns it
+itself). Pre-assigning made that emission dead, so an app collapsing the outgoing row never got the
+callback.
+
+Regression: `test/extensions/scenegraph/ArrayGridFields.test.js` (asserts on a merged notification log, so
+values *and* order are pinned — including three no-pulse cases) and the channel-info/time-pan test in
+`test/extensions/scenegraph/TimeGrid.test.js`.
+
 ## Focus chain consistency (`focusedChild` ↔ live focus)
 
 `focusedChild` is a stored, observable field: `Node.setNodeFocus` walks the parent chain (`createPath`) at

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -108,7 +108,7 @@ export class ArrayGrid extends Group {
         { name: "animateToItem", type: "integer", value: "-1", alwaysNotify: true },
         // Read-only on device: true while the list/grid is scrolling the focus. Documented under
         // ZoomRowList but present on all ArrayGrid-derived nodes on a real Roku (apps alias it on
-        // plain RowList). Scrolling here is instant, so it stays false.
+        // plain RowList). Pulsed true→false around a key-driven focus move (see armScrollPulse).
         { name: "scrollingStatus", type: "boolean", value: "false" },
         { name: "currFocusRow", type: "float", value: "0.0" },
         { name: "currFocusColumn", type: "float", value: "0.0" },
@@ -139,6 +139,13 @@ export class ArrayGrid extends Group {
     protected focusLayoutDirty: boolean = false;
     protected wrap: boolean = false;
     protected lastPressHandled: string;
+    /**
+     * A navigation key is being handled and `scrollingStatus` may still need its rising edge. Armed
+     * by `armScrollPulse`, consumed by the first `emitScrollPulse` (see `armScrollPulse`).
+     */
+    protected scrollPulseArmed: boolean = false;
+    /** The rising edge has been emitted and the falling edge is still owed. */
+    protected scrollPulseActive: boolean = false;
     protected hasNinePatch: boolean;
     protected focusField: string;
     protected vertFocusAnimationStyleName: string = FocusStyle.FloatingFocus.toLowerCase();
@@ -299,14 +306,24 @@ export class ArrayGrid extends Group {
         if (newFocus === -1) {
             return;
         }
+        const nodeFocus = sgRoot.focused === this;
+        const inFocusChain = nodeFocus || this.isChildrenFocused();
+        if (inFocusChain) {
+            // Emit the scroll pulse BEFORE the settled focus fields go out: on a device
+            // scrollingStatus falls while the scroll finishes and the focus settles afterward, and
+            // apps depend on that order (the falling edge tears transient scroll state down, the
+            // focus settle rebuilds it at the new position). Deliberately outside the internal-update
+            // bracket below — these notifications must dispatch synchronously here, not defer past
+            // the settle they precede. Skipped when unfocused: that path publishes no focus fields at
+            // all, so a pulse would be a teardown with nothing to rebuild from (see armScrollPulse).
+            this.emitScrollPulse();
+        }
         // Focus fields are emitted by the grid's internal machinery, not by a direct BrightScript
         // assignment — on Roku their observers dispatch from the message loop, so a reentrant
         // notification defers (see Field.enterInternalUpdate).
         Field.enterInternalUpdate();
         try {
             const focusedIndex = this.getValueJS("itemFocused") as number;
-            const nodeFocus = sgRoot.focused === this;
-            const inFocusChain = nodeFocus || this.isChildrenFocused();
             this.updateItemFocus(this.focusIndex, false, nodeFocus);
             this.focusIndex = newFocus;
             this.focusLayoutDirty = true;
@@ -373,20 +390,89 @@ export class ArrayGrid extends Group {
         itemComp.setValue("focusPercent", new Float(focus ? 1 : 0), false);
     }
 
+    /**
+     * Arms a `scrollingStatus` pulse for a navigation key, without emitting anything yet.
+     *
+     * `scrollingStatus` reports that the list is scrolling the focus (see zoomrowlist.md — the field
+     * is documented under ZoomRowList but exists on every ArrayGrid-derived node on a device, and
+     * apps alias it from a plain RowList). It was declared here but never emitted, so an observer on
+     * it never fired.
+     *
+     * On a device the scroll spans several frames: the field goes true, the focus fields pass
+     * through in-transit values, and it goes false BEFORE the focus finally settles. Apps rely on
+     * that interleave — the falling edge is where they tear transient scroll state down (hiding a
+     * shared overlay/preview player that belongs to the outgoing item), and the *settle* emission of
+     * the focus fields is what rebuilds it at the new position. Our scroll is instant, so both edges
+     * land in one frame and the ORDER is the whole contract: the falling edge must precede the focus
+     * settle, or the teardown runs last and the app is left with its overlay torn down and nothing
+     * to restore it.
+     *
+     * Hence "armed" rather than "open": the pulse is only *emitted* by `emitScrollPulse`, called
+     * from the focus-settle paths. A key that scrolls nothing — a boundary press on a non-wrapping
+     * list, or any key while the grid is outside the focus chain (both of which publish no focus
+     * fields at all) — must emit NOTHING, exactly as a device does. Pulsing there would hand an app
+     * a teardown edge with no settle behind it to rebuild from, which is the same failure as
+     * emitting the edges in the wrong order.
+     */
+    protected armScrollPulse() {
+        this.scrollPulseArmed = true;
+    }
+
+    /**
+     * Emits the rising edge the first time a focus move is about to publish its settled fields, then
+     * immediately the falling edge — the pair a device produces around an instant scroll. Called by
+     * every settle path right before it emits the focus fields, and idempotent per key press: later
+     * calls within the same press (a move that touches several settle paths) do nothing.
+     */
+    protected emitScrollPulse() {
+        if (!this.scrollPulseArmed) {
+            return;
+        }
+        this.scrollPulseArmed = false;
+        this.scrollPulseActive = true;
+        super.setValue("scrollingStatus", BrsBoolean.True);
+        this.scrollPulseActive = false;
+        super.setValue("scrollingStatus", BrsBoolean.False);
+    }
+
+    /**
+     * Disarms at the end of a key press, and closes the pulse if an exception unwound between the
+     * two edges — the field must never be left stranded at `true`, which would suppress every later
+     * notification (it is not `alwaysNotify`, so a same-value write is silent).
+     */
+    protected endScrollPulse() {
+        this.scrollPulseArmed = false;
+        if (!this.scrollPulseActive) {
+            return;
+        }
+        this.scrollPulseActive = false;
+        super.setValue("scrollingStatus", BrsBoolean.False);
+    }
+
     handleKey(key: string, press: boolean): boolean {
         if (!press && this.lastPressHandled === key) {
             this.lastPressHandled = "";
             return true;
         }
         let handled = false;
-        if (key === "up" || key === "down") {
-            handled = press ? this.handleUpDown(key) : false;
-        } else if (key === "left" || key === "right") {
-            handled = press ? this.handleLeftRight(key) : false;
-        } else if (key === "rewind" || key === "fastforward") {
-            handled = press ? this.handlePageUpDown(key) : false;
-        } else if (key === "OK") {
+        if (key === "OK") {
             handled = this.handleOK(press);
+        } else if (press && ["up", "down", "left", "right", "rewind", "fastforward"].includes(key)) {
+            try {
+                // Arm inside the try so an exception from either edge's observers still unwinds
+                // through the finally below and cannot strand the field at true.
+                this.armScrollPulse();
+                if (key === "up" || key === "down") {
+                    handled = this.handleUpDown(key);
+                } else if (key === "left" || key === "right") {
+                    handled = this.handleLeftRight(key);
+                } else {
+                    handled = this.handlePageUpDown(key);
+                }
+            } finally {
+                // Disarm: a key that scrolled nothing emits no pulse at all (see armScrollPulse).
+                this.endScrollPulse();
+            }
         }
         this.lastPressHandled = handled && key !== "OK" ? key : "";
         return handled;

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -166,6 +166,14 @@ export class RowList extends ArrayGrid {
         // but do NOT notify observers; setNodeFocus re-emits on focus-gain. See ArrayGrid.setFocusedItem.
         const inFocusChain = sgRoot.focused === this || this.isChildrenFocused();
 
+        if (inFocusChain) {
+            // Emit the scroll pulse before ANY of the settled focus fields go out — itemUnfocused
+            // below included, so the order matches ArrayGrid.setFocusedItem. See armScrollPulse for
+            // why the pulse precedes the settle, and why it is skipped entirely when the list is
+            // outside the focus chain (that path notifies nothing).
+            this.emitScrollPulse();
+        }
+
         if (isChangingRow && inFocusChain) {
             // Engine-initiated emission (not a direct BrightScript assignment): on Roku its
             // observers dispatch from the message loop, so a reentrant notification defers
@@ -268,6 +276,13 @@ export class RowList extends ArrayGrid {
         // focused item synchronously via subBoundingRect, and the dirty flag makes that query refresh
         // layout first so it reports the settled focus-band position (see needsSubBoundingRectRefresh).
         this.focusLayoutDirty = true;
+        // Emit the scroll pulse BEFORE the settled focus fields go out — the falling edge precedes
+        // the settle on a device and apps rely on that order (see ArrayGrid.armScrollPulse). The
+        // horizontal handlers reach this method directly, without setFocusedItem, so the pulse has to
+        // be emitted here too; it is idempotent per key press, so the vertical path (which already
+        // pulsed) does not double-emit. Outside the internal-update bracket below on purpose: these
+        // notifications must dispatch synchronously rather than defer past the settle.
+        this.emitScrollPulse();
         // Engine-initiated emissions: reentrant observers defer (see Field.enterInternalUpdate).
         Field.enterInternalUpdate();
         try {

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -405,6 +405,9 @@ export class TimeGrid extends ArrayGrid {
             // Focus is now on a real program; no longer a placeholder awaiting content.
             this.initialFocusPending = false;
         }
+        // Emit the scroll pulse before the settled focus fields go out (see
+        // ArrayGrid.armScrollPulse): the falling edge precedes the settle on a device.
+        this.emitScrollPulse();
         const oldChannel = this.channelIndex;
         const oldProgram = this.programIndexByChannel[oldChannel] ?? 0;
         if (oldProgram !== newProgram || oldChannel !== newChannel) {
@@ -514,6 +517,9 @@ export class TimeGrid extends ArrayGrid {
             if (next === this.channelIndex) {
                 return false;
             }
+            // Moving within the channel-info column publishes its focus fields directly, without
+            // focusCell, so the pulse is emitted here too (see ArrayGrid.armScrollPulse).
+            this.emitScrollPulse();
             super.setValue("channelInfoUnfocused", new Int32(this.channelIndex));
             this.channelIndex = next;
             this.focusIndex = next;
@@ -592,12 +598,18 @@ export class TimeGrid extends ArrayGrid {
 
     protected enterChannelInfo() {
         this.inChannelInfoColumn = true;
+        // Crossing into the channel-info column is a horizontal focus move that bypasses focusCell
+        // (see ArrayGrid.armScrollPulse for why the pulse precedes the settle).
+        this.emitScrollPulse();
         super.setValue("channelInfoFocused", new Int32(this.channelIndex));
         this.isDirty = true;
     }
 
     protected exitChannelInfo() {
         this.inChannelInfoColumn = false;
+        // Leaving the channel-info column publishes the grid's focus fields directly, without
+        // focusCell (see ArrayGrid.armScrollPulse).
+        this.emitScrollPulse();
         super.setValue("channelInfoUnfocused", new Int32(this.channelIndex));
         const prog = this.programIndexByChannel[this.channelIndex] ?? 0;
         super.setValue("programFocusedDetails", brsValueOf({ focusChannelIndex: this.channelIndex, focusIndex: prog }));
@@ -612,6 +624,9 @@ export class TimeGrid extends ArrayGrid {
         this.viewStartTime += duration / 2;
         this.clampViewStart();
         if (this.viewStartTime !== before) {
+            // Panning the time window is a horizontal scroll that publishes no focus fields via
+            // focusCell (see ArrayGrid.armScrollPulse).
+            this.emitScrollPulse();
             super.setValue("leftEdgeTargetTime", new Int32(Math.floor(this.viewStartTime)));
             this.isDirty = true;
             return true;

--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -72,7 +72,6 @@ export class ZoomRowList extends ArrayGrid {
         { name: "rowUnfocused", type: "integer", value: "-1", alwaysNotify: true },
         { name: "rowItemSelected", type: "intarray", value: "[]", alwaysNotify: true },
         { name: "rowItemFocused", type: "intarray", value: "[]", alwaysNotify: true },
-        { name: "scrollingStatus", type: "boolean", value: "false", alwaysNotify: true },
         { name: "rowsRendered", type: "intarray", value: "[]", alwaysNotify: true },
         { name: "rowItemsRendered", type: "intarray", value: "[]", alwaysNotify: true },
         { name: "currFocusRow", type: "float", value: "-1.0", alwaysNotify: true },
@@ -200,6 +199,9 @@ export class ZoomRowList extends ArrayGrid {
         } else {
             colIndex = 0;
         }
+        // Emit the scroll pulse BEFORE the settled focus fields go out — the falling edge precedes
+        // the settle on a device, and apps rely on that order (see ArrayGrid.armScrollPulse).
+        this.emitScrollPulse();
         const previousRow = this.focusIndex;
         if (previousRow !== rowIndex) {
             super.setValue("rowUnfocused", new Int32(previousRow));
@@ -248,14 +250,13 @@ export class ZoomRowList extends ArrayGrid {
         // single-row grid moves focus to a sibling above/below (e.g. a ButtonBar). RowList guards the
         // same way.
         if (next >= 0 && next < this.content.length && next !== this.focusIndex) {
-            super.setValue("scrollingStatus", BrsBoolean.True);
-            this.focusIndex = next;
             this.rowFocus[next] ??= 0;
+            // Do NOT assign this.focusIndex here: setFocusedItem reads it as the OUTGOING row to emit
+            // rowUnfocused (and assigns it itself). Setting it first made that emission dead, so an
+            // app collapsing the outgoing row off rowUnfocused never got the callback.
             this.setFocusedItem(next, this.rowFocus[next]);
-            super.setValue("currFocusRow", new Float(next));
             handled = true;
         }
-        super.setValue("scrollingStatus", BrsBoolean.False);
         return handled;
     }
 
@@ -281,9 +282,10 @@ export class ZoomRowList extends ArrayGrid {
         }
         if (nextCol !== this.rowFocus[currentRow]) {
             this.rowFocus[currentRow] = nextCol;
+            // This path emits the settle directly (it does not go through setFocusedItem), so the
+            // pulse is emitted here — see ArrayGrid.armScrollPulse for why the order matters.
+            this.emitScrollPulse();
             super.setValue("rowItemFocused", new RoArray([new Int32(currentRow), new Int32(nextCol)]));
-            super.setValue("scrollingStatus", BrsBoolean.True);
-            super.setValue("scrollingStatus", BrsBoolean.False);
             return true;
         }
         return false;

--- a/test/extensions/scenegraph/ArrayGridFields.test.js
+++ b/test/extensions/scenegraph/ArrayGridFields.test.js
@@ -3,8 +3,23 @@ const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { RowList, ZoomRowList, MarkupGrid } = scenegraph;
-const { BrsDevice, BrsString } = core;
+const { RowList, ZoomRowList, MarkupGrid, SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Int32, RoMessagePort } = core;
+
+/** Builds a root → rows → items ContentNode tree; `rows` is an array of arrays of item titles. */
+function buildContent(rows) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (const items of rows) {
+        const rowNode = SGNodeFactory.createNode("ContentNode");
+        for (const title of items) {
+            const itemNode = SGNodeFactory.createNode("ContentNode");
+            itemNode.setValue("title", new BrsString(title));
+            rowNode.appendChildToParent(itemNode);
+        }
+        root.appendChildToParent(rowNode);
+    }
+    return root;
+}
 
 describe("ArrayGrid scrollingStatus field", () => {
     beforeAll(() => {
@@ -22,6 +37,198 @@ describe("ArrayGrid scrollingStatus field", () => {
             expect(node.hasNodeField("scrollingstatus")).toBe(true);
             expect(node.getValueJS("scrollingStatus")).toBe(false);
         }
+    });
+});
+
+/**
+ * `scrollingStatus` must PULSE true → false around a key-driven focus move. Per the reference it is
+ * "set to true whenever the list is scrolling the focus horizontally or vertically"; our scroll is
+ * instant, so both edges land in the same frame — which makes their ORDER relative to the focus
+ * fields the whole contract.
+ *
+ * On a device the scroll spans several frames: the field goes true, the focus fields pass through
+ * in-transit values, and it goes false BEFORE the focus finally settles. Apps depend on that
+ * interleave in both directions — the falling edge is where they tear transient scroll state down
+ * (hiding a shared overlay/preview container that belongs to the outgoing item) and the *settle*
+ * emission of the focus fields is what rebuilds it at the new position. So the falling edge must be
+ * emitted BEFORE the settled focus fields; emitting it afterwards leaves such an app with its
+ * overlay torn down and nothing left to restore it.
+ *
+ * By the same reasoning the pulse must NOT be emitted when nothing scrolls — a boundary press on a
+ * non-wrapping list, or any key while the list is outside the focus chain. Those paths publish no
+ * focus fields at all, so a pulse there is a teardown with no settle behind it to rebuild from, and
+ * the field is not alwaysNotify, so a device emits nothing.
+ */
+describe("ArrayGrid scrollingStatus pulses on key navigation", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+    /**
+     * Observes `fields` on `node` through one shared port and returns the merged notification log as
+     * `"field=value"` entries, so both the values AND their relative order are pinned.
+     */
+    function observe(node, fields) {
+        const log = [];
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            const name = event.fieldName ? event.fieldName.getValue() : "";
+            const value = event.fieldValue?.getValue?.();
+            log.push(`${name}=${Array.isArray(value) ? "[...]" : value}`);
+            originalPush(event);
+        };
+        for (const field of fields) {
+            node.addObserver(fakeInterpreter, "unscoped", new BrsString(field), port);
+        }
+        return log;
+    }
+
+    /** A list of `rows`, focused by default — focus fields only notify while the list is focused. */
+    function makeList(type, rows, focused = true) {
+        const list = SGNodeFactory.createNode(type);
+        list.setValue("content", buildContent(rows));
+        if (focused) {
+            list.setNodeFocus(true);
+        }
+        return list;
+    }
+
+    test("vertical navigation closes the pulse BEFORE the settled focus fields", () => {
+        const list = makeList("RowList", [["A", "B"], ["C", "D"], ["E"]]);
+        const log = observe(list, [
+            "scrollingStatus",
+            "itemUnfocused",
+            "itemFocused",
+            "currFocusRow",
+            "rowItemFocused",
+        ]);
+
+        expect(list.handleKey("down", true)).toBe(true);
+
+        // Both edges come first, then EVERY settled focus field — itemUnfocused included, so the
+        // ordering matches ArrayGrid.setFocusedItem. An app that tears its transient scroll state
+        // down on the falling edge still gets the focus notifications afterwards to rebuild from.
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.indexOf("itemUnfocused=0")).toBeGreaterThan(1);
+        expect(log.indexOf("currFocusRow=1")).toBeGreaterThan(1);
+        expect(log.lastIndexOf("rowItemFocused=[...]")).toBeGreaterThan(log.indexOf("currFocusRow=1"));
+        // Exactly one pulse per key press (no duplicate same-value notifications).
+        expect(log.filter((e) => e === "scrollingStatus=true").length).toBe(1);
+        expect(log.filter((e) => e === "scrollingStatus=false").length).toBe(1);
+        // And the field settles back to false.
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+    });
+
+    test("horizontal navigation also closes the pulse before the settle", () => {
+        const list = makeList("RowList", [["A", "B", "C"]]);
+        const log = observe(list, ["scrollingStatus", "rowItemFocused"]);
+
+        expect(list.handleKey("right", true)).toBe(true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log).toContain("rowItemFocused=[...]");
+        expect(log.lastIndexOf("rowItemFocused=[...]")).toBeGreaterThan(1);
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+    });
+
+    test("a navigation key that scrolls nothing emits no pulse at all", () => {
+        // A single-row list has nowhere to go vertically, so the key stays unhandled and bubbles, and
+        // nothing scrolled: emitting a pulse here would hand an app a teardown edge with no focus
+        // settle behind it — the same failure as emitting the edges in the wrong order.
+        const list = makeList("RowList", [["A", "B"]]);
+        const log = observe(list, ["scrollingStatus"]);
+
+        expect(list.handleKey("up", true)).toBe(false);
+        expect(log).toEqual([]);
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+    });
+
+    test("a boundary press at the end of a row emits no pulse", () => {
+        const list = makeList("RowList", [["A", "B"]]);
+        expect(list.handleKey("right", true)).toBe(true); // to the last column
+        const log = observe(list, ["scrollingStatus", "rowItemFocused"]);
+
+        expect(list.handleKey("right", true)).toBe(false); // nowhere left to go
+        expect(log).toEqual([]);
+    });
+
+    test("no pulse while the list is outside the focus chain (it notifies no focus fields there)", () => {
+        // Reachable in practice: dialog/panel container nodes forward keys to children without
+        // checking focus. An unfocused list records the cursor silently, so a pulse would be an
+        // unaccompanied teardown.
+        const list = makeList(
+            "RowList",
+            [
+                ["A", "B"],
+                ["C", "D"],
+            ],
+            false
+        );
+        const log = observe(list, ["scrollingStatus", "itemFocused", "rowItemFocused"]);
+
+        list.handleKey("down", true);
+        expect(log).toEqual([]);
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+    });
+
+    test("OK does not pulse (it selects, it does not scroll the focus)", () => {
+        const list = makeList("RowList", [["A", "B"]]);
+        const log = observe(list, ["scrollingStatus"]);
+
+        list.handleKey("OK", true);
+        list.handleKey("OK", false);
+        expect(log).toEqual([]);
+    });
+
+    test("ZoomRowList pulses once per edge, ahead of its settle, on both axes", () => {
+        // ZoomRowList used to emit the field manually and redeclare it with alwaysNotify, which
+        // produced a spurious same-value notification; both are gone and the base pulse covers it.
+        // Its vertical and horizontal handlers emit the settle by different routes (setFocusedItem
+        // vs. a direct rowItemFocused write), so both have to close the pulse first.
+        const list = makeList("ZoomRowList", [
+            ["A", "B"],
+            ["C", "D"],
+        ]);
+        list.setValue("itemComponentName", new BrsString("X"));
+        const log = observe(list, ["scrollingStatus", "rowUnfocused", "rowFocused", "rowItemFocused"]);
+
+        expect(list.handleKey("down", true)).toBe(true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.lastIndexOf("rowItemFocused=[...]")).toBeGreaterThan(1);
+        // handleUpDown must not pre-assign focusIndex: setFocusedItem reads it as the OUTGOING row,
+        // so doing so made rowUnfocused dead and an app collapsing that row never heard about it.
+        expect(log).toContain("rowUnfocused=0");
+        expect(log).toContain("rowFocused=1");
+
+        log.length = 0;
+        expect(list.handleKey("right", true)).toBe(true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.lastIndexOf("rowItemFocused=[...]")).toBeGreaterThan(1);
+    });
+
+    test("a grid node pulses too (the emission is central to ArrayGrid, not per node type)", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        // numColumns defaults to 1, which would leave `right` with nowhere to go.
+        grid.setValue("numColumns", new Int32(4));
+        grid.setValue("content", buildContent([["A", "B", "C", "D"]]).getNodeChildren()[0]);
+        grid.setNodeFocus(true);
+        const log = observe(grid, ["scrollingStatus", "itemFocused"]);
+
+        grid.handleKey("right", true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.lastIndexOf("itemFocused=1")).toBeGreaterThan(1);
     });
 });
 

--- a/test/extensions/scenegraph/TimeGrid.test.js
+++ b/test/extensions/scenegraph/TimeGrid.test.js
@@ -203,6 +203,59 @@ describe("TimeGrid node", () => {
         expect(grid.getValueJS("programFocused")).toBe(2);
     });
 
+    test("pulses scrollingStatus ahead of the settle on the channel-info and time-pan paths", () => {
+        // Those three paths (entering/leaving the channel-info column, moving inside it, and panning
+        // the time window) publish their focus fields directly instead of going through focusCell, so
+        // each has to emit the pulse itself — otherwise the falling edge lands AFTER the settle and an
+        // app that tears transient scroll state down on it is left with nothing to rebuild from.
+        // See ArrayGrid.armScrollPulse.
+        const grid = SGNodeFactory.createNode("TimeGrid");
+        const base = 1_000_000_000;
+        grid.setValue("contentStartTime", new Int32(base));
+        grid.setValue("numRows", new Int32(2));
+        grid.setValue("channelInfoFocusable", core.BrsBoolean.True);
+        grid.setValue(
+            "content",
+            buildContent([
+                { title: "Channel A", programs: [{ title: "A1", start: base, duration: 3600 }] },
+                { title: "Channel B", programs: [{ title: "B1", start: base, duration: 3600 }] },
+            ])
+        );
+        grid.setNodeFocus(true);
+
+        const log = [];
+        const port = new core.RoMessagePort();
+        port.pushMessage = (event) => {
+            log.push(`${event.fieldName.getValue()}=${event.fieldValue?.getValue?.()}`);
+        };
+        const fields = ["scrollingStatus", "channelInfoFocused", "channelInfoUnfocused", "channelFocused"];
+        for (const field of fields) {
+            grid.addObserver({ environment: {}, inSubEnv: () => {} }, "unscoped", new BrsString(field), port);
+        }
+
+        // Left → into the channel-info column.
+        grid.handleKey("left", true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.indexOf("channelInfoFocused=0")).toBeGreaterThan(1);
+
+        // Down → moves within the channel-info column.
+        log.length = 0;
+        grid.handleKey("down", true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.indexOf("channelInfoUnfocused=0")).toBeGreaterThan(1);
+        expect(log.indexOf("channelInfoFocused=1")).toBeGreaterThan(1);
+
+        // Right → back out of the channel-info column.
+        log.length = 0;
+        grid.handleKey("right", true);
+        expect(log[0]).toBe("scrollingStatus=true");
+        expect(log[1]).toBe("scrollingStatus=false");
+        expect(log.indexOf("channelInfoUnfocused=1")).toBeGreaterThan(1);
+        expect(grid.getValueJS("scrollingStatus")).toBe(false);
+    });
+
     test("renders without a draw surface", () => {
         const grid = SGNodeFactory.createNode("TimeGrid");
         const base = 1_000_000_000;


### PR DESCRIPTION
## Problem

`scrollingStatus` was declared as an `ArrayGrid` default field but **never emitted**. The only node that wrote it was `ZoomRowList`, which pulsed it manually in its own handlers. On every other list/grid the field was permanently `false`, so an observer on it never fired — including apps that alias it up from a plain `RowList` and hang their "the scroll settled" logic on it.

One consequence: an app pairing a list of posters with a single reusable preview `Video` node held *outside* the list never received the settle callback that stops and hides the player. After a vertical move, the previous item's paused frame stayed composited over the newly focused row instead of that item's poster — the app had only sent `control = "pause"`, and `Video.renderNode`'s `presenting` gate includes `"paused"`, so the video plane kept being punched.

## The ordering contract

Per [`zoomrowlist.md`](https://github.com/rokudev/dev-doc/blob/v2.0/docs/REFERENCES/scenegraph/list-and-grid-nodes/zoomrowlist.md) the field is "set to true whenever the list is scrolling the focus horizontally or vertically". It's documented only under `ZoomRowList` but exists on every `ArrayGrid`-derived node on hardware.

On a device the scroll spans several frames: the field goes true, the focus fields pass through in-transit values, and it goes false **before** the focus finally settles. Apps depend on that interleave in *both* directions — the falling edge is where they tear transient scroll state down (hiding a shared overlay that belongs to the outgoing item), and the *settle* emission of the focus fields is what rebuilds it at the new position.

Our scroll is instant, so both edges land in one frame and their **order relative to the focus fields is the whole contract**. Getting it backwards leaves such an app with its overlay torn down and nothing left to restore it.

## Approach

Emit centrally in `ArrayGrid` so every derived node behaves alike, via a **lazy pulse**:

- a navigation key **arms** the pulse (`armScrollPulse`) without emitting anything;
- the first focus-settle path to publish its fields **emits both edges** just ahead of them (`emitScrollPulse`, idempotent per press).

Arming rather than opening is the point: a boundary press on a non-wrapping list, or any key while the grid is outside the focus chain, publishes no focus fields at all — so it must emit **nothing**, as a device does. Pulsing there would hand an app a teardown edge with no settle behind it, the same failure as the wrong order. The edges dispatch **outside** the `Field.enterInternalUpdate()` bracket on purpose: they must not defer past the settle they precede.

Settle paths covered: `ArrayGrid.setFocusedItem`; `RowList.setFocusedItem` and `setRowItemFocused` (reached directly by the horizontal handlers); `ZoomRowList`'s `setFocusedItem` and its direct `rowItemFocused` write; `TimeGrid`'s `focusCell` plus the three paths that bypass it (entering/leaving the channel-info column, moving within it, panning the time window).

`handleKey` disarms in a `finally`, so an exception between the edges cannot strand the field at `true` — which would silently suppress every later notification, since it is not `alwaysNotify`.

Programmatic focus writes (`jumpToItem`/`jumpToRowItem`/`animateToItem`) deliberately do **not** pulse: those are content-loading paths, and on a device they don't scroll the focus.

## Also fixed along the way

- `RowList` emitted `itemUnfocused` before the pulse, disagreeing with `ArrayGrid.setFocusedItem`. The pulse now precedes every focus emission on both.
- `ZoomRowList.handleUpDown` assigned `this.focusIndex` before calling `setFocusedItem`, which reads it as the **outgoing** row — making the `rowUnfocused` emission dead on vertical navigation, so an app collapsing the outgoing row never got the callback. Removed that pre-assignment, plus a duplicate `currFocusRow` write `setFocusedItem` already performs.
- Dropped `ZoomRowList`'s redundant `scrollingStatus` declaration; its `alwaysNotify: true` produced a spurious same-value notification on a key that scrolled nothing.

## Tests

`test/extensions/scenegraph/ArrayGridFields.test.js` — 12 tests asserting on a **merged notification log**, so values *and* their relative order are pinned: both edges ahead of the settle on each axis, `itemUnfocused` included; exactly one pulse per press; `ZoomRowList` on both axes (its two settle routes) plus `rowUnfocused`/`rowFocused`; a grid node (the emission is central to `ArrayGrid`, not per node type); `OK` does not pulse; and three **no-pulse** cases — a key that scrolls nothing, a boundary press at the end of a row, and a list outside the focus chain.

`test/extensions/scenegraph/TimeGrid.test.js` — a test covering the three channel-info/time-pan paths that bypass `focusCell`.

Full suite: **194 files, 2416 tests passing**. `npm run lint` and `npm run prettier` clean.

End-to-end confirmation of the preview-player symptom is manual (the app involved doesn't run under `brs-cli`) and is being verified separately in the desktop host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)