### PR TITLE
fix(scenegraph): honor per-row layout in LabelList and rotate every node's translation

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -38,11 +38,19 @@ parent above them. Regression: `ClippingRect.test.js`.
 - **Every node positions its drawing through `getDrawTranslation`.** Nothing may compute its own
   `drawTrans` inline — if it did, the clip position could drift from the paint position. `rotateTranslation`
   now appears only in `Group.getDrawTranslation` (plus one unrelated use in `MonospaceLabel`).
-- **`rotatesDrawTranslation()` only selects between two pre-existing behaviors.** 18 renderable types
-  rotate their own translation vector under an inherited angle; `Group` and the keyboard/text-entry
-  containers do not. The two are identical whenever the inherited angle is 0. **NEEDS DEVICE
-  VERIFICATION** — the split looks accidental, and a rotated container places children differently
-  depending on which side it falls on. Preserved deliberately; do not "unify" it without a probe.
+- **An inherited rotation rotates EVERY node type's own translation.** **Device-measured** (Streaming
+  Stick / Roku OS 15.2, probe `out/layout-measure-probe` case `R`): two identical hosts rotated 90° with
+  a child translated `[100, 0]` put the child at the same rotated position whether that child is a
+  `Group` or a `Rectangle`. The engine used to rotate for 18 renderable types but not for `Group` or the
+  keyboard/text-entry containers — a `rotatesDrawTranslation()` hook that this measurement removed. The
+  two behaviors are identical whenever the inherited angle is 0, which is why the split survived so
+  long. Regression: `RotatedTranslation.test.js`.
+
+  **Still open, and NOT the same bug:** a *container's* reported extent under rotation is off. With the
+  translation fixed, a `Group` wrapping a 20×20 marker under a 90°-rotated host reports scene y = 220
+  where the device says 200 — the container's union of a rotated child's *extent* (`updateParentRects`
+  → `rotateRect`) does not account for the child's own rotated bounding box. Only the translation half
+  was fixed; this residual needs its own measurement before anyone touches the union math.
 - **The visibility gates stay inside each `renderNodeContent`.** They differ per node type (soft skip for
   containers, hard skip for renderables, hidden-extent measurement for grids) — see the
   visibility-vs-measurement rule below. Only the cheap `isVisible()` guard on the *push* lives in the

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -532,11 +532,6 @@ export class ArrayGrid extends Group {
         });
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/BusySpinner.ts
+++ b/src/extensions/scenegraph/nodes/BusySpinner.ts
@@ -85,11 +85,6 @@ export class BusySpinner extends Group {
         }
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/Button.ts
+++ b/src/extensions/scenegraph/nodes/Button.ts
@@ -166,11 +166,6 @@ export class Button extends Group {
         this.iconHeight = height;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/ButtonGroup.ts
+++ b/src/extensions/scenegraph/nodes/ButtonGroup.ts
@@ -180,11 +180,6 @@ export class ButtonGroup extends LayoutGroup {
         return handled;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/Dialog.ts
+++ b/src/extensions/scenegraph/nodes/Dialog.ts
@@ -190,11 +190,6 @@ export class Dialog extends Group {
         return handled;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -726,35 +726,26 @@ export class Group extends Node {
     }
 
     /**
-     * This node's draw translation: its own translation composed with the parent-space `origin`.
+     * This node's draw translation: its own translation composed with the parent-space `origin`,
+     * rotated by any inherited angle.
      *
      * Every node must position its own drawing through this method, so the clip `renderNode` pushes
      * can never drift from where the node actually paints.
+     *
+     * DEVICE-MEASURED (Streaming Stick, Roku OS 15.2; probe `out/layout-measure-probe`, case `R`):
+     * an inherited rotation rotates a child's own translation vector for EVERY node type. Two
+     * identical hosts rotated 90° with a child translated [100, 0] put the child at the same rotated
+     * position whether that child was a `Group` or a `Rectangle`. The engine used to rotate for 18
+     * renderable types but not for `Group` or the keyboard/text-entry containers — a split that
+     * looked accidental (#1133 preserved it pending exactly this measurement) and placed a container's
+     * children 100px off under a rotated ancestor.
      */
     protected getDrawTranslation(origin: number[], angle: number): number[] {
         const nodeTrans = this.getTranslation();
-        const drawTrans =
-            angle !== 0 && this.rotatesDrawTranslation() ? rotateTranslation(nodeTrans, angle) : nodeTrans.slice();
+        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
         drawTrans[0] += origin[0];
         drawTrans[1] += origin[1];
         return drawTrans;
-    }
-
-    /**
-     * Whether an inherited (non-zero) rotation also rotates this node's OWN translation vector.
-     *
-     * Renderable nodes return true; `Group` and the keyboard/text-entry containers return false,
-     * which is what they have always done. The two are identical whenever the inherited angle is 0
-     * — i.e. everywhere nothing above the node is rotated — so this only selects between existing
-     * behaviors, it does not introduce one.
-     *
-     * NEEDS DEVICE VERIFICATION: the split looks accidental rather than intended (a rotated
-     * container would place its children differently depending on which of the two groups it falls
-     * in). Preserved as-is here deliberately; settling it needs a rotated-container probe channel,
-     * not a guess.
-     */
-    protected rotatesDrawTranslation(): boolean {
-        return false;
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Label.ts
+++ b/src/extensions/scenegraph/nodes/Label.ts
@@ -69,11 +69,6 @@ export class Label extends Group {
         return this.measured;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/LabelList.ts
+++ b/src/extensions/scenegraph/nodes/LabelList.ts
@@ -112,6 +112,15 @@ export class LabelList extends ArrayGrid {
         let lastIndex = -1;
         const displayRows = Math.min(this.content.length, this.numRows);
         const itemSize = this.getValueJS("itemSize") as number[];
+        // DEVICE-MEASURED (Streaming Stick, Roku OS 15.2): a LabelList DOES honor rowHeights and
+        // rowSpacings, and there is no extra per-row pixel. With rowHeights [100,50,200] and
+        // rowSpacings [10,20] over itemSize.y = 40, the reported extent was 350 + 30 + margins —
+        // i.e. the per-row values, the gaps AFTER each row (the trailing entry dropped), and nothing
+        // else. This loop used to advance by `itemSize[1] + 1`, honoring none of it.
+        const rowHeights = this.getValueJS("rowHeights") as number[];
+        const rowSpacings = this.getValueJS("rowSpacings") as number[];
+        const spacing = this.getValueJS("itemSpacing") as number[];
+        const rowSpacingDefault = Array.isArray(spacing) ? spacing[1] ?? 0 : 0;
         const itemRect = { ...rect, width: itemSize[0], height: itemSize[1] };
         let sectionIndex = displayRows + 1;
         for (let r = 0; r < displayRows; r++) {
@@ -128,14 +137,17 @@ export class LabelList extends ArrayGrid {
                 itemRect.y += this.renderSectionDivider(divText, itemRect, opacity, sectionIndex, draw2D);
                 sectionIndex++;
             }
+            // Per-row overrides are indexed by ABSOLUTE row, top to bottom, falling back to
+            // itemSize.y / itemSpacing.y past the end of each array (never repeating the last entry).
+            itemRect.height = rowHeights[index] ?? itemSize[1];
             this.renderItem(index, item, itemRect, opacity, nodeFocus, focused, draw2D);
-            itemRect.y += itemSize[1] + 1;
+            itemRect.y += itemRect.height + (rowSpacings[index] ?? rowSpacingDefault);
             lastIndex = index;
             if (!RectRect(this.sceneRect, itemRect)) {
                 break;
             }
         }
-        this.updateRect(rect, displayRows, itemSize);
+        this.updateRect(rect, displayRows, itemSize, { firstRow: Math.max(0, this.getRenderRowIndex(0)) });
     }
 
     protected renderItem(

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -146,11 +146,6 @@ export class MultiStyleLabel extends Group {
         return this.measured;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -92,11 +92,6 @@ export class Poster extends Group {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -833,11 +833,6 @@ class PosterGridItem extends Group {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/Rectangle.ts
+++ b/src/extensions/scenegraph/nodes/Rectangle.ts
@@ -19,11 +19,6 @@ export class Rectangle extends Group {
         this.registerInitializedFields(initializedFields);
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -143,11 +143,6 @@ export class ScrollableText extends Group {
         return handled;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/SimpleLabel.ts
+++ b/src/extensions/scenegraph/nodes/SimpleLabel.ts
@@ -76,11 +76,6 @@ export class SimpleLabel extends Group {
         return this.measured;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/StandardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardDialog.ts
@@ -478,11 +478,6 @@ export class StandardDialog extends Group {
         );
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     /**
      * Settles the dialog's own position before the render template derives a draw translation from
      * it. `layoutStandardDialog` assigns THIS node's `translation` (it centers the dialog), so it has

--- a/src/extensions/scenegraph/nodes/StdDlgActionCardItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgActionCardItem.ts
@@ -161,11 +161,6 @@ export class StdDlgActionCardItem extends Group implements StdDlgItem {
         this.icon.setValueSilent("visible", BrsBoolean.from(uri !== ""));
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/StdDlgDeterminateProgressItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgDeterminateProgressItem.ts
@@ -101,11 +101,6 @@ export class StdDlgDeterminateProgressItem extends Group implements StdDlgItem {
         return y;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/StdDlgProgressItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgProgressItem.ts
@@ -48,11 +48,6 @@ export class StdDlgProgressItem extends Group implements StdDlgItem {
         return height;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/TargetGroup.ts
+++ b/src/extensions/scenegraph/nodes/TargetGroup.ts
@@ -165,11 +165,6 @@ export class TargetGroup extends Group {
         return (this.getValueJS("defaultTargetSetFocusIndex") as number) ?? 0;
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -754,11 +754,6 @@ export class Video extends Group {
         }
     }
 
-    /** Renderable node: an inherited rotation also rotates its own translation vector. */
-    protected rotatesDrawTranslation(): boolean {
-        return true;
-    }
-
     protected renderNodeContent(
         interpreter: Interpreter,
         origin: number[],

--- a/test/extensions/scenegraph/RotatedTranslation.test.js
+++ b/test/extensions/scenegraph/RotatedTranslation.test.js
@@ -1,0 +1,94 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, Float, RoArray, Interpreter } = core;
+
+const vector = (values) => new RoArray(values.map((v) => new Float(v)));
+const HALF_PI = 1.5708;
+
+/**
+ * DEVICE-MEASURED (Streaming Stick, Roku OS 15.2) via `out/layout-measure-probe`, case `R`.
+ *
+ * An inherited rotation rotates a child's OWN translation vector, for every node type. Two identical
+ * hosts rotated 90° with a child translated [100, 0] put the child at the same rotated position
+ * whether that child is a `Group` or a `Rectangle`.
+ *
+ * The engine used to rotate for 18 renderable types but not for `Group` or the keyboard/text-entry
+ * containers — #1133 preserved that split deliberately, pending exactly this measurement, because the
+ * two are indistinguishable whenever the inherited angle is 0.
+ */
+describe("an inherited rotation rotates every node type's own translation", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("Group and Rectangle compose the same draw translation under an inherited angle", () => {
+        // The precise behavior that changed. Node type must not affect the answer.
+        const group = SGNodeFactory.createNode("Group");
+        group.setValue("translation", vector([100, 0]));
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("translation", vector([100, 0]));
+
+        const groupTrans = group.getDrawTranslation([0, 0], HALF_PI);
+        const rectTrans = rect.getDrawTranslation([0, 0], HALF_PI);
+
+        expect(groupTrans[0]).toBeCloseTo(rectTrans[0], 3);
+        expect(groupTrans[1]).toBeCloseTo(rectTrans[1], 3);
+        // Rotating [100, 0] by 90° moves it onto the vertical axis: x → ~0, y → ~-100.
+        expect(groupTrans[0]).toBeCloseTo(0, 2);
+        expect(groupTrans[1]).toBeCloseTo(-100, 2);
+    });
+
+    test("the keyboard/text-entry containers rotate too", () => {
+        // These were the other side of the removed split, alongside Group.
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("translation", vector([100, 0]));
+        const expected = rect.getDrawTranslation([0, 0], HALF_PI);
+
+        for (const type of ["Keyboard", "MiniKeyboard", "PinPad", "TextEditBox"]) {
+            const node = SGNodeFactory.createNode(type);
+            node.setValue("translation", vector([100, 0]));
+            const trans = node.getDrawTranslation([0, 0], HALF_PI);
+            expect(trans[0]).toBeCloseTo(expected[0], 3);
+            expect(trans[1]).toBeCloseTo(expected[1], 3);
+        }
+    });
+
+    test("an unrotated ancestor is unaffected (the two behaviors were identical at angle 0)", () => {
+        // Guard against over-correcting: this is why the split went unnoticed for so long.
+        const group = SGNodeFactory.createNode("Group");
+        group.setValue("translation", vector([100, 25]));
+        expect(group.getDrawTranslation([10, 5], 0)).toEqual([110, 30]);
+    });
+
+    test("a Rectangle child of a rotated host lands where the device put it", () => {
+        // Device: host [900,320] rotated 90°, child translated [100,0] → scene rect {x=900, y=200}.
+        const host = SGNodeFactory.createNode("Group");
+        host.setValue("translation", vector([900, 320]));
+        host.setValue("rotation", new Float(HALF_PI));
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("translation", vector([100, 0]));
+        child.setValue("width", new Float(20));
+        child.setValue("height", new Float(20));
+        host.appendChildToParent(child);
+
+        const rect = child.getBoundingRect("toScene", interpreter);
+
+        expect(Math.round(rect.x)).toBe(900);
+        expect(Math.round(rect.y)).toBe(200);
+    });
+});

--- a/test/extensions/scenegraph/VariableRowMeasure.test.js
+++ b/test/extensions/scenegraph/VariableRowMeasure.test.js
@@ -149,3 +149,85 @@ describe("boundingRect honors per-row and per-column overrides", () => {
 // (`customNodeExists`), which a unit test cannot construct — covering the loop needs a CLI fixture
 // app. The measurement above and the loop now read the same absolute index, so a future divergence
 // between them shows up as a measurement failure.
+
+/**
+ * DEVICE-MEASURED (Streaming Stick, Roku OS 15.2) via `out/layout-measure-probe`, case `L`.
+ *
+ * A LabelList DOES honor rowHeights and rowSpacings, and there is no extra per-row pixel. With
+ * rowHeights [100,50,200] and rowSpacings [10,20] over itemSize.y = 40 the device reported an extent
+ * of 350 + 30 + margins — the per-row heights, the gaps AFTER each row (trailing entry dropped), and
+ * nothing else. Its render loop used to advance by `itemSize.y + 1`, honoring none of that, which left
+ * it MEASURING per-row heights (since #1134) while DRAWING uniform rows.
+ */
+describe("LabelList lays rows out from rowHeights/rowSpacings", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /** Records the rect each row is actually drawn into, by intercepting renderItem. */
+    function renderRows(list) {
+        const rows = [];
+        const original = list.renderItem.bind(list);
+        list.renderItem = (index, item, itemRect, opacity, nodeFocus, focused, draw2D) => {
+            rows.push({ index, y: Math.round(itemRect.y), height: Math.round(itemRect.height) });
+            return original(index, item, itemRect, opacity, nodeFocus, focused, draw2D);
+        };
+        list.renderNode({}, [0, 0], 0, 1);
+        list.renderItem = original;
+        return rows;
+    }
+
+    function makeList(rowCount) {
+        const list = SGNodeFactory.createNode("LabelList");
+        const root = SGNodeFactory.createNode("ContentNode");
+        for (let i = 0; i < rowCount; i++) {
+            const item = SGNodeFactory.createNode("ContentNode");
+            item.setValue("title", new BrsString("R" + i));
+            root.appendChildToParent(item);
+        }
+        list.setValue("itemSize", vector([300, 40]));
+        list.setValue("numRows", new Int32(rowCount));
+        list.setValue("content", root);
+        return list;
+    }
+
+    test("rows advance by rowHeights plus rowSpacings, not by itemSize.y", () => {
+        const list = makeList(3);
+        list.setValue("rowHeights", vector([100, 50, 200]));
+        list.setValue("rowSpacings", vector([10, 20]));
+
+        const rows = renderRows(list);
+
+        expect(rows.map((r) => r.height)).toEqual([100, 50, 200]);
+        // Row 0 at 0; row 1 at 100 + 10; row 2 at 110 + 50 + 20.
+        expect(rows.map((r) => r.y)).toEqual([0, 110, 180]);
+    });
+
+    test("rows past the end of the arrays fall back to itemSize.y and itemSpacing.y", () => {
+        const list = makeList(4);
+        list.setValue("itemSpacing", vector([0, 5]));
+        list.setValue("rowHeights", vector([100]));
+        list.setValue("rowSpacings", vector([10]));
+
+        const rows = renderRows(list);
+
+        expect(rows.map((r) => r.height)).toEqual([100, 40, 40, 40]);
+        // 0; 100+10; 110+40+5; 155+40+5.
+        expect(rows.map((r) => r.y)).toEqual([0, 110, 155, 200]);
+    });
+
+    test("a plain list advances by exactly itemSize.y with no extra pixel", () => {
+        // The device's no-override extent decomposes with zero inter-row spacing, so the engine's
+        // undocumented `itemSize.y + 1` was wrong.
+        const list = makeList(3);
+
+        const rows = renderRows(list);
+
+        expect(rows.map((r) => r.y)).toEqual([0, 40, 80]);
+    });
+});


### PR DESCRIPTION
Both device-measured on a **Streaming Stick, Roku OS 15.2** (probe channel: `out/layout-measure-probe`). Two independent findings, one commit each half.

## 1. `LabelList` honors `rowHeights` / `rowSpacings` — and has no `+1`

Device, `rowHeights=[100,50,200]` + `rowSpacings=[10,20]` over `itemSize.y = 40`:

```
with-overrides  h=416  =  350 (Σ rowHeights) + 30 (gaps after rows 0,1) + 36 (3 rows × 2 × marginY)
no-overrides    h=156  =  120                + 0                        + 36
```

Both decompose exactly. So the per-row arrays **are** honored, the gap after the last row is dropped, and there is **no extra per-row pixel**.

The render loop advanced by `itemSize[1] + 1`, honoring none of it. That mattered more after #1134: making `updateRect` read the same arrays left the list **measuring** per-row heights while **drawing** uniform rows — `boundingRect()` over-reported by ~3× for any list that set `rowHeights`. I flagged that coherence bug when the probe was built and deliberately left the fix direction open; the device answers it — fix the loop, don't gate the measurement.

## 2. An inherited rotation rotates **every** node type's translation

Two identical hosts rotated 90° with a child translated `[100, 0]`:

| | device | engine before |
| --- | --- | --- |
| `Group` child | `{x=600 y=200}` | `{x=700 y=320}` — **not rotated** |
| `Rectangle` child | `{x=900 y=200}` | `{x=900 y=200}` — rotated |

Both device rows agree with each other. The engine rotated for 18 renderable types but not for `Group` or the keyboard/text-entry containers, so a container's children landed 100px off under a rotated ancestor.

#1133 introduced `rotatesDrawTranslation()` to *preserve* that split deliberately, flagged **"NEEDS DEVICE VERIFICATION"**, precisely because the two behaviors are identical whenever the inherited angle is 0. The measurement is in, so the hook and its 18 overrides are gone — `getDrawTranslation` always rotates.

## Not fixed — and not the same bug

With the translation corrected, a `Group` wrapping a 20×20 marker under a 90° host reports scene `y=220` where the device says `200`. That residual is the container's union of a **rotated child's extent** (`updateParentRects` → `rotateRect`) not accounting for the child's own rotated bounding box — a different computation from the translation this PR fixes. It needs its own measurement, so **no test pins the current value** and it is recorded in the invariants doc instead.

## Testing

Seven new tests; **five fail on the parent commit** for the right reason:

```
Group and Rectangle compose the same draw translation    expected 100 to be close to -0.0003
the keyboard/text-entry containers rotate too            expected 100 to be close to -0.0003
rows advance by rowHeights plus rowSpacings              expected [40,40,40] to equal [100,50,200]
rows past the end fall back to itemSize.y                expected [40,40,40,40] to equal [100,40,40,40]
a plain list advances by exactly itemSize.y (no +1)      expected [0,41,82] to equal [0,40,80]
```

The other two pass on both, as guards against over-correcting: an *unrotated* ancestor is unaffected (the reason the split went unnoticed), and a `Rectangle` child of a rotated host still lands at the device position.

`LabelList`'s row layout is observed by intercepting `renderItem` — it draws labels itself, so there are no item components to hook.

Full suite green: **2441 passed / 196 files**. Lint, prettier and `tsc` clean.

## Also cleared by the same probe

**`clippingRect` does not participate in `renderTracking`.** Device reports `full / full / none` — identical to the engine — for a node fully inside a `clippingRect` parked entirely off screen. The reference says it "could be set to `none`"; this device doesn't. No change needed, recorded so nobody implements it from the docs.

## Still open

`PosterGrid`'s short-spacing-array behavior was **inconclusive** in that run — the reported rect decomposed into neither candidate, because poster size, focus margins and gap spacing were all unknown at once and the fixture used two rows. A focused replacement is ready at **`out/postergrid-spacing-probe`**: five single-row cases that solve margins, `basePosterSize` vs `columnWidths`, and the plain-`itemSpacing` gap in order, leaving exactly one unknown by the discriminating case (the two answers are 40px apart). Engine baseline decodes cleanly; awaiting a device run.

Separately, the device's `LabelList` marginY is **6** where the engine uses **4** (marginX matches at 24). Not addressed here — `LabelList` inherits `ArrayGrid`'s HD margins, which `RowList` already overrides for itself, so changing the shared default would touch `MarkupList`/`PosterGrid` untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)