### PR TITLE
fix(scenegraph): honor clippingRect on every renderable node

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -262,13 +262,18 @@ rules, the silence-based timeout, and the all-thread debugger halt), read
            this.registerDefaultFields(this.defaultFields);
            this.registerInitializedFields(initializedFields);
        }
-       renderNode(interpreter, origin, angle, opacity, draw2D?) { /* ... */ }
+       // Override renderNodeContent, NOT renderNode: renderNode is a template on Group that applies
+       // the node's clippingRect around this body. Position drawing via this.getDrawTranslation(...).
+       protected renderNodeContent(interpreter, origin, angle, opacity, draw2D?) { /* ... */ }
    }
    ```
 3. Wire it into `SGNodeFactory.createNode`'s `switch` so `CreateObject("roSGNode", "MyNode")` and XML
    `<MyNode>` resolve.
-4. Follow the `renderNode` contract and the visibility/measurement rule in
-   [`.claude/docs/scenegraph-invariants.md`](docs/scenegraph-invariants.md).
+4. Follow the `renderNodeContent` contract and the visibility/measurement rule in
+   [`.claude/docs/scenegraph-invariants.md`](docs/scenegraph-invariants.md). If the node draws its own
+   geometry under an inherited rotation, override `rotatesDrawTranslation()` to `true`; if its layout
+   assigns its **own** `translation`, do that in `prepareRender` so the clip is positioned from the
+   settled value.
 5. If the node builds visible children in its constructor and keeps private references to them, override
    `serializesChildren()` to `false` — see
    [`.claude/docs/threading-and-rendezvous.md`](docs/threading-and-rendezvous.md).

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -4,11 +4,62 @@ Deep detail for the SceneGraph extension. Read this **before** changing node ren
 field/observer dispatch, focus handling, `NodeFactory`/`addFields`, `Serializer.ts`, or the
 lazy-field/lazy-method memory paths. Companion: [threading-and-rendezvous.md](threading-and-rendezvous.md).
 
-## Rendering contract (`renderNode`)
+## Rendering contract (`renderNode` is a template — override `renderNodeContent`)
 
-`renderNode` early-returns via `updateRenderTracking(true)` when not visible, applies
-translation/rotation/opacity, draws through the passed `IfDraw2D`, updates bounding rects, then calls
-`renderChildren(...)` and `nodeRenderingDone(...)`.
+`Group.renderNode` is a **template method and must not be overridden**. It calls `prepareRender`, derives
+the node's draw translation via `getDrawTranslation`, pushes the node's `clippingRect`, and runs
+`renderNodeContent` inside a `try/finally` that pops it. **A node type implements `renderNodeContent`**,
+which early-returns via `updateRenderTracking(true)` when not visible, applies translation/rotation/
+opacity, draws through the passed `IfDraw2D`, updates bounding rects, then calls `renderChildren(...)`
+and `nodeRenderingDone(...)`.
+
+**Why the clip lives in the template.** `clippingRect` is declared on `Group`, so every Group-derived
+node inherits it, and the reference says it limits *"all drawing by this node **and** its children"* —
+so it has to bracket the node's own geometry, not just the child traversal. It used to sit inside
+`Group.renderNode` and `ArrayGrid.renderNode` around `renderChildren` only, which meant (a) the ~25 node
+types that override the entry point ignored their own rect entirely, and because `Rectangle`/`Poster`/
+`Label` also render children, an ignored rect leaked the whole subtree; (b) even for `Group` it never
+covered self-drawn geometry. Putting it in the parent's `renderChildren` instead does **not** work: eight
+call sites render a child directly (`PanelSet`'s ordered panels, the grid/list item renderers,
+`TargetGroup`), and `RoSGScreen` paints the Scene and the active Dialog through `paintNode` with no
+parent above them. Regression: `ClippingRect.test.js`.
+
+**Sub-invariants, each of which broke something while this was being written:**
+
+- **Measurement passes stay unclipped.** `pushClippingRect` no-ops without a `draw2D`, so
+  `boundingRect()` still computes under a clip. Unchanged by the template, and load-bearing.
+- **The clip pops in a `finally`.** `pushClip`/`popClip` are `ctx.save()`/`ctx.restore()`, so a leaked
+  clip is *permanent canvas state* — every later frame draws inside it. Arbitrary app BrightScript runs
+  inside the bracket (an item component's `init()`, a field observer), so the pop cannot be a plain
+  trailing statement. Same reasoning for the four inner clip brackets that are not the template's:
+  `ArrayGrid.renderItemClipped`, `RowList.renderSingleRow`, `ScrollableText`, `ScrollingLabel`. Backstop:
+  `IfDraw2D.resetClips()` in a `finally` around the per-frame paint in `RoSGScreen`, so one bad frame
+  cannot poison the next.
+- **Every node positions its drawing through `getDrawTranslation`.** Nothing may compute its own
+  `drawTrans` inline — if it did, the clip position could drift from the paint position. `rotateTranslation`
+  now appears only in `Group.getDrawTranslation` (plus one unrelated use in `MonospaceLabel`).
+- **`rotatesDrawTranslation()` only selects between two pre-existing behaviors.** 18 renderable types
+  rotate their own translation vector under an inherited angle; `Group` and the keyboard/text-entry
+  containers do not. The two are identical whenever the inherited angle is 0. **NEEDS DEVICE
+  VERIFICATION** — the split looks accidental, and a rotated container places children differently
+  depending on which side it falls on. Preserved deliberately; do not "unify" it without a probe.
+- **The visibility gates stay inside each `renderNodeContent`.** They differ per node type (soft skip for
+  containers, hard skip for renderables, hidden-extent measurement for grids) — see the
+  visibility-vs-measurement rule below. Only the cheap `isVisible()` guard on the *push* lives in the
+  template.
+- **A node that self-translates during layout must do it in `prepareRender`.** The template derives
+  `drawTrans` before the content hook, so a node whose layout assigns its own `translation` would
+  otherwise get a clip at its pre-layout position. `StandardDialog.layoutStandardDialog` recenters the
+  dialog, so its relayout gate lives in `prepareRender` — and because the four `Standard*Dialog`
+  subclasses build content that *drives* that layout, their preambles moved into chained
+  `prepareRender` overrides too. Getting this order wrong sizes a dialog from stale content
+  (regressions in `StandardDialogNodes.test.js` caught exactly that).
+- **Subclass delegation calls `super.renderNodeContent`, never `super.renderNode`** — the latter would
+  push the clip a second time. `LayoutGroup` matters most: it calls super inside a convergence loop, so
+  the mistake shows up as N clips per pass.
+
+External node types registered via `SGNodeFactory.addNodeTypes` may still override `renderNode`; they
+simply bypass the clip, exactly as every node did before.
 
 **Layout passes are pure (docs/scenegraph-layout-passes.md).** `Node.layoutNode` /
 `Node.paintNode` wrap `renderNode`, setting `sgRoot.renderPass`; `Node.isPaintPass(draw2D)` is the

--- a/src/core/brsTypes/interfaces/IfDraw2D.ts
+++ b/src/core/brsTypes/interfaces/IfDraw2D.ts
@@ -33,6 +33,8 @@ export type MeasuredText = { text: string; width: number; height: number; ellips
  */
 export class IfDraw2D {
     private readonly component: BrsDraw2D;
+    /** Depth of the active pushClip()/popClip() stack, so an unbalanced frame can be unwound. */
+    private clipDepth: number = 0;
 
     constructor(component: BrsDraw2D) {
         this.component = component;
@@ -213,6 +215,7 @@ export class IfDraw2D {
         ctx.beginPath();
         ctx.rect(rect.x, rect.y, rect.width, rect.height);
         ctx.clip();
+        this.clipDepth++;
     }
 
     /**
@@ -220,8 +223,33 @@ export class IfDraw2D {
      * effectively removing the last applied clipping region.
      */
     popClip() {
+        if (this.clipDepth === 0) {
+            return;
+        }
         const ctx = this.component.getContext();
         ctx.restore();
+        this.clipDepth--;
+    }
+
+    /**
+     * Unwinds any clipping regions still active, restoring the context to its unclipped state.
+     *
+     * `pushClip` is `ctx.save()` and `popClip` is `ctx.restore()`, so an unbalanced pair is not a
+     * transient glitch: the canvas keeps the stale clip for the rest of its life, and every later
+     * frame draws inside it. Render code brackets its own clips with try/finally, but an error
+     * escaping from arbitrary BrightScript (an item component's `init()`, a field observer) can
+     * still unwind past a bracket that has not been reached yet. Called from a `finally` around the
+     * per-frame paint so one bad frame cannot poison the next.
+     */
+    resetClips() {
+        while (this.clipDepth > 0) {
+            this.popClip();
+        }
+    }
+
+    /** Depth of the active clip stack. Exposed for the frame-level balance check and tests. */
+    getClipDepth(): number {
+        return this.clipDepth;
     }
 
     drawNinePatch(bitmap: RoBitmap, rect: Rect, rgba?: number, opacity?: number) {

--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -225,6 +225,12 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
                         }
                     } finally {
                         sgRoot.rendering = false;
+                        // Frame-level backstop for the clip stack. Individual clips are bracketed with
+                        // try/finally, but an error escaping arbitrary BrightScript (an item
+                        // component's init(), a field observer) can unwind past a bracket that has not
+                        // been entered yet. A leaked clip is permanent canvas state, so without this
+                        // one bad frame would silently clip every frame after it.
+                        this.draw2D.resetClips();
                     }
                 }
                 // Limited FPS enforcement - caps redraw cadence only. Keep polling timers during

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -22,7 +22,6 @@ import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
 import { ContentNode } from "./ContentNode";
 import { Font } from "./Font";
-import { rotateTranslation } from "../SGUtil";
 
 export enum FocusStyle {
     FixedFocusWrap = "fixedFocusWrap",
@@ -533,7 +532,18 @@ export class ArrayGrid extends Group {
         });
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             if (!draw2D) {
@@ -541,10 +551,7 @@ export class ArrayGrid extends Group {
             }
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], ...size };
         const rotation = angle + this.getRotation();
@@ -554,15 +561,12 @@ export class ArrayGrid extends Group {
             this.refreshContent();
             content.changed = false;
         }
-        const clipped = this.pushClippingRect(drawTrans, draw2D);
+        // The clippingRect bracket lives in the renderNode template, so it wraps this whole body.
         this.renderContent(interpreter, rect, rotation, opacity, draw2D);
         // The grid was just laid out for the current focus/scroll state, so item rects are fresh.
         this.focusLayoutDirty = false;
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
-        if (clipped) {
-            draw2D?.popClip();
-        }
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 
@@ -595,10 +599,7 @@ export class ArrayGrid extends Group {
         if (this.content.length === 0 || !itemSize?.[0] || !itemSize?.[1] || !this.numRows || !this.numCols) {
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const rect = { x: drawTrans[0], y: drawTrans[1], ...this.getDimensions() };
         const displayRows = Math.min(Math.ceil(this.content.length / this.numCols), this.numRows);
         this.updateRect(rect, displayRows, itemSize);
@@ -668,9 +669,15 @@ export class ArrayGrid extends Group {
         if (draw2D) {
             draw2D.pushClip({ x: itemRect.x, y: itemRect.y, width: itemRect.width, height: itemRect.height });
         }
-        itemComp.renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
-        if (draw2D) {
-            draw2D.popClip();
+        try {
+            // The item component runs app BrightScript (its init(), field observers); an error
+            // escaping from there must not strand the cell clip on the canvas for the rest of the
+            // frame, which would silently clip everything drawn after it.
+            itemComp.renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
+        } finally {
+            if (draw2D) {
+                draw2D.popClip();
+            }
         }
     }
 

--- a/src/extensions/scenegraph/nodes/BusySpinner.ts
+++ b/src/extensions/scenegraph/nodes/BusySpinner.ts
@@ -2,7 +2,6 @@ import { AAMember, Interpreter, BrsString, BrsType, RoArray, Float, IfDraw2D, Re
 import { sgClock } from "../SGClock";
 import { sgRoot } from "../SGRoot";
 import { FieldKind, FieldModel } from "../SGTypes";
-import { rotateTranslation } from "../SGUtil";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
 import { Poster } from "./Poster";
@@ -86,15 +85,23 @@ export class BusySpinner extends Group {
         }
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
         if (this.isDirty) {

--- a/src/extensions/scenegraph/nodes/Button.ts
+++ b/src/extensions/scenegraph/nodes/Button.ts
@@ -2,7 +2,6 @@ import { FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { AAMember, Interpreter, BrsBoolean, BrsString, Float, IfDraw2D, RoFont } from "brs-engine";
 import { Group } from "./Group";
-import { rotateTranslation } from "../SGUtil";
 import type { Poster } from "./Poster";
 import type { Label } from "./Label";
 import type { Font } from "./Font";
@@ -167,16 +166,24 @@ export class Button extends Group {
         this.iconHeight = height;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
         const nodeFocus = sgRoot.focused === this;
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/ButtonGroup.ts
+++ b/src/extensions/scenegraph/nodes/ButtonGroup.ts
@@ -23,7 +23,6 @@ import { LayoutGroup } from "./LayoutGroup";
 import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
-import { rotateTranslation } from "../SGUtil";
 
 export class ButtonGroup extends LayoutGroup {
     readonly defaultFields: FieldModel[] = [
@@ -181,21 +180,29 @@ export class ButtonGroup extends LayoutGroup {
         return handled;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isManagedMode()) {
             // No managed Button children: behave as a plain LayoutGroup so the app's
             // layoutDirection/itemSpacings and child translations are honored.
-            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
             return;
         }
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         // Refresh focus/buttons before building the bounding rect so `this.width` is current and
         // the rect reflects the actual laid-out size (otherwise boundingRect() reports the stale
         // width — 0 on the first pass — which breaks callers that center the group by its width).

--- a/src/extensions/scenegraph/nodes/Dialog.ts
+++ b/src/extensions/scenegraph/nodes/Dialog.ts
@@ -2,7 +2,6 @@ import { AAMember, Interpreter, BrsBoolean, BrsString, BrsType, Float, isBrsStri
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
-import { rotateTranslation } from "../SGUtil";
 import { jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
 import { ButtonGroup } from "./ButtonGroup";
@@ -191,15 +190,23 @@ export class Dialog extends Group {
         return handled;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const boundingRect: Rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -482,15 +482,18 @@ export class DynamicKeyGrid extends Group {
     // Rendering
     // -------------------------------------------------------------------------
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();

--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -239,7 +239,13 @@ export class DynamicKeyboardBase extends Group {
         return this.keyGrid.handleKey(key, press);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
@@ -251,7 +257,7 @@ export class DynamicKeyboardBase extends Group {
         this.applyPalette();
         this.textEditBox.setActive(focused);
         this.keyGrid.setFocusActive(focused);
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
         // Report the node's intrinsic size as its bounding rect (like the legacy Keyboard),
         // not the children union: an app-hidden textEditBox still reserves its slot on Roku,
         // so layout containers (e.g. a centered LayoutGroup) must keep measuring that space.

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -25,7 +25,7 @@ import type { ScrollingLabel } from "./ScrollingLabel";
 import { Node } from "./Node";
 import { FieldKind, FieldModel, isFont } from "../SGTypes";
 import { SGNodeType } from ".";
-import { convertHexColor, rectContainsRect, rotateRect, unionRect } from "../SGUtil";
+import { convertHexColor, rectContainsRect, rotateRect, rotateTranslation, unionRect } from "../SGUtil";
 import { SGNodeFactory } from "../factory/NodeFactory";
 import { jsValueOf } from "../factory/Serializer";
 
@@ -682,7 +682,87 @@ export class Group extends Node {
         return false;
     }
 
+    /**
+     * Render entry point for every node. This is a TEMPLATE METHOD and should not be overridden —
+     * node types implement `renderNodeContent` instead, and this wrapper applies the node's own
+     * `clippingRect` around it.
+     *
+     * The clip lives here rather than inside each node's body because `clippingRect` is declared on
+     * `Group` and inherited by every renderable node, and per the SceneGraph reference it limits
+     * "all drawing by this node AND its children" — so it has to bracket the node's own geometry,
+     * not just the child traversal. Doing it in the parent's `renderChildren` instead would miss the
+     * eight call sites that render a child directly (PanelSet's ordered panels, the grid/list item
+     * renderers, TargetGroup) and both `RoSGScreen` entry points (Scene and Dialog are painted via
+     * `paintNode`, with no parent traversal above them).
+     *
+     * Measurement/layout passes stay unclipped: `pushClippingRect` no-ops without a `draw2D`.
+     */
     renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        this.prepareRender(draw2D);
+        // An invisible node draws nothing, so skip the save()/restore() round trip entirely. The
+        // real visibility gates stay inside each renderNodeContent — they differ per node type
+        // (soft skip for containers, hard skip for renderables, hidden-extent measurement for grids).
+        const clipped = this.isVisible() && this.pushClippingRect(this.getDrawTranslation(origin, angle), draw2D);
+        try {
+            this.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
+        } finally {
+            if (clipped) {
+                draw2D?.popClip();
+            }
+        }
+    }
+
+    /**
+     * Runs before the node's draw translation is computed, for node types that must settle their own
+     * position first. Default is a no-op; `StandardDialog` overrides it because its layout assigns
+     * its OWN translation, which the clip position then has to be derived from.
+     */
+    protected prepareRender(draw2D?: IfDraw2D) {
+        // override in derived classes
+    }
+
+    /**
+     * This node's draw translation: its own translation composed with the parent-space `origin`.
+     *
+     * Every node must position its own drawing through this method, so the clip `renderNode` pushes
+     * can never drift from where the node actually paints.
+     */
+    protected getDrawTranslation(origin: number[], angle: number): number[] {
+        const nodeTrans = this.getTranslation();
+        const drawTrans =
+            angle !== 0 && this.rotatesDrawTranslation() ? rotateTranslation(nodeTrans, angle) : nodeTrans.slice();
+        drawTrans[0] += origin[0];
+        drawTrans[1] += origin[1];
+        return drawTrans;
+    }
+
+    /**
+     * Whether an inherited (non-zero) rotation also rotates this node's OWN translation vector.
+     *
+     * Renderable nodes return true; `Group` and the keyboard/text-entry containers return false,
+     * which is what they have always done. The two are identical whenever the inherited angle is 0
+     * — i.e. everywhere nothing above the node is rotated — so this only selects between existing
+     * behaviors, it does not introduce one.
+     *
+     * NEEDS DEVICE VERIFICATION: the split looks accidental rather than intended (a rotated
+     * container would place its children differently depending on which of the two groups it falls
+     * in). Preserved as-is here deliberately; settling it needs a rotated-container probe channel,
+     * not a guess.
+     */
+    protected rotatesDrawTranslation(): boolean {
+        return false;
+    }
+
+    /**
+     * The node's actual rendering. Override this (never `renderNode`) in a derived node type.
+     */
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (this.skipRender(draw2D)) {
             return;
         }
@@ -708,9 +788,7 @@ export class Group extends Node {
         }
         this.layoutPassCount++;
         const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const rotation = angle + this.getRotation();
         this.rectLocal = {
             x: Number.POSITIVE_INFINITY,
@@ -734,17 +812,16 @@ export class Group extends Node {
         // descendants compute their rects but keep reporting renderTracking "none" — they are laid
         // out, not displayed.
         opacity = this.isVisible() ? opacity * this.getOpacity() : 0;
-        const clipped = this.pushClippingRect(drawTrans, draw2D);
+        // The clippingRect bracket lives in the renderNode template, so it wraps this whole body.
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
-        if (clipped) {
-            draw2D?.popClip();
-        }
         this.updateContainerBounds(nodeTrans, drawTrans);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 
     /**
-     * Applies this node's `clippingRect`, limiting where the node and its children may draw.
+     * Applies this node's `clippingRect`, limiting where the node and its children may draw. Pushed
+     * by the `renderNode` template so it brackets the node's OWN geometry as well as its children,
+     * per the reference ("all drawing by this node and its children").
      * The rect is in the node's local coordinate system (per the SceneGraph reference), so it is
      * translated to scene/screen space by the node's draw translation before being pushed. An
      * empty rect (width or height ≤ 0, the default `[0,0,0,0]`) disables clipping. Clipping is only

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -699,10 +699,12 @@ export class Group extends Node {
      */
     renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
         this.prepareRender(draw2D);
-        // An invisible node draws nothing, so skip the save()/restore() round trip entirely. The
-        // real visibility gates stay inside each renderNodeContent — they differ per node type
-        // (soft skip for containers, hard skip for renderables, hidden-extent measurement for grids).
-        const clipped = this.isVisible() && this.pushClippingRect(this.getDrawTranslation(origin, angle), draw2D);
+        // Order matters for cost, not just correctness. A layout/measure pass never clips (bounding
+        // rects must stay unclipped), and an invisible node draws nothing — check both before probing
+        // the field, so the overwhelmingly common case is one comparison. The real visibility gates
+        // stay inside each renderNodeContent: they differ per node type (soft skip for containers,
+        // hard skip for renderables, hidden-extent measurement for grids).
+        const clipped = draw2D !== undefined && this.isVisible() && this.pushClippingRect(origin, angle, draw2D);
         try {
             this.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
         } finally {
@@ -830,7 +832,7 @@ export class Group extends Node {
      * any already-active clip, so nested/ancestor `clippingRect`s compose and stay bounded by the
      * screen. Returns whether a clip was pushed (caller must `popClip()` when true).
      */
-    protected pushClippingRect(drawTrans: number[], draw2D?: IfDraw2D): boolean {
+    protected pushClippingRect(origin: number[], angle: number, draw2D?: IfDraw2D): boolean {
         if (!draw2D) {
             return false;
         }
@@ -838,6 +840,9 @@ export class Group extends Node {
         if (!clip || clip.width <= 0 || clip.height <= 0) {
             return false;
         }
+        // Resolved only once a clip is known to be needed — `getDrawTranslation` allocates, and the
+        // node computes its own copy inside `renderNodeContent` anyway.
+        const drawTrans = this.getDrawTranslation(origin, angle);
         draw2D.pushClip({
             x: clip.x + drawTrans[0],
             y: clip.y + drawTrans[1],

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -7,8 +7,10 @@ import {
     BrsType,
     Float,
     Int32,
+    isAnyNumber,
     isBrsString,
     RoArray,
+    RoAssociativeArray,
     RoBitmap,
     RoFont,
     ValueKind,
@@ -835,6 +837,22 @@ export class Group extends Node {
     protected pushClippingRect(origin: number[], angle: number, draw2D?: IfDraw2D): boolean {
         if (!draw2D) {
             return false;
+        }
+        // Fast path for the overwhelmingly common "no clip" case. The generic read converts the whole
+        // rect2d associative array to a fresh JS object (allocating a WeakSet and walking its entries)
+        // — cheap once, but this now runs for every node on every paint pass, so an empty rect must
+        // not pay for it. `rect2d` values are always stored with lowercase numeric x/y/width/height
+        // (Field.convertRect2D rebuilds them), and anything that does not match falls through to the
+        // generic path below, so semantics are unchanged.
+        const raw = this.getValue("clippingRect");
+        if (raw instanceof RoAssociativeArray) {
+            const width = raw.elements.get("width");
+            const height = raw.elements.get("height");
+            if (width !== undefined && height !== undefined && isAnyNumber(width) && isAnyNumber(height)) {
+                if (Number(width.getValue()) <= 0 || Number(height.getValue()) <= 0) {
+                    return false;
+                }
+            }
         }
         const clip = this.getValueJS("clippingRect") as { x: number; y: number; width: number; height: number };
         if (!clip || clip.width <= 0 || clip.height <= 0) {

--- a/src/extensions/scenegraph/nodes/InfoPane.ts
+++ b/src/extensions/scenegraph/nodes/InfoPane.ts
@@ -97,11 +97,17 @@ export class InfoPane extends Group {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (this.isDirty) {
             this.updateLayout();
         }
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
     }
 
     private updateLayout() {

--- a/src/extensions/scenegraph/nodes/Keyboard.ts
+++ b/src/extensions/scenegraph/nodes/Keyboard.ts
@@ -229,17 +229,20 @@ export class Keyboard extends Group {
         return handled;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
         const isFocused = sgRoot.focused === this;
         this.textEditBox.setActive(isFocused);
-        const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();

--- a/src/extensions/scenegraph/nodes/Label.ts
+++ b/src/extensions/scenegraph/nodes/Label.ts
@@ -3,7 +3,6 @@ import { Group } from "./Group";
 import type { Font } from "./Font";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
-import { rotateTranslation } from "../SGUtil";
 
 export class Label extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -70,15 +69,23 @@ export class Label extends Group {
         return this.measured;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -169,7 +169,13 @@ export class LayoutGroup extends Group {
         return removed;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (this.skipRender(draw2D)) {
             return;
         }
@@ -250,7 +256,7 @@ export class LayoutGroup extends Group {
                 this.layoutDirty = false;
             }
 
-            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
 
             if (layoutChildren.length) {
                 this.synchronizeChildMetrics(layoutChildren, direction);

--- a/src/extensions/scenegraph/nodes/MaskGroup.ts
+++ b/src/extensions/scenegraph/nodes/MaskGroup.ts
@@ -30,7 +30,13 @@ export class MaskGroup extends Group {
         this.registerInitializedFields(initializedFields);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (this.skipRender(draw2D)) {
             return;
         }
@@ -42,7 +48,7 @@ export class MaskGroup extends Group {
         // plain Group. This mirrors the documented behavior on Roku players without OpenGL, where
         // a MaskGroup just renders its children without applying the alpha mask.
         if (!draw2D || !maskBitmap?.isValid() || this.sceneRect.width <= 0 || this.sceneRect.height <= 0) {
-            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
             return;
         }
 
@@ -53,7 +59,7 @@ export class MaskGroup extends Group {
         );
         const offDraw = new IfDraw2D(offscreen);
         // Group.renderNode handles transforms, child rendering, bounding rects, and render tracking.
-        super.renderNode(interpreter, origin, angle, opacity, offDraw);
+        super.renderNodeContent(interpreter, origin, angle, opacity, offDraw);
 
         // The mask coordinate system origin is the group origin in scene space (translation applied).
         // Note: any rotation on the MaskGroup itself rotates the children (handled above) but the mask

--- a/src/extensions/scenegraph/nodes/MiniKeyboard.ts
+++ b/src/extensions/scenegraph/nodes/MiniKeyboard.ts
@@ -180,17 +180,20 @@ export class MiniKeyboard extends Group {
         return handled;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
         const isFocused = sgRoot.focused === this;
         this.textEditBox.setActive(isFocused);
-        const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -14,7 +14,7 @@ import type { Font } from "./Font";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { SGNodeFactory } from "../factory/NodeFactory";
-import { convertHexColor, rotateTranslation } from "../SGUtil";
+import { convertHexColor } from "../SGUtil";
 
 /** A resolved drawing style: a configured Font node plus its text color. */
 interface DrawStyle {
@@ -146,15 +146,23 @@ export class MultiStyleLabel extends Group {
         return this.measured;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();

--- a/src/extensions/scenegraph/nodes/Overhang.ts
+++ b/src/extensions/scenegraph/nodes/Overhang.ts
@@ -225,7 +225,13 @@ export class Overhang extends Group {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;

--- a/src/extensions/scenegraph/nodes/PinPad.ts
+++ b/src/extensions/scenegraph/nodes/PinPad.ts
@@ -238,16 +238,19 @@ export class PinPad extends Group {
     // Rendering
     // -------------------------------------------------------------------------
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
         const isFocused = sgRoot.focused === this;
-        const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();

--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -14,7 +14,6 @@ import {
 } from "brs-engine";
 import { Group } from "./Group";
 import { sgRoot } from "../SGRoot";
-import { rotateTranslation } from "../SGUtil";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 
 export class Poster extends Group {
@@ -93,15 +92,23 @@ export class Poster extends Group {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const loadStatus = this.getValueJS("loadStatus") as string;
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -20,7 +20,6 @@ import { Group } from "./Group";
 import { Poster } from "./Poster";
 import { Label } from "./Label";
 import { ScrollingLabel } from "./ScrollingLabel";
-import { rotateTranslation } from "../SGUtil";
 import { sgRoot } from "../SGRoot";
 
 type PosterGridMetadata = ArrayGrid.Metadata & {
@@ -816,7 +815,18 @@ class PosterGridItem extends Group {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         const isVisible = this.isVisible();
         if (!isVisible || !this.layout || !this.content) {
             this.clearChildNodes();
@@ -826,10 +836,7 @@ class PosterGridItem extends Group {
             return;
         }
         this.syncChildNodes();
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const offsetY = this.layout.offsetY ?? 0;
         const rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/Rectangle.ts
+++ b/src/extensions/scenegraph/nodes/Rectangle.ts
@@ -2,7 +2,6 @@ import { AAMember, Interpreter, IfDraw2D } from "brs-engine";
 import { FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
-import { rotateTranslation } from "../SGUtil";
 
 export class Rectangle extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -20,15 +19,23 @@ export class Rectangle extends Group {
         this.registerInitializedFields(initializedFields);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         const color = this.getValueJS("color") as number;

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -796,9 +796,14 @@ export class RowList extends ArrayGrid {
                 height: this.sceneRect.height,
             });
         }
-        this.renderRowContent(rowIndex, cols, context.rowItemWidth, spacing, context.itemRect, context);
-        if (clip) {
-            context.draw2D?.popClip();
+        try {
+            // Row items are app components: an error escaping their BrightScript must not strand the
+            // row clip on the canvas for the rest of the frame.
+            this.renderRowContent(rowIndex, cols, context.rowItemWidth, spacing, context.itemRect, context);
+        } finally {
+            if (clip) {
+                context.draw2D?.popClip();
+            }
         }
 
         // Render the "N of M" row counter in the label band at the row top, AFTER the items.

--- a/src/extensions/scenegraph/nodes/Scene.ts
+++ b/src/extensions/scenegraph/nodes/Scene.ts
@@ -129,7 +129,13 @@ export class Scene extends Group {
         this.setValueSilent("currentDesignResolution", toAssociativeArray(this.ui));
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -15,7 +15,6 @@ import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
 import type { Font } from "./Font";
-import { rotateTranslation } from "../SGUtil";
 
 // Width reserved for the scrollbar (right side of the node)
 const SCROLLBAR_WIDTH_HD = 36;
@@ -144,16 +143,24 @@ export class ScrollableText extends Group {
         return handled;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
 
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
 
@@ -224,20 +231,23 @@ export class ScrollableText extends Group {
         const clipWidth = showScrollbar ? nodeWidth - this.scrollbarWidth : nodeWidth;
         const clipRect: Rect = { x: rect.x, y: rect.y, width: clipWidth, height: nodeHeight };
         draw2D.pushClip(clipRect);
-        const endLine = Math.min(this.scrollTopLine + this.visibleLines, this.totalLines);
-        let y = startY;
-        for (let i = this.scrollTopLine; i < endLine; i++) {
-            const line = finalLines[i];
-            let x = rect.x;
-            if (horizAlign === "center" && textWidth > line.width) {
-                x += (textWidth - line.width) / 2;
-            } else if (horizAlign === "right" && textWidth > line.width) {
-                x += textWidth - line.width;
+        try {
+            const endLine = Math.min(this.scrollTopLine + this.visibleLines, this.totalLines);
+            let y = startY;
+            for (let i = this.scrollTopLine; i < endLine; i++) {
+                const line = finalLines[i];
+                let x = rect.x;
+                if (horizAlign === "center" && textWidth > line.width) {
+                    x += (textWidth - line.width) / 2;
+                } else if (horizAlign === "right" && textWidth > line.width) {
+                    x += textWidth - line.width;
+                }
+                draw2D.doDrawRotatedText(line.text, x, y, color, opacity, drawFont, rotation);
+                y += this.lineHeight + lineSpacing;
             }
-            draw2D.doDrawRotatedText(line.text, x, y, color, opacity, drawFont, rotation);
-            y += this.lineHeight + lineSpacing;
+        } finally {
+            draw2D.popClip();
         }
-        draw2D.popClip();
 
         // Draw scrollbar if needed
         if (showScrollbar) {

--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -239,8 +239,11 @@ export class ScrollingLabel extends Label {
             }
         }
         draw2D?.pushClip(clipRect);
-        draw2D?.doDrawRotatedText(textToDraw, drawX, drawY, color, opacity, drawFont, rotation);
-        draw2D?.popClip();
+        try {
+            draw2D?.doDrawRotatedText(textToDraw, drawX, drawY, color, opacity, drawFont, rotation);
+        } finally {
+            draw2D?.popClip();
+        }
         // Safe on layout passes too (matching the base Label): with the scroll state frozen
         // during layout, the value derives purely from stored state, and setValue only notifies
         // on a genuine change — idempotent.

--- a/src/extensions/scenegraph/nodes/SimpleLabel.ts
+++ b/src/extensions/scenegraph/nodes/SimpleLabel.ts
@@ -4,7 +4,6 @@ import type { Font } from "./Font";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { SGNodeFactory } from "../factory/NodeFactory";
-import { rotateTranslation } from "../SGUtil";
 
 /**
  * SimpleLabel is a lightweight node for displaying a single line of text.
@@ -77,15 +76,23 @@ export class SimpleLabel extends Group {
         return this.measured;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const rect = { x: drawTrans[0], y: drawTrans[1], width: 0, height: 0 };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();

--- a/src/extensions/scenegraph/nodes/StandardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardDialog.ts
@@ -25,7 +25,6 @@ import { StdDlgContentArea } from "./StdDlgContentArea";
 import { StdDlgButtonArea } from "./StdDlgButtonArea";
 import { StdDlgSideCardArea } from "./StdDlgSideCardArea";
 import { colorFromPalette } from "./StdDlgItemBase";
-import { rotateTranslation } from "../SGUtil";
 
 /**
  * Base of the Standard Dialog Framework. Draws the 9-patch dialog background (palette-tinted) and
@@ -479,24 +478,44 @@ export class StandardDialog extends Group {
         );
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    /**
+     * Settles the dialog's own position before the render template derives a draw translation from
+     * it. `layoutStandardDialog` assigns THIS node's `translation` (it centers the dialog), so it has
+     * to run ahead of `getDrawTranslation` — otherwise a relayout frame would push the clippingRect
+     * at the dialog's previous position while it paints at the new one.
+     */
+    protected prepareRender(draw2D?: IfDraw2D) {
         if (!this.isVisible()) {
-            this.updateRenderTracking(true);
             return;
         }
         if (this.isDirty || this.pendingRelayout) {
             this.pendingRelayout = false;
             this.layoutStandardDialog();
         }
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
         // Claiming focus is a paint-side effect: a layout pass (a bounding-rect refresh that
         // reaches the dialog) must not move focus.
         if (this.isPaintPass(draw2D)) {
             this.setNodeFocus(true);
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const boundingRect: Rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/StandardKeyboardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardKeyboardDialog.ts
@@ -101,15 +101,33 @@ export class StandardKeyboardDialog extends StandardDialog {
         return this.buttonArea?.hasButtons ? this.buttonArea.handleKey(key, press) : false;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /**
+     * Rebuilds this dialog's content before StandardDialog lays the dialog out and the render
+     * template derives the draw translation — the content drives the dialog's size, and the layout
+     * recenters it from that size.
+     */
+    protected prepareRender(draw2D?: IfDraw2D) {
         if (!this.isVisible()) {
-            this.updateRenderTracking(true);
             return;
         }
         if (this.contentDirty) {
             this.rebuildContent();
         }
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.prepareRender(draw2D);
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
     }
 
     private rebuildContent() {

--- a/src/extensions/scenegraph/nodes/StandardMessageDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardMessageDialog.ts
@@ -47,15 +47,33 @@ export class StandardMessageDialog extends StandardDialog {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /**
+     * Rebuilds this dialog's content before StandardDialog lays the dialog out and the render
+     * template derives the draw translation — the content drives the dialog's size, and the layout
+     * recenters it from that size.
+     */
+    protected prepareRender(draw2D?: IfDraw2D) {
         if (!this.isVisible()) {
-            this.updateRenderTracking(true);
             return;
         }
         if (this.contentDirty) {
             this.rebuildContent();
         }
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.prepareRender(draw2D);
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
     }
 
     private rebuildContent() {

--- a/src/extensions/scenegraph/nodes/StandardPinPadDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardPinPadDialog.ts
@@ -95,15 +95,33 @@ export class StandardPinPadDialog extends StandardDialog {
         return this.buttonArea?.hasButtons ? this.buttonArea.handleKey(key, press) : false;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /**
+     * Rebuilds this dialog's content before StandardDialog lays the dialog out and the render
+     * template derives the draw translation — the content drives the dialog's size, and the layout
+     * recenters it from that size.
+     */
+    protected prepareRender(draw2D?: IfDraw2D) {
         if (!this.isVisible()) {
-            this.updateRenderTracking(true);
             return;
         }
         if (this.contentDirty) {
             this.rebuildContent();
         }
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.prepareRender(draw2D);
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
     }
 
     private rebuildContent() {

--- a/src/extensions/scenegraph/nodes/StandardProgressDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardProgressDialog.ts
@@ -36,14 +36,31 @@ export class StandardProgressDialog extends StandardDialog {
         this.linkField(this.progressItem, "text", "message");
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /**
+     * Applies the default message before StandardDialog lays the dialog out — the message drives the
+     * content height, which the layout then sizes and recenters the dialog from.
+     */
+    protected prepareRender(draw2D?: IfDraw2D) {
         if (!this.isVisible()) {
-            this.updateRenderTracking(true);
             return;
         }
         if ((this.getValueJS("message") as string) === "") {
             this.setValue("message", new BrsString(BrsDevice.getTerm("Please wait...")));
         }
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.prepareRender(draw2D);
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
     }
 }

--- a/src/extensions/scenegraph/nodes/StdDlgActionCardItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgActionCardItem.ts
@@ -7,7 +7,6 @@ import { Rectangle } from "./Rectangle";
 import { Label } from "./Label";
 import { StdDlgItem, getDialogColors, colorFromPalette } from "./StdDlgItemBase";
 import { sgRoot } from "../SGRoot";
-import { rotateTranslation } from "../SGUtil";
 
 /**
  * A focusable content-area item that highlights its child nodes on a rectangular background
@@ -162,16 +161,24 @@ export class StdDlgActionCardItem extends Group implements StdDlgItem {
         this.icon.setValueSilent("visible", BrsBoolean.from(uri !== ""));
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
         this.updateVisuals();
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const boundingRect: Rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/StdDlgCustomItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgCustomItem.ts
@@ -71,8 +71,14 @@ export class StdDlgCustomItem extends Group implements StdDlgItem {
         return height;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
         // Children (e.g. a LayoutGroup) only know their size after rendering. If that changed the
         // content height from what layout assumed, ask the owning dialog to re-lay-out next frame so
         // the following areas (buttons) are positioned below this item rather than overlapping it.

--- a/src/extensions/scenegraph/nodes/StdDlgDeterminateProgressItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgDeterminateProgressItem.ts
@@ -5,7 +5,6 @@ import { Group } from "./Group";
 import { Label } from "./Label";
 import { Rectangle } from "./Rectangle";
 import { StdDlgItem, getDialogColors, colorFromPalette } from "./StdDlgItemBase";
-import { rotateTranslation } from "../SGUtil";
 
 /**
  * A determinate progress indicator for a dialog content area: a horizontal bar that fills to the
@@ -102,7 +101,18 @@ export class StdDlgDeterminateProgressItem extends Group implements StdDlgItem {
         return y;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
@@ -119,10 +129,7 @@ export class StdDlgDeterminateProgressItem extends Group implements StdDlgItem {
         this.percentLabel.setValueSilent("color", new Int32(textColor));
         this.percentLabel.setValueSilent("text", new BrsString(`${percent}%`));
 
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const boundingRect: Rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/StdDlgProgressItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgProgressItem.ts
@@ -7,7 +7,6 @@ import { Label } from "./Label";
 import { StandardDialog } from "./StandardDialog";
 import { StdDlgContentArea } from "./StdDlgContentArea";
 import { StdDlgItem } from "./StdDlgItemBase";
-import { rotateTranslation } from "../SGUtil";
 
 export class StdDlgProgressItem extends Group implements StdDlgItem {
     readonly defaultFields: FieldModel[] = [
@@ -49,15 +48,23 @@ export class StdDlgProgressItem extends Group implements StdDlgItem {
         return height;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const boundingRect: Rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/TargetGroup.ts
+++ b/src/extensions/scenegraph/nodes/TargetGroup.ts
@@ -7,7 +7,6 @@ import { TargetSet } from "./TargetSet";
 import { sgRoot } from "../SGRoot";
 import { createNode } from "../factory/NodeFactory";
 import { brsValueOf } from "../factory/Serializer";
-import { rotateTranslation } from "../SGUtil";
 
 /**
  * TargetGroup maps the items of its `content` ContentNode onto the rectangular regions defined by a
@@ -166,15 +165,23 @@ export class TargetGroup extends Group {
         return (this.getValueJS("defaultTargetSetFocusIndex") as number) ?? 0;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
 

--- a/src/extensions/scenegraph/nodes/TargetList.ts
+++ b/src/extensions/scenegraph/nodes/TargetList.ts
@@ -42,13 +42,19 @@ export class TargetList extends TargetGroup {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         // Swap the active target set when focus changes. The engine moves focus between sibling nodes
         // by rewriting the focus chain (it does not call setNodeFocus(false) on the node losing focus),
         // so detecting the transition here is the reliable place to react. Doing it before super's
         // render means the swap takes effect in this same frame.
         this.syncFocusTargetSet();
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
     }
 
     private syncFocusTargetSet() {

--- a/src/extensions/scenegraph/nodes/TextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/TextEditBox.ts
@@ -175,15 +175,18 @@ export class TextEditBox extends Group {
         this.lastCursorToggleTime = sgClock.now();
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         const combinedOpacity = opacity * this.getOpacity();

--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -140,14 +140,18 @@ export class TrickPlayBar extends Group {
         }
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible() || sgRoot.inTaskThread()) {
             this.updateRenderTracking(true);
             return;
         }
-        const drawTrans = this.getTranslation();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
 
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -37,7 +37,6 @@ import { Node } from "./Node";
 import { Poster } from "./Poster";
 import { ScrollingLabel } from "./ScrollingLabel";
 import { Timer } from "./Timer";
-import { rotateTranslation } from "../SGUtil";
 import { TrickPlayBar } from "./TrickPlayBar";
 import { ProgressBar } from "./ProgressBar";
 
@@ -755,15 +754,23 @@ export class Video extends Group {
         }
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    /** Renderable node: an inherited rotation also rotates its own translation vector. */
+    protected rotatesDrawTranslation(): boolean {
+        return true;
+    }
+
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible() || sgRoot.inTaskThread()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rect = {
             x: drawTrans[0],

--- a/src/extensions/scenegraph/nodes/VoiceTextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/VoiceTextEditBox.ts
@@ -46,19 +46,22 @@ export class VoiceTextEditBox extends TextEditBox {
         this.pinPadBg = this.loadBitmap("common:/images/inputField.9.png");
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderNodeContent(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.pinPadMode) {
-            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            super.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
             return;
         }
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
         }
-        const nodeTrans = this.getTranslation();
-        const drawTrans = nodeTrans.slice();
-        drawTrans[0] += origin[0];
-        drawTrans[1] += origin[1];
+        const drawTrans = this.getDrawTranslation(origin, angle);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         opacity *= this.getOpacity();

--- a/test/extensions/scenegraph/ClippingRect.test.js
+++ b/test/extensions/scenegraph/ClippingRect.test.js
@@ -132,3 +132,225 @@ describe("clippingRect limits child rendering", () => {
         expect(draw2D.getDepth()).toBe(0);
     });
 });
+
+/**
+ * `clippingRect` is declared on Group, so EVERY Group-derived node inherits it, and per the reference
+ * it limits "all drawing by this node AND its children" — the node's own geometry included. Only the
+ * two nodes that draw nothing of their own (Group, ArrayGrid) used to apply it; the ~25 node types
+ * that override the render entry point drew unclipped, and because a Rectangle/Poster/Label also
+ * renders children, an ignored rect leaked the whole subtree. The clip now lives in the `renderNode`
+ * template on Group, so it brackets each node's own drawing as well as its children.
+ */
+describe("clippingRect on nodes that draw their own geometry", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /** Records every clip push/pop plus the draw calls, so we can assert a draw happened inside a clip. */
+    function recorder() {
+        const events = [];
+        let depth = 0;
+        const record =
+            (kind) =>
+            (...args) => {
+                events.push({ kind, arg: args[0] });
+            };
+        return {
+            events,
+            getDepth: () => depth,
+            clips: () => events.filter((e) => e.kind === "push").map((e) => ({ ...e.arg })),
+            pushClip(rect) {
+                events.push({ kind: "push", arg: { ...rect } });
+                depth += 1;
+            },
+            popClip() {
+                events.push({ kind: "pop" });
+                depth -= 1;
+            },
+            doDrawRotatedRect: record("draw"),
+            doDrawRotatedBitmap: record("draw"),
+            doDrawScaledObject: record("draw"),
+            doDrawRotatedText: record("draw"),
+            drawNinePatch: record("draw"),
+            doDrawText: record("draw"),
+            doDrawObject: record("draw"),
+            doClearCanvas: () => {},
+            getContext: () => undefined,
+        };
+    }
+
+    /** True when at least one draw call happened between a push and its matching pop. */
+    function drewInsideAClip(events) {
+        let depth = 0;
+        for (const e of events) {
+            if (e.kind === "push") depth += 1;
+            else if (e.kind === "pop") depth -= 1;
+            else if (e.kind === "draw" && depth > 0) return true;
+        }
+        return false;
+    }
+
+    test("a Rectangle's OWN fill is clipped by its own clippingRect", () => {
+        // The "this node" half of the contract. A Rectangle used to push no clip at all, so an app
+        // collapsing a filled panel by shrinking its clippingRect still saw the full fill.
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("translation", vector([40, 20]));
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(100));
+        rect.setValue("clippingRect", vector([0, 0, 120, 100]));
+        const draw2D = recorder();
+
+        rect.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips()).toEqual([{ x: 40, y: 20, width: 120, height: 100 }]);
+        expect(drewInsideAClip(draw2D.events)).toBe(true);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("a Label's own text draw is clipped by its own clippingRect", () => {
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("translation", vector([10, 10]));
+        label.setValue("text", new BrsString("clipped text"));
+        label.setValue("clippingRect", vector([0, 0, 40, 20]));
+        const draw2D = recorder();
+
+        label.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips()).toEqual([{ x: 10, y: 10, width: 40, height: 20 }]);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("a node painted directly via paintNode honors its clippingRect", () => {
+        // RoSGScreen paints the scene and the active dialog through paintNode, with no parent
+        // traversal above them — the entry point a parent-side clip would never reach. (A Dialog
+        // stands in for the Scene here: Scene buffers every field write until init, which is
+        // unrelated to clipping.)
+        const dialog = SGNodeFactory.createNode("Dialog");
+        dialog.setValue("translation", vector([100, 50]));
+        dialog.setValue("clippingRect", vector([0, 0, 640, 360]));
+        const draw2D = recorder();
+
+        dialog.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips()).toEqual([{ x: 100, y: 50, width: 640, height: 360 }]);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("nested clippingRects compose and stay balanced", () => {
+        const outer = SGNodeFactory.createNode("Group");
+        outer.setValue("translation", vector([10, 10]));
+        outer.setValue("clippingRect", vector([0, 0, 500, 500]));
+        const inner = SGNodeFactory.createNode("Group");
+        inner.setValue("translation", vector([5, 5]));
+        inner.setValue("clippingRect", vector([0, 0, 100, 100]));
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(300));
+        inner.appendChildToParent(rect);
+        outer.appendChildToParent(inner);
+        const draw2D = recorder();
+
+        outer.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        // Each rect is pushed in scene coordinates, outer first; the canvas intersects them.
+        expect(draw2D.clips()).toEqual([
+            { x: 10, y: 10, width: 500, height: 500 },
+            { x: 15, y: 15, width: 100, height: 100 },
+        ]);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("a measurement pass pushes no clip on a self-drawing node", () => {
+        // Extends the existing measurement invariant to the newly clipped node types: boundingRect()
+        // must stay unclipped so hidden UI still lays out.
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(100));
+        rect.setValue("clippingRect", vector([0, 0, 10, 10]));
+
+        expect(() => rect.renderNode(interpreter, [0, 0], 0, 1)).not.toThrow();
+        expect(rect.getBoundingRect("toScene", interpreter).width).toBe(300);
+    });
+
+    test("an invisible node with a clippingRect pushes no clip", () => {
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(100));
+        rect.setValue("clippingRect", vector([0, 0, 50, 50]));
+        rect.setValue("visible", core.BrsBoolean.False);
+        const draw2D = recorder();
+
+        rect.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips()).toHaveLength(0);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("a throwing child leaves the clip stack balanced", () => {
+        // A clip is ctx.save() without its restore(): leaking one does not just break this frame, it
+        // clips every frame drawn afterwards. Arbitrary app BrightScript runs inside the bracket, so
+        // the pop has to be in a finally.
+        const group = SGNodeFactory.createNode("Group");
+        group.setValue("clippingRect", vector([0, 0, 100, 100]));
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.renderNode = () => {
+            throw new Error("boom");
+        };
+        group.appendChildToParent(child);
+        const draw2D = recorder();
+
+        expect(() => group.renderNode(interpreter, [0, 0], 0, 1, draw2D)).toThrow("boom");
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("a LayoutGroup pushes its clip exactly once, balanced", () => {
+        // LayoutGroup calls its super render inside a convergence loop, so a super call that reached
+        // the clipping template (instead of the content hook) would push one clip per pass.
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("translation", vector([20, 30]));
+        layout.setValue("clippingRect", vector([0, 0, 200, 200]));
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(80));
+        rect.setValue("height", new Float(40));
+        layout.appendChildToParent(rect);
+        const draw2D = recorder();
+
+        layout.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips()).toEqual([{ x: 20, y: 30, width: 200, height: 200 }]);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+
+    test("IfDraw2D.resetClips unwinds a leaked clip so the next frame is not poisoned", () => {
+        // The frame-level backstop RoSGScreen runs in a finally around the scene+dialog paint.
+        const { RoBitmap, IfDraw2D } = core;
+        const bitmap = new RoBitmap({ width: 100, height: 100, alphaEnable: false });
+        const draw2D = new IfDraw2D(bitmap);
+
+        draw2D.pushClip({ x: 0, y: 0, width: 10, height: 10 });
+        draw2D.pushClip({ x: 0, y: 0, width: 5, height: 5 });
+        expect(draw2D.getClipDepth()).toBe(2);
+
+        draw2D.resetClips();
+        expect(draw2D.getClipDepth()).toBe(0);
+
+        // Idempotent: an already-balanced frame is left alone (no stray ctx.restore()).
+        draw2D.resetClips();
+        expect(draw2D.getClipDepth()).toBe(0);
+    });
+});


### PR DESCRIPTION
Follow-up to the "Noted, not fixed here" list in #1131.

## Problem

`clippingRect` is declared on `Group` (`Group.ts:43`), so **every** Group-derived node inherits it, and per the [reference](https://developer.roku.com/docs/references/scenegraph/layout-group-nodes/group.md) it limits:

> "all drawing by **this node** and its children will be limited to that rectangular area"

Only two nodes actually applied it — `Group.renderNode` and `ArrayGrid.renderNode` — and both bracketed just the child traversal. Two consequences:

1. **~25 node types ignored their own rect entirely** — every class that overrides the render entry point without delegating: `Rectangle`, `Poster`, `Label`, `SimpleLabel`, `MultiStyleLabel`, `ScrollableText`, `Video`, `Scene`, `Dialog`/`StandardDialog` and its four subclasses, `Overhang`, `Button`, `BusySpinner`, `Keyboard`, `MiniKeyboard`, `PinPad`, `DynamicKeyGrid`, `TextEditBox`, `TargetGroup`, `TrickPlayBar`, the `StdDlg*` items… plus 6 subclasses whose super is one of those and 8 that inherit without overriding. Since `Rectangle`/`Poster`/`Label` also render children, an ignored rect leaked the **whole subtree**.
2. **Even on `Group` it never covered self-drawn geometry** — the "this node" half of the contract was unimplemented everywhere.

Separately, none of the six clip brackets were exception-safe. `pushClip` is `ctx.save()` and `popClip` is `ctx.restore()`, so a leaked clip is not a transient glitch — it is **permanent canvas state**, and every frame after it draws inside the stale clip.

## Fix

`Group.renderNode` becomes a **template method** (not to be overridden); each node type implements `renderNodeContent`:

```ts
renderNode(interpreter, origin, angle, opacity, draw2D?) {
    this.prepareRender(draw2D);
    const clipped = this.isVisible() && this.pushClippingRect(this.getDrawTranslation(origin, angle), draw2D);
    try {
        this.renderNodeContent(interpreter, origin, angle, opacity, draw2D);
    } finally {
        if (clipped) draw2D?.popClip();
    }
}
```

**Why not clip in the parent's `renderChildren`** — the cheaper design, and the one I tried to justify first. It cannot work: eight call sites render a child directly (`PanelSet.ts:248,256,259,268,272`, `ZoomRowList.ts:689`, `TargetGroup.ts:280`, `ArrayGrid.ts:585`, `RowList.ts:1046`), and `RoSGScreen.ts:218,224` paints the Scene and the active Dialog through `paintNode` with no parent traversal above them — so neither would ever be clipped. It also cannot satisfy the "this node" clause. `ClippingRect.test.js` drives `renderNode` directly with no parent, so under that design all five of its existing tests would fail — the design telling us it is wrong, rather than tests needing an update.

The template picks up Scene and Dialog for free, since `layoutNode`/`paintNode` (`Node.ts:1002-1025`) both wrap `this.renderNode`.

Measurement passes are unaffected: `pushClippingRect` already no-ops without a `draw2D`, so `boundingRect()` stays unclipped.

### Supporting changes

- **All draw translations go through `getDrawTranslation`.** Previously 25 classes each recomputed `drawTrans` inline; now nothing does, so the clip position provably cannot drift from the paint position. `rotateTranslation` is left with exactly one caller in `nodes/` (plus an unrelated use in `MonospaceLabel`).
- **`rotatesDrawTranslation()` only selects between two behaviors that already existed.** 18 renderable types rotate their own translation vector under an inherited angle; `Group` and the keyboard/text-entry containers do not. The two are identical whenever that angle is 0, so this introduces nothing. The split looks accidental rather than intended — a rotated container would place children differently depending on which side it falls on — and is flagged in the invariants doc as **needing a device probe**. Preserved as-is, deliberately not unified.
- **`StandardDialog` self-translates during layout** (`:448-450` recenters the dialog), so its relayout has to run before the template derives `drawTrans` — moved into `prepareRender`. The four `Standard*Dialog` subclasses build the content that *drives* that layout, so their preambles chain through `prepareRender` too. Getting this order wrong sizes a dialog from stale content; two `StandardDialogNodes.test.js` tests caught exactly that mid-change.
- **The four clip brackets outside the template** (`ArrayGrid.renderItemClipped`, `RowList.renderSingleRow`, `ScrollableText`, `ScrollingLabel`) now pop in a `finally`.
- Subclass delegation is `super.renderNodeContent`, never `super.renderNode` — the latter double-pushes. `LayoutGroup` matters most: it calls super inside a convergence loop, so the mistake shows up as N clips per pass (pinned by a test).

The first commit is separable: a clip-depth counter on `IfDraw2D` plus `resetClips()`, called from the `finally` that already wraps the per-frame paint in `RoSGScreen`, so one bad frame cannot poison the next.

## Testing

Nine new tests in `ClippingRect.test.js`. **Five fail on the parent commit for the right reason**:

| Test | Failure on master |
| --- | --- |
| a Rectangle's OWN fill is clipped | `expected [] to deeply equal [{x:40,y:20,…}]` — no clip pushed at all |
| a Label's own text draw is clipped | `expected [] to deeply equal [{x:10,y:10,…}]` |
| a node painted via `paintNode` is clipped | `expected [] to deeply equal [{x:100,y:50,…}]` |
| a throwing child leaves the clip stack balanced | `expected 1 to be +0` — the leak itself |
| `resetClips` unwinds a leaked clip | `getClipDepth is not a function` |

The other four (nested clips compose, measurement pass pushes nothing, invisible node pushes nothing, `LayoutGroup` pushes exactly once) pass on both — they pin behavior that already worked, as a guard against over-correcting.

All five pre-existing `ClippingRect.test.js` tests and `GridItemClipping.test.js` pass **verbatim**, which is the strongest evidence the seam is in the right place: their exact-clip-list and depth-balance assertions are precisely what catches a wrong one.

Full suite green: **2425 passed / 194 files**. `npm run lint`, `npm run prettier` and `tsc` clean.

Invariants written up in `.claude/docs/scenegraph-invariants.md` (rewritten rendering-contract section: the template/hook split, why the seam is where it is, why the visibility gates stay per-class, the `finally` reasoning, the `prepareRender` ordering rule), and `.claude/CLAUDE.md`'s node-creation recipe now says to override `renderNodeContent`.

**Worth a device pass before merge** — the diff is mechanical but touches every renderable node's entry point. A screen with lists, a dialog, a keyboard and video playback would cover it.

## Still open from #1131's list

- `ArrayGrid.updateRect` reports a uniform height, ignoring `rowHeights`/`rowSpacings` — next PR.
- `childRenderOrder`, `inheritParentOpacity`/`inheritParentTransform` and `Rectangle.blendingEnabled` remain declared-but-unread; the documented `renderLast` default would make a `Rectangle`'s fill paint over its children, which contradicts the common `Rectangle > Label` idiom, so those need a probe first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)