### PR TITLE
fix(scenegraph): report per-row extents in a grid's boundingRect

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -601,7 +601,7 @@ export class ArrayGrid extends Group {
         drawTrans[1] += origin[1];
         const rect = { x: drawTrans[0], y: drawTrans[1], ...this.getDimensions() };
         const displayRows = Math.min(Math.ceil(this.content.length / this.numCols), this.numRows);
-        this.updateRect(rect, displayRows, itemSize);
+        this.updateRect(rect, displayRows, itemSize, { firstRow: this.topRow });
         this.updateBoundingRects(rect, origin, angle + this.getRotation());
     }
 
@@ -964,21 +964,100 @@ export class ArrayGrid extends Group {
         return { x: 0, y: 0 };
     }
 
-    protected updateRect(rect: Rect, numRows: number, itemSize: number[]) {
+    /**
+     * Whether this node lays its columns out from `columnWidths`/`columnSpacings`. Per the ArrayGrid
+     * reference those fields are "not used by lists", so only grids opt in.
+     */
+    protected usesColumnWidths(): boolean {
+        return false;
+    }
+
+    /**
+     * Resolves a per-row/per-column override array against its uniform fallback. Per the ArrayGrid
+     * reference the arrays are indexed by ABSOLUTE row/column, top to bottom, and any index past the
+     * end of the array falls back to the `itemSize`/`itemSpacing` value — it does NOT repeat the last
+     * entry (unlike `LayoutGroup.itemSpacings`, which is device-confirmed to repeat).
+     */
+    private resolveTrackValue(values: unknown, index: number, fallback: number): number {
+        if (!Array.isArray(values)) {
+            return fallback;
+        }
+        const value = values[index];
+        return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+    }
+
+    /**
+     * Sizes the reported bounding rect to the laid-out extent.
+     *
+     * Inter-item spacing is part of that extent: the render loop advances by `itemSize + itemSpacing`
+     * per row/column, so N uniform rows span `N*itemH + (N-1)*spacing`. `boundingRect` reported only
+     * `N*itemH` before, omitting the gaps — an app centering a vertical menu via
+     * `(screenH - boundingRect().height)/2` then placed it too low by the total gap height.
+     *
+     * Rows and columns are not necessarily uniform, though: `rowHeights`/`rowSpacings` (and
+     * `columnWidths`/`columnSpacings` on grids) override `itemSize`/`itemSpacing` per track, and the
+     * render loops honor them. Measuring uniformly made every variable-height list report a rect that
+     * disagreed with what it drew.
+     *
+     * @param layout.firstRow Absolute index of the first RENDERED row — a scrolled list starts its
+     *   window at `topRow`, not 0, so the per-row overrides have to be indexed from there.
+     * @param layout.width/height An extent the caller already accumulated while laying out, which
+     *   wins over the arithmetic below. RowList and PosterGrid need this: their rows grow by amounts
+     *   (a label/counter band, a caption zone) that cannot be re-derived here without duplicating the
+     *   measurement.
+     */
+    protected updateRect(
+        rect: Rect,
+        numRows: number,
+        itemSize: number[],
+        layout?: { firstRow?: number; width?: number; height?: number }
+    ) {
         const numCols = this.numCols || 1;
-        // Inter-item spacing is part of the laid-out extent: the render loop advances by
-        // `itemSize + itemSpacing` per row/column, so N rows span `N*itemH + (N-1)*spacing`
-        // (and likewise across columns). `boundingRect` reported only `N*itemH` before, omitting
-        // the gaps — an app centering a vertical menu via `(screenH - boundingRect().height)/2`
-        // then placed it too low by the total gap height. `itemSpacing` defaults to [0,0].
         const spacing = this.getValueJS("itemSpacing") as number[];
         const colSpacing = Array.isArray(spacing) ? spacing[0] ?? 0 : 0;
         const rowSpacing = Array.isArray(spacing) ? spacing[1] ?? 0 : 0;
         const margin = this.rectMargins();
         rect.x = rect.x - margin.x;
         rect.y = rect.y - margin.y;
-        rect.width = numCols * (itemSize[0] + margin.x * 2) + Math.max(0, numCols - 1) * colSpacing;
-        rect.height = numRows * (itemSize[1] + margin.y * 2) + Math.max(0, numRows - 1) * rowSpacing;
+
+        if (typeof layout?.width === "number") {
+            rect.width = layout.width;
+        } else if (this.usesColumnWidths()) {
+            const columnWidths = this.getValueJS("columnWidths");
+            const columnSpacings = this.getValueJS("columnSpacings");
+            let width = 0;
+            for (let c = 0; c < numCols; c++) {
+                width += this.resolveTrackValue(columnWidths, c, itemSize[0]) + margin.x * 2;
+                if (c < numCols - 1) {
+                    width += this.resolveTrackValue(columnSpacings, c, colSpacing);
+                }
+            }
+            rect.width = width;
+        } else {
+            rect.width = numCols * (itemSize[0] + margin.x * 2) + Math.max(0, numCols - 1) * colSpacing;
+        }
+
+        if (typeof layout?.height === "number") {
+            rect.height = layout.height;
+            return;
+        }
+        const rowHeights = this.getValueJS("rowHeights");
+        const rowSpacings = this.getValueJS("rowSpacings");
+        const totalRows = Math.max(1, Math.ceil(this.content.length / numCols));
+        const firstRow = layout?.firstRow ?? 0;
+        let height = 0;
+        for (let r = 0; r < numRows; r++) {
+            // A wrapping list renders a contiguous window that can run past the last row and resume
+            // at the top, so the override arrays are indexed modulo the row count.
+            const absolute = this.wrap ? (((firstRow + r) % totalRows) + totalRows) % totalRows : firstRow + r;
+            height += this.resolveTrackValue(rowHeights, absolute, itemSize[1]) + margin.y * 2;
+            if (r < numRows - 1) {
+                // Per the reference, rowSpacings[i] is the spacing AFTER row i, so the last rendered
+                // row contributes none.
+                height += this.resolveTrackValue(rowSpacings, absolute, rowSpacing);
+            }
+        }
+        rect.height = height;
     }
 
     protected getIndex(offset: number = 0, currIndex?: number) {

--- a/src/extensions/scenegraph/nodes/MarkupGrid.ts
+++ b/src/extensions/scenegraph/nodes/MarkupGrid.ts
@@ -58,6 +58,11 @@ export class MarkupGrid extends ArrayGrid {
         return { x: 0, y: 0 };
     }
 
+    /** A grid lays its columns out from columnWidths/columnSpacings; per the reference, lists do not. */
+    protected usesColumnWidths(): boolean {
+        return true;
+    }
+
     protected handleUpDown(key: string) {
         let handled = false;
         let offset: number;
@@ -209,7 +214,10 @@ export class MarkupGrid extends ArrayGrid {
             if (rowIndex < 0) {
                 break;
             }
-            itemRect.height = rowHeights[rowIndex / this.numCols] ?? itemSize[1];
+            // Per-row overrides are indexed by ABSOLUTE row, top to bottom — not by the display slot,
+            // which differs as soon as the grid is scrolled.
+            const absoluteRow = Math.floor(rowIndex / this.numCols);
+            itemRect.height = rowHeights[absoluteRow] ?? itemSize[1];
             if (!hasSections && this.wrap && rowIndex < lastIndex && r > 0) {
                 const divRect = { ...itemRect, width: rowWidth };
                 const divHeight = this.renderWrapDivider(divRect, opacity, draw2D);
@@ -238,11 +246,13 @@ export class MarkupGrid extends ArrayGrid {
                 }
             }
             itemRect.x = rect.x;
-            itemRect.y += itemRect.height + (rowSpacings[r] ?? spacing[1]);
+            itemRect.y += itemRect.height + (rowSpacings[absoluteRow] ?? spacing[1]);
             if (!RectRect(this.sceneRect, itemRect)) {
                 break;
             }
         }
-        this.updateRect(rect, displayRows, itemSize);
+        this.updateRect(rect, displayRows, itemSize, {
+            firstRow: Math.max(0, Math.floor(this.getRenderRowIndex(0) / this.numCols)),
+        });
     }
 }

--- a/src/extensions/scenegraph/nodes/MarkupList.ts
+++ b/src/extensions/scenegraph/nodes/MarkupList.ts
@@ -152,12 +152,14 @@ export class MarkupList extends ArrayGrid {
             this.renderItemComponent(interpreter, index, itemRect, rotation, opacity, draw2D);
             lastIndex = index;
             itemRect.x = rect.x;
-            itemRect.y += itemRect.height + (rowSpacings[r] ?? spacing[1]);
+            // Per-row overrides are indexed by ABSOLUTE row, top to bottom — not by the display slot,
+            // which differs as soon as the list is scrolled (rowHeights above already does this).
+            itemRect.y += itemRect.height + (rowSpacings[rowIndex] ?? spacing[1]);
             if (!RectRect(this.sceneRect, itemRect)) {
                 break;
             }
         }
-        this.updateRect(rect, displayRows, itemSize);
+        this.updateRect(rect, displayRows, itemSize, { firstRow: Math.max(0, this.getRenderRowIndex(0)) });
     }
 
     protected focusMargins() {

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -220,6 +220,13 @@ export class PosterGrid extends ArrayGrid {
         let sectionIndex = 0;
         let maxCellHeight = 0;
         const itemRect = { ...rect, width: columnWidths[0], height: baseSize[1] };
+        // Accumulate the extent actually laid out. Each row's height is its poster height PLUS its
+        // caption zone, which updateRect cannot re-derive from rowHeights alone — measuring from
+        // rowHeights there would silently drop every caption. `startY` is captured before the loop so
+        // wrap/section dividers, which also advance itemRect.y, are counted.
+        const startY = itemRect.y;
+        let renderedRows = 0;
+        let trailingGap = 0;
         for (let r = 0; r < displayRows; r++) {
             const rowIndex = this.getRenderRowIndex(r);
             if (rowIndex < 0 || rowIndex >= contentLength) {
@@ -281,13 +288,24 @@ export class PosterGrid extends ArrayGrid {
             maxCellHeight = Math.max(maxCellHeight, rowHeightWithCaptions);
             lastRowIndex = rowIndex;
             lastRowNumber = rowNumber;
+            renderedRows++;
+            trailingGap = this.resolveSpacingValue(rowSpacingValues, rowNumber, baseRowSpacing);
             if (itemRect.y > (this.sceneRect?.y ?? 0) + (this.sceneRect?.height ?? 0)) {
+                itemRect.y += rowHeightWithCaptions;
+                trailingGap = 0;
                 break;
             }
             const rowGap = this.resolveSpacingValue(rowSpacingValues, rowNumber, baseRowSpacing);
             itemRect.y += rowHeightWithCaptions + rowGap;
         }
-        this.updateRect(rect, displayRows, [Math.max(...columnWidths), maxCellHeight || baseSize[1]]);
+        // Explicit extents: the accumulated height (caption zones included) and the row width the
+        // layout already computes per row — the old `Math.max(...columnWidths) * numCols` ignored both
+        // per-column widths and column spacing.
+        const height = renderedRows === 0 ? 0 : itemRect.y - startY - trailingGap;
+        this.updateRect(rect, displayRows, [Math.max(...columnWidths), maxCellHeight || baseSize[1]], {
+            width: this.computeRowWidth(columnWidths, columnSpacings),
+            height,
+        });
     }
 
     protected handleUpDown(key: string) {

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -665,16 +665,28 @@ export class RowList extends ArrayGrid {
             this.currRow = this.topRow;
         }
 
+        // Rows advance by their own height plus, when the label/counter band does not fit in the row's
+        // slack, that band's height (see renderSingleRow). No arithmetic in updateRect can reproduce
+        // that without re-measuring the label, so accumulate the extent the loop actually laid out and
+        // hand it over. `itemRect.y` ends one rowSpacing past the last row, which is dropped below.
+        const startY = context.itemRect.y;
+        let renderedRows = 0;
+        let trailingSpacing = 0;
         for (let r = 0; r < context.displayRows; r++) {
             const rowIndex = this.calculateActualRowIndex(r);
             if (rowIndex === -1) {
                 break;
             }
-            if (!this.renderSingleRow(rowIndex, r, context)) {
+            const fits = this.renderSingleRow(rowIndex, r, context);
+            renderedRows++;
+            trailingSpacing = this.calculateRowSpacing(rowIndex, context.rowSpacings, context.globalSpacing);
+            if (!fits) {
                 break;
             }
         }
-        this.updateRect(rect, context.displayRows, context.itemSize);
+        const margin = this.rectMargins();
+        const height = renderedRows === 0 ? 0 : context.itemRect.y - startY - trailingSpacing + margin.y * 2;
+        this.updateRect(rect, context.displayRows, context.itemSize, { height, firstRow: this.currRow });
     }
 
     private validateRenderPrerequisites(): boolean {

--- a/test/extensions/scenegraph/VariableRowMeasure.test.js
+++ b/test/extensions/scenegraph/VariableRowMeasure.test.js
@@ -1,0 +1,151 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, MarkupGrid, MarkupList } = scenegraph;
+const { BrsDevice, BrsString, Int32, Float, RoArray } = core;
+
+/**
+ * `rowHeights` / `rowSpacings` (and `columnWidths` / `columnSpacings` on grids) override
+ * `itemSize` / `itemSpacing` per track, and the render loops honor them — but `updateRect` computed a
+ * uniform `numRows * itemSize.y + (numRows - 1) * itemSpacing.y`, so every variable-height list
+ * reported a bounding rect that disagreed with what it drew. An app sizing a sibling background or
+ * centering from `boundingRect()` drifted by the difference.
+ *
+ * Per the ArrayGrid reference the arrays are indexed by ABSOLUTE row (top to bottom), an index past
+ * the end of the array falls back to the `itemSize` / `itemSpacing` value (it does NOT repeat the last
+ * entry, unlike LayoutGroup's `itemSpacings`), and `rowSpacings[i]` is the spacing AFTER row i.
+ */
+describe("boundingRect honors per-row and per-column overrides", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /** Calls the protected updateRect directly, isolating the extent from the 9-patch outset. */
+    function measure(grid, numRows, itemSize, layout) {
+        grid.hasNinePatch = false;
+        const rect = { x: 0, y: 0, width: 0, height: 0 };
+        grid.updateRect(rect, numRows, itemSize, layout);
+        return rect;
+    }
+
+    /** A MarkupList with `count` rows of content, so absolute row indices resolve. */
+    function listWithRows(count) {
+        const list = new MarkupList();
+        const root = SGNodeFactory.createNode("ContentNode");
+        for (let i = 0; i < count; i++) {
+            const item = SGNodeFactory.createNode("ContentNode");
+            item.setValue("title", new BrsString("R" + i));
+            root.appendChildToParent(item);
+        }
+        list.setValue("numRows", new Int32(count));
+        list.setValue("numColumns", new Int32(1));
+        list.setValue("content", root);
+        return list;
+    }
+
+    test("rowHeights are summed instead of multiplying itemSize.y", () => {
+        // The core defect: 100 + 50 + 200 = 350, not 3 * 72.
+        const list = listWithRows(3);
+        list.setValue("itemSize", vector([400, 72]));
+        list.setValue("rowHeights", vector([100, 50, 200]));
+
+        expect(measure(list, 3, [400, 72]).height).toBe(350);
+    });
+
+    test("rows past the end of rowHeights fall back to itemSize.y (no last-entry repeat)", () => {
+        // 100 + 50 + 72 + 72 = 294. Repeating the last entry would give 100+50+50+50 = 250.
+        const list = listWithRows(4);
+        list.setValue("itemSize", vector([400, 72]));
+        list.setValue("rowHeights", vector([100, 50]));
+
+        expect(measure(list, 4, [400, 72]).height).toBe(294);
+    });
+
+    test("rowSpacings counts the gaps BETWEEN rows only — the trailing entry is dropped", () => {
+        // 3 rows of 100 with spacings [10, 20, 30]: 300 + 10 + 20 = 330. The gap after the last
+        // rendered row is not part of the extent.
+        const list = listWithRows(3);
+        list.setValue("itemSize", vector([400, 100]));
+        list.setValue("rowSpacings", vector([10, 20, 30]));
+
+        expect(measure(list, 3, [400, 100]).height).toBe(330);
+    });
+
+    test("gaps past the end of rowSpacings fall back to itemSpacing.y", () => {
+        // 4 rows of 100, spacings [10] then the itemSpacing default of 5: 400 + 10 + 5 + 5 = 420.
+        const list = listWithRows(4);
+        list.setValue("itemSize", vector([400, 100]));
+        list.setValue("itemSpacing", vector([0, 5]));
+        list.setValue("rowSpacings", vector([10]));
+
+        expect(measure(list, 4, [400, 100]).height).toBe(420);
+    });
+
+    test("a scrolled window measures the rows it actually rendered", () => {
+        // rowHeights [300, 300, 50, 50] with a 2-row window scrolled to the bottom pair measures
+        // 50 + 50 = 100, not the first two rows' 600.
+        const list = listWithRows(4);
+        list.setValue("itemSize", vector([400, 72]));
+        list.setValue("rowHeights", vector([300, 300, 50, 50]));
+
+        expect(measure(list, 2, [400, 72], { firstRow: 2 }).height).toBe(100);
+        expect(measure(list, 2, [400, 72], { firstRow: 0 }).height).toBe(600);
+    });
+
+    test("a grid sums columnWidths and columnSpacings", () => {
+        // 100 + 200 + 300 widths, 10 + 20 gaps = 630.
+        const grid = new MarkupGrid();
+        grid.setValue("numRows", new Int32(1));
+        grid.setValue("numColumns", new Int32(3));
+        grid.setValue("columnWidths", vector([100, 200, 300]));
+        grid.setValue("columnSpacings", vector([10, 20]));
+
+        expect(measure(grid, 1, [150, 72]).width).toBe(630);
+    });
+
+    test("a list ignores columnWidths (per the reference, they are not used by lists)", () => {
+        const list = listWithRows(1);
+        list.setValue("itemSize", vector([400, 72]));
+        list.setValue("columnWidths", vector([100]));
+
+        expect(measure(list, 1, [400, 72]).width).toBe(400);
+    });
+
+    test("an explicit accumulated extent overrides the arithmetic", () => {
+        // RowList and PosterGrid pass the extent their loop actually laid out, because a label band /
+        // caption zone grows a row by an amount updateRect cannot re-derive from rowHeights.
+        const list = listWithRows(2);
+        list.setValue("itemSize", vector([400, 72]));
+        list.setValue("rowHeights", vector([100, 100]));
+
+        expect(measure(list, 2, [400, 72], { height: 999, width: 888 })).toMatchObject({
+            width: 888,
+            height: 999,
+        });
+    });
+
+    test("uniform lists are unchanged (no rowHeights/rowSpacings set)", () => {
+        // Pins the pre-existing uniform formula, so the per-track path cannot regress the common case.
+        const list = listWithRows(11);
+        list.setValue("itemSize", vector([438, 72]));
+        list.setValue("itemSpacing", vector([0, 12]));
+
+        const rect = measure(list, 11, [438, 72]);
+        expect(rect.height).toBe(11 * 72 + 10 * 12);
+        expect(rect.width).toBe(438);
+    });
+});
+
+// NOTE: the matching render-loop fix (MarkupGrid/MarkupList advanced by `rowSpacings[r]`, the
+// RELATIVE display slot, while indexing `rowHeights` by the absolute row) is not directly pinned
+// here. Both nodes refuse to build items unless `itemComponentName` names an XML-defined component
+// (`customNodeExists`), which a unit test cannot construct — covering the loop needs a CLI fixture
+// app. The measurement above and the loop now read the same absolute index, so a future divergence
+// between them shows up as a measurement failure.


### PR DESCRIPTION
Second follow-up from #1131's "Noted, not fixed here" list (the first is #1133). Independent of #1133 — either can merge first.

## Problem

`ArrayGrid.updateRect` computed a uniform extent and never read `rowHeights` / `rowSpacings` / `columnWidths` / `columnSpacings`, even though the render loops honor all four:

```ts
rect.width  = numCols * (itemSize[0] + margin.x * 2) + Math.max(0, numCols - 1) * colSpacing;
rect.height = numRows * (itemSize[1] + margin.y * 2) + Math.max(0, numRows - 1) * rowSpacing;
```

So every variable-height list reported a bounding rect that disagreed with what it drew. Four node types lay rows out with variable heights — `MarkupGrid`, `MarkupList`, `PosterGrid`, `RowList` — and an app sizing a sibling background or centering from `boundingRect()` drifted by the difference.

Per the [ArrayGrid reference](https://developer.roku.com/docs/references/scenegraph/abstract-nodes/arraygrid.md):

> **rowHeights**: "The specified values override the itemSize field vector2d Y-value for each list or grid row corresponding to its position in the array, **in top to bottom order**. If the array contains fewer elements than the number of rows needed to display all the items, **the itemSize field vector2d Y-value is used for any unspecified rows**"

and from [rowlist.md](https://developer.roku.com/docs/references/scenegraph/list-and-grid-nodes/rowlist.md), `rowSpacings` is "the spacing **after** each row". `columnWidths` is "not used by lists".

## Fix

Sum the per-track values, following those three rules exactly: absolute top-to-bottom indexing, fall back to the `itemSize`/`itemSpacing` value past the end of the array (**not** last-entry repeat — unlike `LayoutGroup.itemSpacings`, which is device-confirmed to repeat, so the two genuinely differ), and N−1 gaps. `columnWidths` is gated on a new `usesColumnWidths()` hook that defaults to `false`, so lists keep ignoring it.

`updateRect` **keeps its 3-argument signature** and gains an optional 4th describing the layout — `GridMeasureSpacing.test.js` and `ListMeasureStability.test.js` call it directly, and both are untouched:

- **`firstRow`** — the absolute index of the first *rendered* row. A scrolled list starts its window at `topRow`, not 0; measuring the first N rows of a scrolled list is its own wrong answer.
- **`width` / `height`** — an extent the caller already accumulated, which wins over the arithmetic. Two callers need it:
  - **`RowList`**: a row grows by its label/counter band when the band does not fit the row's slack (`RowList.ts:812`). That cannot be re-derived in `updateRect` without duplicating the label measurement.
  - **`PosterGrid`**: it passed `[Math.max(...columnWidths), maxCellHeight || baseSize[1]]`, where `maxCellHeight` is **caption-aware**. Naively reading `rowHeights` inside `updateRect` would have *replaced* that and silently dropped every row's caption zone — a regression, not a double-count. It now hands over the accumulated height plus the row width its layout already computes, which also fixes `Math.max(...columnWidths) * numCols` ignoring per-column widths and column spacing.

### Secondary bug fixed along the way

`MarkupGrid.ts:241` and `MarkupList.ts:155` advanced by `rowSpacings[r]` — the **relative** display slot — while indexing `rowHeights` by the absolute row on the line above. Wrong as soon as the list is scrolled, and inconsistent with `RowList.calculateRowSpacing`, which already indexes absolutely.

## Testing

Nine new tests in `test/extensions/scenegraph/VariableRowMeasure.test.js`. **Seven fail on the parent commit for the right reason**:

| Test | On master |
| --- | --- |
| rowHeights are summed | `expected 216 to be 350` |
| short rowHeights fall back to itemSize.y (no last-entry repeat) | `expected 288 to be 294` |
| rowSpacings counts gaps between rows only | `expected 300 to be 330` |
| short rowSpacings fall back to itemSpacing.y | `expected 415 to be 420` |
| a scrolled window measures the rows it rendered | `expected 144 to be 100` |
| a grid sums columnWidths + columnSpacings | `expected 450 to be 630` |
| an explicit accumulated extent overrides the arithmetic | width/height ignored |

The other two pass on both, pinning what must not change: a list ignores `columnWidths`, and uniform lists keep the existing formula.

Full suite green: **2425 passed / 195 files**. `npm run lint`, `npm run prettier` and `tsc` clean.

**One disclosed coverage gap:** the render-loop half of the `rowSpacings` indexing fix is not directly unit-pinned. `MarkupGrid`/`MarkupList` refuse to build items unless `itemComponentName` names an XML-defined component (`customNodeExists`), which a unit test cannot construct — covering the loop needs a CLI fixture app. The measurement and the loop now read the same absolute index, so a future divergence surfaces as a measurement failure, but the loop change itself rests on inspection.

## Left alone deliberately

Both need a hardware probe rather than a guess, and are noted in code:

- `LabelList.ts:132` advances by `itemSize[1] + 1`, honoring neither `rowHeights` nor `rowSpacings` nor `itemSpacing.y` — and that `+ 1` already contradicts `updateRect`. Its call site stays on the 3-arg form.
- `PosterGrid.resolveSpacingValue` repeats the last spacing entry via `values.at(-1)` instead of falling back to `itemSpacing`. These differ for e.g. `columnSpacings=[10]` across 3 columns, and since `LayoutGroup.itemSpacings` **is** device-confirmed to repeat, the two may legitimately disagree.

Also still open from #1131's list: `childRenderOrder`, `inheritParentOpacity`/`inheritParentTransform` and `Rectangle.blendingEnabled` remain declared-but-unread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)