### PR TITLE
fix(scenegraph): match a device's PosterGrid extent

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -397,6 +397,47 @@ already did), and `pause` leaves each child's own `state` reading `paused`.
 Regression: `test/extensions/scenegraph/AnimationControl.test.js`. Note the `resume` test asserts the
 *paused precondition* first — without pause propagation the children were never paused, so "they run
 after resume" would pass vacuously.
+## `PosterGrid` extent — asymmetric axes, trailing gaps, fall-back spacing
+
+**Device-measured** (Streaming Stick / Roku OS 15.2, HD 1280x720; probes `out/postergrid-spacing-probe`
+and `out/postergrid-rows-probe`, each fixture isolating one unknown). The engine reproduces every
+width and every x/y offset exactly:
+
+```
+width  = Σ over ALL N cols of (basePosterSize.x + colSpacing_i) + 2*marginX    columnWidths IGNORED
+height = Σ over ALL N rows of (rowHeight_i      + rowSpacing_i) + 2*marginY    rowHeights HONORED
+spacing_i = (column|row)Spacings[i] ?? itemSpacing.(x|y)
+marginX = marginY = 14 (HD)
+```
+
+Four rules, each of which the engine had wrong:
+
+1. **Short spacing arrays fall back to `itemSpacing`, they do not repeat the last entry.**
+   `columnSpacings=[10]` across 3 columns measured 438 (`10 + 50 + 50`); repeating would have given
+   358. Note `LayoutGroup.itemSpacings` **is** device-confirmed to repeat — the two genuinely differ,
+   which is why this was measured rather than reasoned by analogy. Watch the *fallback value* too: it
+   is `itemSpacing`, not the array's first entry (the old `defaultColumnSpacing` derived from
+   `columnSpacings[0]`, which silently made short arrays behave like a repeat).
+2. **The gap AFTER the last track counts**, on both axes — matching the reference's "the spacing after
+   each row" wording. 3 columns of 100 at `itemSpacing.x = 50` measure 478, not 428.
+3. **The axes are NOT symmetric.** `columnWidths` is **ignored** (cell width always comes from
+   `basePosterSize.x`) while `rowHeights` **is** honored. Do not unify them into one helper.
+4. **`rectMargins` is 14/14**, not `ArrayGrid`'s shared 24/4. The FHD value (21) is *inferred* from the
+   standard 1.5× design-resolution scale, **not measured**.
+
+**Related general fix:** `Group.updateBoundingRects` built `rectToParent` from the node's *translation*,
+discarding `drawRect.x/y`. Identical for an ordinary node, but a grid's `updateRect` outsets `drawRect`
+by its focus margins — and a device reports that outset — so a grid's reported rect had the widened
+width/height with un-offset x/y. It now derives the position from `drawRect` too.
+
+**Still divergent — the caption zone.** A device reserves a base zone below the poster even with
+`caption1NumLines = 0`: a 100-tall poster yields a 136-tall cell (+36), and one caption line makes it
+168 (+32/line). The engine reserves 0 with no lines and 44 with one. So PosterGrid heights are ~36
+short of a device. This is **not** the empty-caption background — setting
+`showBackgroundForEmptyCaptions = false` changed nothing on device, which killed that hypothesis. The
+mechanism is unknown, only HD was measured, and two data points cannot model ≥2 lines, so it is
+deliberately unfixed rather than approximated with a constant (a flat +36 would over-correct the
+one-caption case, where the engine's line height is already 12 too tall).
 
 ## `ArrayGrid.scrollingStatus` — a lazy pulse, ordered ahead of the focus settle
 

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -430,6 +430,28 @@ discarding `drawRect.x/y`. Identical for an ordinary node, but a grid's `updateR
 by its focus margins — and a device reports that outset — so a grid's reported rect had the widened
 width/height with un-offset x/y. It now derives the position from `drawRect` too.
 
+**All three coordinate spaces have to move together.** `rectLocal` stayed at `{0,0}` in the first cut,
+so `localBoundingRect()`/`localSubBoundingRect()` disagreed with the parent and scene rects by the
+margin (`Node.getSubBoundingRect` bases its `"local"` variant on `rectLocal`). Local is parent-space
+minus the node's own translation; fixing two of three spaces is worse than fixing none, because the
+disagreement is silent.
+
+**`Overhang` was the one node not positioning through `getDrawTranslation`** — it built its rect from
+`origin` alone and passed `origin` to its children, ignoring its own `translation`. That made the
+general fix above report `{0,0}` for a translated Overhang (previously `{30,40}` from the translation
+path, which disagreed with where it actually painted). It now uses `getDrawTranslation` like every
+other node, so its paint position and its reported rect agree. Regression: `OverhangLayout.test.js`.
+
+**Per-track arrays: `rowHeights` follows the same fall-back rule as the spacing arrays.** It used to
+resolve through `ArrayGrid.resolveNumber`, which *repeats* the last entry — so `rowHeights=[200]` over
+3 rows measured `3 x 200` instead of `200 + 100 + 100`. `resolveNumber` itself is left alone:
+`ZoomRowList` depends on it and its behavior there is unmeasured.
+
+**The trailing gap belongs to the reported extent, not to drawn geometry.** `computeRowWidth` feeds
+both the reported width and the section/wrap divider rect; letting the trailing gap into the divider
+drew it past the last poster's right edge. The divider takes the content-only width
+(`includeTrailingGap: false`).
+
 **Still divergent — the caption zone.** A device reserves a base zone below the poster even with
 `caption1NumLines = 0`: a 100-tall poster yields a 136-tall cell (+36), and one caption line makes it
 168 (+32/line). The engine reserves 0 with no lines and 44 with one. So PosterGrid heights are ~36

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -980,7 +980,7 @@ export class ArrayGrid extends Group {
      * end of the array falls back to the `itemSize`/`itemSpacing` value — it does NOT repeat the last
      * entry (unlike `LayoutGroup.itemSpacings`, which is device-confirmed to repeat).
      */
-    private resolveTrackValue(values: unknown, index: number, fallback: number): number {
+    protected resolveTrackValue(values: unknown, index: number, fallback: number): number {
         if (!Array.isArray(values)) {
             return fallback;
         }

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -617,6 +617,16 @@ export class Group extends Node {
         const nodeTrans = this.getTranslation();
         this.rectLocal = { x: 0, y: 0, width: drawRect.width, height: drawRect.height };
         if (rotation === 0) {
+            // Local space must agree with the parent/scene rects below: a grid's drawRect is outset
+            // by its focus margins, and local is parent-space minus the node's own translation. Left
+            // at {0,0} this reported a local sub-rect offset by the margin on both axes
+            // (Node.getSubBoundingRect bases the "local" variant on rectLocal).
+            this.rectLocal = {
+                x: drawRect.x - origin[0] - nodeTrans[0],
+                y: drawRect.y - origin[1] - nodeTrans[1],
+                width: drawRect.width,
+                height: drawRect.height,
+            };
             this.rectToScene = drawRect;
             // Parent-relative position comes from the DRAW rect, not from the node's translation.
             // The two are the same for an ordinary node, but a grid's updateRect outsets drawRect by

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -618,9 +618,15 @@ export class Group extends Node {
         this.rectLocal = { x: 0, y: 0, width: drawRect.width, height: drawRect.height };
         if (rotation === 0) {
             this.rectToScene = drawRect;
+            // Parent-relative position comes from the DRAW rect, not from the node's translation.
+            // The two are the same for an ordinary node, but a grid's updateRect outsets drawRect by
+            // its focus margins — and a device reports that outset. Reading nodeTrans here dropped it,
+            // so a grid's reported rect had the widened width/height but the un-offset x/y.
+            // DEVICE-MEASURED: a PosterGrid at translation [0,320] reports y=306 (a 14px outset), and
+            // a LabelList at [0,0] reports x=-24.
             this.rectToParent = {
-                x: nodeTrans[0],
-                y: nodeTrans[1],
+                x: drawRect.x - origin[0],
+                y: drawRect.y - origin[1],
                 width: drawRect.width,
                 height: drawRect.height,
             };

--- a/src/extensions/scenegraph/nodes/Overhang.ts
+++ b/src/extensions/scenegraph/nodes/Overhang.ts
@@ -241,10 +241,15 @@ export class Overhang extends Group {
             this.alignChildren();
         }
         const size = this.getDimensions();
-        const rect = { x: origin[0], y: origin[1], width: size.width, height: size.height };
+        // Position through getDrawTranslation like every other node: this used to build its rect from
+        // `origin` alone and pass `origin` to its children, ignoring its own translation entirely — so
+        // a translated Overhang painted at the wrong place, and its reported rect (which came from the
+        // node translation) disagreed with where it drew.
+        const drawTrans = this.getDrawTranslation(origin, angle);
+        const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         opacity = opacity * this.getOpacity();
         this.updateBoundingRects(rect, origin, angle);
-        this.renderChildren(interpreter, origin, angle, opacity, draw2D);
+        this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 }

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -248,9 +248,15 @@ export class PosterGrid extends ArrayGrid {
                 break;
             }
             const rowNumber = Math.floor(rowIndex / this.numCols);
-            const posterHeight = this.resolveNumber(rowHeights, rowNumber, baseSize[1]);
+            // resolveTrackValue, not resolveNumber: a row past the end of `rowHeights` falls back
+            // to basePosterSize.y rather than repeating the array's last entry, matching the rule the
+            // spacing arrays follow. (resolveNumber still repeats and is left alone — ZoomRowList
+            // depends on it and its behavior is unmeasured.)
+            const posterHeight = this.resolveTrackValue(rowHeights, rowNumber, baseSize[1]);
             const rowCaptionHeight = captionsExtendLayout ? this.computeRowCaptionHeight(rowIndex, placement) : 0;
-            const rowWidth = this.computeRowWidth(columnWidths, columnSpacings);
+            // Content-only width: the trailing gap belongs to the REPORTED extent (device-measured),
+            // not to the drawn section/wrap divider, which would otherwise extend past the last poster.
+            const rowWidth = this.computeRowWidth(columnWidths, columnSpacings, false);
             const rowHeightWithCaptions = posterHeight + rowCaptionHeight;
             itemRect.height = rowHeightWithCaptions;
             if (!hasSections && this.wrap && rowIndex < lastRowIndex && r > 0) {
@@ -304,13 +310,13 @@ export class PosterGrid extends ArrayGrid {
             lastRowIndex = rowIndex;
             lastRowNumber = rowNumber;
             renderedRows++;
-            if (itemRect.y > (this.sceneRect?.y ?? 0) + (this.sceneRect?.height ?? 0)) {
-                // Broke on the scene edge: count the row itself, but no gap was added after it.
-                itemRect.y += rowHeightWithCaptions;
-                break;
-            }
+            // Advance identically on both exits: the gap after the LAST row counts toward the
+            // extent, so breaking on the scene edge must not silently drop it.
             const rowGap = this.resolveSpacingValue(rowSpacingValues, rowNumber, baseRowSpacing);
             itemRect.y += rowHeightWithCaptions + rowGap;
+            if (itemRect.y > (this.sceneRect?.y ?? 0) + (this.sceneRect?.height ?? 0)) {
+                break;
+            }
         }
         // Explicit extents, both including the focus outset the arithmetic path would otherwise add
         // per track (these values are the whole reported rect, not just the content).
@@ -667,8 +673,12 @@ export class PosterGrid extends ArrayGrid {
      * 100 with `itemSpacing.x = 50` measured 478 (3 x 100 + 3 x 50 + margins), not 428. That matches
      * the reference's wording for the sibling field ("the spacing after each row").
      */
-    private computeRowWidth(widths: number[], spacings: number[]) {
-        return widths.reduce((acc, width, index) => acc + width + (spacings[index] ?? 0), 0);
+    private computeRowWidth(widths: number[], spacings: number[], includeTrailingGap: boolean = true) {
+        return widths.reduce((acc, width, index) => {
+            const isLast = index === widths.length - 1;
+            const gap = isLast && !includeTrailingGap ? 0 : spacings[index] ?? 0;
+            return acc + width + gap;
+        }, 0);
     }
 
     private computeRowCaptionHeight(rowIndex: number, placement: string) {

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -117,6 +117,20 @@ export class PosterGrid extends ArrayGrid {
         this.defaultCaptionBackgroundUri = `common:/images/${this.resolution}/caption_background.9.png`;
     }
 
+    /**
+     * Per-axis outset the reported bounding rect adds around the laid-out extent.
+     *
+     * DEVICE-MEASURED (Streaming Stick, Roku OS 15.2, HD 1280x720): a one-column one-row PosterGrid
+     * with `basePosterSize=[100,100]` reports `{x:-14, y:-14, w:128, h:...}` — a 14px outset on both
+     * axes, where ArrayGrid's shared default would give 24/4. The FHD value is NOT measured; 21 is
+     * the standard 1.5x design-resolution scale the other grid margins use (24->36), so it is an
+     * inference, not a measurement.
+     */
+    protected rectMargins(): { x: number; y: number } {
+        const margin = this.resolution === "FHD" ? 21 : 14;
+        return { x: margin, y: margin };
+    }
+
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
         const fieldName = index.toLowerCase();
         if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
@@ -208,7 +222,10 @@ export class PosterGrid extends ArrayGrid {
         const fixedFocusMode = this.isFixedFocusMode();
         this.currRow = fixedFocusMode ? this.updateCurrRow() : this.updateListCurrRow();
         const columnWidths = this.resolveColumnWidths(baseSize[0]);
-        const columnSpacings = this.resolveColumnSpacings(defaultColumnSpacing, columnSpacingValues);
+        // DEVICE-MEASURED: a column past the end of `columnSpacings` falls back to `itemSpacing.x`,
+        // NOT to the array's first entry (which is what `defaultColumnSpacing` holds — it stays for
+        // inferColumnCount, a separate "how many columns fit" heuristic).
+        const columnSpacings = this.resolveColumnSpacings(baseColumnSpacing, columnSpacingValues);
         const rowHeights = this.getValueJS("rowHeights") as number[];
         const rowSpacingValues = this.getValueJS("rowSpacings");
         const hasSections = this.metadata.length > 0;
@@ -225,7 +242,6 @@ export class PosterGrid extends ArrayGrid {
         // wrap/section dividers, which also advance itemRect.y, are counted.
         const startY = itemRect.y;
         let renderedRows = 0;
-        let trailingGap = 0;
         for (let r = 0; r < displayRows; r++) {
             const rowIndex = this.getRenderRowIndex(r);
             if (rowIndex < 0 || rowIndex >= contentLength) {
@@ -288,21 +304,25 @@ export class PosterGrid extends ArrayGrid {
             lastRowIndex = rowIndex;
             lastRowNumber = rowNumber;
             renderedRows++;
-            trailingGap = this.resolveSpacingValue(rowSpacingValues, rowNumber, baseRowSpacing);
             if (itemRect.y > (this.sceneRect?.y ?? 0) + (this.sceneRect?.height ?? 0)) {
+                // Broke on the scene edge: count the row itself, but no gap was added after it.
                 itemRect.y += rowHeightWithCaptions;
-                trailingGap = 0;
                 break;
             }
             const rowGap = this.resolveSpacingValue(rowSpacingValues, rowNumber, baseRowSpacing);
             itemRect.y += rowHeightWithCaptions + rowGap;
         }
-        // Explicit extents: the accumulated height (caption zones included) and the row width the
-        // layout already computes per row — the old `Math.max(...columnWidths) * numCols` ignored both
-        // per-column widths and column spacing.
-        const height = renderedRows === 0 ? 0 : itemRect.y - startY - trailingGap;
+        // Explicit extents, both including the focus outset the arithmetic path would otherwise add
+        // per track (these values are the whole reported rect, not just the content).
+        //
+        // DEVICE-MEASURED: the gap AFTER the last row counts, exactly as it does after the last
+        // column — 3 rows of 100 with `itemSpacing.y = 50` measured 3 x 100 + 3 x 50 + margins, not
+        // 2 gaps. So the loop's accumulated `itemRect.y` is used as-is, with nothing backed out (the
+        // early-break path above adds the row height without a gap, so it needs no adjustment).
+        const margin = this.rectMargins();
+        const height = renderedRows === 0 ? 0 : itemRect.y - startY + margin.y * 2;
         this.updateRect(rect, displayRows, [Math.max(...columnWidths), maxCellHeight || baseSize[1]], {
-            width: this.computeRowWidth(columnWidths, columnSpacings),
+            width: this.computeRowWidth(columnWidths, columnSpacings) + margin.x * 2,
             height,
         });
     }
@@ -600,13 +620,17 @@ export class PosterGrid extends ArrayGrid {
         return Math.max(1, Math.floor(available / step));
     }
 
+    /**
+     * Column widths, all taken from `basePosterSize.x`.
+     *
+     * DEVICE-MEASURED: PosterGrid **ignores** the inherited ArrayGrid `columnWidths` field — a
+     * single-column grid with `basePosterSize=[100,100]` measured the same 128 whether or not
+     * `columnWidths=[200]` was set. Note the axes are NOT symmetric here: `rowHeights` IS honored
+     * (a 3-row grid with `rowHeights=[200,50,100]` measured those heights), so do not "unify" these
+     * two into one helper.
+     */
     private resolveColumnWidths(defaultWidth: number) {
-        const values = this.getValueJS("columnWidths");
-        const result: number[] = [];
-        for (let i = 0; i < this.numCols; i++) {
-            result.push(this.resolveNumber(values, i, defaultWidth));
-        }
-        return result;
+        return new Array(this.numCols).fill(defaultWidth);
     }
 
     private resolveColumnSpacings(defaultSpacing: number, values?: any) {
@@ -618,20 +642,33 @@ export class PosterGrid extends ArrayGrid {
         return result;
     }
 
+    /**
+     * Resolves one entry of `columnSpacings`/`rowSpacings`.
+     *
+     * DEVICE-MEASURED (Streaming Stick, Roku OS 15.2; probes `out/postergrid-spacing-probe` and
+     * `out/postergrid-rows-probe`): an index past the end of the array falls back to
+     * `itemSpacing.x`/`.y`. It does NOT repeat the last entry, which is what this used to do —
+     * `columnSpacings=[10]` across 3 columns measured 438 on device (10 + 50 + 50), where repeating
+     * would have given 358. Note `LayoutGroup.itemSpacings` IS device-confirmed to repeat, so the
+     * two genuinely differ; that is why this was measured rather than assumed.
+     */
     private resolveSpacingValue(values: any, index: number, fallback: number) {
-        if (!Array.isArray(values) || values.length === 0) {
+        if (!Array.isArray(values) || index >= values.length) {
             return fallback;
         }
-        const selected = index < values.length ? values[index] : values.at(-1);
-        const parsed = Number(selected);
+        const parsed = Number(values[index]);
         return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
     }
 
+    /**
+     * Laid-out width of one row: every column's width plus its own trailing gap.
+     *
+     * DEVICE-MEASURED: the gap AFTER the last column is part of the reported extent — 3 columns of
+     * 100 with `itemSpacing.x = 50` measured 478 (3 x 100 + 3 x 50 + margins), not 428. That matches
+     * the reference's wording for the sibling field ("the spacing after each row").
+     */
     private computeRowWidth(widths: number[], spacings: number[]) {
-        return widths.reduce((acc, width, index) => {
-            const spacing = index < widths.length - 1 ? spacings[index] ?? 0 : 0;
-            return acc + width + spacing;
-        }, 0);
+        return widths.reduce((acc, width, index) => acc + width + (spacings[index] ?? 0), 0);
     }
 
     private computeRowCaptionHeight(rowIndex: number, placement: string) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -955,10 +955,16 @@ describe.concurrent("cli", () => {
         // stacked position). subBoundingRect must refresh layout when a focus change is pending so it
         // reports the settled band position — matching a real device where the observer fires
         // post-layout. Without the refresh, row 1 reads its stacked y (band + one row height).
+        //
+        // The absolute y includes the grid's focus outset (RowList marginY), which the reported rect
+        // now carries: Group.updateBoundingRects used to build rectToParent from the node's
+        // translation and drop the outset that updateRect applies. A device does report it —
+        // measured on LabelList (x=-24) and PosterGrid (x=-14, y=-14). Both rows moved by the same
+        // 4px, so the invariant this test exists for ("SAME BAND") is unchanged.
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== RowList SubRect Repro ===",
-            "band row0 y = -15",
-            "focused row1 y = -15",
+            "band row0 y = -19",
+            "focused row1 y = -19",
             "SAME BAND: true",
             "=== RowList SubRect Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",

--- a/test/extensions/scenegraph/OverhangLayout.test.js
+++ b/test/extensions/scenegraph/OverhangLayout.test.js
@@ -1,0 +1,57 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, Float, RoArray, Interpreter } = core;
+
+const vector = (values) => new RoArray(values.map((v) => new Float(v)));
+
+/**
+ * Every node positions its own drawing through `Group.getDrawTranslation` — that is what keeps a
+ * node's clippingRect, its paint position and its reported rect from drifting apart (see the
+ * rendering contract in `.claude/docs/scenegraph-invariants.md`).
+ *
+ * `Overhang` was the one node that did not: it built its draw rect from `origin` alone and passed
+ * `origin` straight to its children, ignoring its own `translation`. A translated Overhang therefore
+ * painted in the wrong place, and its reported rect (which came from the node translation) disagreed
+ * with where it actually drew.
+ */
+describe("Overhang honors its own translation", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("a translated Overhang reports its translation", () => {
+        const overhang = SGNodeFactory.createNode("Overhang");
+        overhang.setValue("translation", vector([30, 40]));
+
+        overhang.renderNode(interpreter, [0, 0], 0, 1);
+
+        // Before the fix this reported {0, 0}: the draw rect was built from `origin` alone, and
+        // rectToParent now derives from that draw rect.
+        const rect = overhang.getBoundingRect("toParent", interpreter);
+        expect(Math.round(rect.x)).toBe(30);
+        expect(Math.round(rect.y)).toBe(40);
+    });
+
+    test("an untranslated Overhang is unchanged", () => {
+        const overhang = SGNodeFactory.createNode("Overhang");
+        overhang.renderNode(interpreter, [0, 0], 0, 1);
+        const rect = overhang.getBoundingRect("toParent", interpreter);
+        expect(Math.round(rect.x)).toBe(0);
+        expect(Math.round(rect.y)).toBe(0);
+    });
+});

--- a/test/extensions/scenegraph/PosterGridExtent.test.js
+++ b/test/extensions/scenegraph/PosterGridExtent.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, Int32, Float, RoArray, Interpreter } = core;
+const { BrsDevice, BrsString, Int32, Float, RoArray, Interpreter } = core;
 
 const vector = (values) => new RoArray(values.map((v) => new Float(v)));
 
@@ -151,5 +151,66 @@ describe("PosterGrid reports the extent a device reports", () => {
             itemSpacing: vector([0, 0]),
         });
         expect(Math.round(rectOf(noArray).height) - Math.round(rectOf(noSpacing).height)).toBe(150);
+    });
+
+    test("rowHeights past the end of the array falls back, it does not repeat", () => {
+        // The same rule the spacing arrays follow. `rowHeights=[200]` over 3 rows is
+        // 200 + 100 + 100, not 3 x 200 — the latter is what repeating the last entry gives.
+        const grid = makeGrid(3, {
+            numColumns: new Int32(1),
+            numRows: new Int32(3),
+            itemSpacing: vector([0, 0]),
+            rowHeights: vector([200]),
+        });
+        expect(Math.round(rectOf(grid).height)).toBe(200 + 100 + 100 + 28);
+    });
+
+    test("local, parent and scene rects agree once the focus outset is applied", () => {
+        // The outset lives in the draw rect, so all three coordinate spaces have to carry it.
+        // Local is parent-space minus the node's own translation.
+        const grid = makeGrid(1, {
+            numColumns: new Int32(1),
+            numRows: new Int32(1),
+            itemSpacing: vector([0, 0]),
+            translation: vector([0, 320]),
+        });
+        const parent = grid.getBoundingRect("toParent", interpreter);
+        const local = grid.getBoundingRect("local", interpreter);
+        expect(Math.round(parent.x)).toBe(-14);
+        expect(Math.round(parent.y)).toBe(306);
+        expect(Math.round(local.x)).toBe(-14);
+        expect(Math.round(local.y)).toBe(-14);
+        expect(Math.round(local.x)).toBe(Math.round(parent.x) - 0);
+        expect(Math.round(local.y)).toBe(Math.round(parent.y) - 320);
+    });
+
+    test("a section divider is drawn at the content width, without the trailing gap", () => {
+        // The trailing gap is device-backed for the REPORTED extent only. Letting it into the drawn
+        // divider would run it 50px past the last poster's right edge.
+        const grid = SGNodeFactory.createNode("PosterGrid");
+        grid.setValue("basePosterSize", vector([100, 100]));
+        grid.setValue("numColumns", new Int32(3));
+        grid.setValue("numRows", new Int32(2));
+        grid.setValue("itemSpacing", vector([50, 0]));
+        grid.setValue("vertFocusAnimationStyle", new BrsString("fixedFocusWrap"));
+
+        const widths = [];
+        grid.renderWrapDivider = (rect) => {
+            widths.push(Math.round(rect.width));
+            return 0;
+        };
+
+        const root = SGNodeFactory.createNode("ContentNode");
+        for (let i = 0; i < 6; i++) {
+            root.appendChildToParent(SGNodeFactory.createNode("ContentNode"));
+        }
+        grid.setValue("content", root);
+        grid.setFocusedItem?.(3);
+        grid.renderNode({}, [0, 0], 0, 1);
+
+        // Content width is 3*100 + 2 gaps of 50 = 400; with the trailing gap it would be 450.
+        for (const width of widths) {
+            expect(width).toBe(400);
+        }
     });
 });

--- a/test/extensions/scenegraph/PosterGridExtent.test.js
+++ b/test/extensions/scenegraph/PosterGridExtent.test.js
@@ -1,0 +1,155 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, Int32, Float, RoArray, Interpreter } = core;
+
+const vector = (values) => new RoArray(values.map((v) => new Float(v)));
+
+/**
+ * DEVICE-MEASURED (Streaming Stick, Roku OS 15.2, HD 1280x720) via `out/postergrid-spacing-probe`
+ * and `out/postergrid-rows-probe`. Every expected number below is a device reading.
+ *
+ *   width  = Σ over ALL N cols of (basePosterSize.x + colSpacing_i) + 2*14   columnWidths IGNORED
+ *   height = Σ over ALL N rows of (rowHeight_i      + rowSpacing_i) + 2*14   rowHeights HONORED
+ *   spacing_i = (column|row)Spacings[i] ?? itemSpacing.(x|y)   — falls back, never repeats
+ *
+ * The axes are deliberately NOT symmetric: `columnWidths` is ignored while `rowHeights` is honored.
+ * Do not "unify" them.
+ */
+describe("PosterGrid reports the extent a device reports", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    /** A PosterGrid with `count` empty content items — no fields, so nothing can resize a cell. */
+    function makeGrid(count, fields) {
+        const grid = SGNodeFactory.createNode("PosterGrid");
+        grid.setValue("basePosterSize", vector([100, 100]));
+        for (const [name, value] of Object.entries(fields)) {
+            grid.setValue(name, value);
+        }
+        const root = SGNodeFactory.createNode("ContentNode");
+        for (let i = 0; i < count; i++) {
+            root.appendChildToParent(SGNodeFactory.createNode("ContentNode"));
+        }
+        grid.setValue("content", root);
+        grid.renderNode({}, [0, 0], 0, 1);
+        return grid;
+    }
+
+    const rectOf = (grid) => grid.getBoundingRect("toParent", interpreter);
+
+    test("a one-column grid outsets the reported rect by the focus margin", () => {
+        // Device P1: {x:-14, y:-14, w:128} for a 100-wide poster.
+        const grid = makeGrid(1, {
+            numColumns: new Int32(1),
+            numRows: new Int32(1),
+            itemSpacing: vector([0, 0]),
+        });
+        const rect = rectOf(grid);
+        expect(Math.round(rect.width)).toBe(128);
+        expect(Math.round(rect.x)).toBe(-14);
+        expect(Math.round(rect.y)).toBe(-14);
+    });
+
+    test("columnWidths is ignored — the cell width comes from basePosterSize", () => {
+        // Device P2: identical to P1 despite columnWidths=[200].
+        const grid = makeGrid(1, {
+            numColumns: new Int32(1),
+            numRows: new Int32(1),
+            itemSpacing: vector([0, 0]),
+            columnWidths: vector([200]),
+        });
+        expect(Math.round(rectOf(grid).width)).toBe(128);
+    });
+
+    test("the gap AFTER the last column is part of the extent", () => {
+        // Device P3: 3 cols of 100, itemSpacing.x=50 → 3*100 + 3*50 + 28 = 478 (not 428).
+        const grid = makeGrid(3, {
+            numColumns: new Int32(3),
+            numRows: new Int32(1),
+            itemSpacing: vector([50, 0]),
+        });
+        expect(Math.round(rectOf(grid).width)).toBe(478);
+    });
+
+    test("a short columnSpacings falls back to itemSpacing.x rather than repeating", () => {
+        // Device P4: columnSpacings=[10] over 3 columns → 10 + 50 + 50, i.e. 438.
+        // Repeating the last entry would give 358.
+        const grid = makeGrid(3, {
+            numColumns: new Int32(3),
+            numRows: new Int32(1),
+            itemSpacing: vector([50, 0]),
+            columnSpacings: vector([10]),
+        });
+        expect(Math.round(rectOf(grid).width)).toBe(438);
+    });
+
+    test("a fully specified columnSpacings still adds a trailing fall-back gap", () => {
+        // Device P5: columnSpacings=[10,20] over 3 columns → 10 + 20 + 50 (the third falls back).
+        const grid = makeGrid(3, {
+            numColumns: new Int32(3),
+            numRows: new Int32(1),
+            itemSpacing: vector([50, 0]),
+            columnSpacings: vector([10, 20]),
+        });
+        expect(Math.round(rectOf(grid).width)).toBe(408);
+    });
+
+    test("rowHeights IS honored, unlike columnWidths", () => {
+        // Device R6: rowHeights=[200,50,100] with no spacing → those heights are used.
+        // The height assertion is relative: see the caption-zone note below.
+        const honored = makeGrid(3, {
+            numColumns: new Int32(1),
+            numRows: new Int32(3),
+            itemSpacing: vector([0, 0]),
+            rowHeights: vector([200, 50, 100]),
+        });
+        const uniform = makeGrid(3, {
+            numColumns: new Int32(1),
+            numRows: new Int32(3),
+            itemSpacing: vector([0, 0]),
+        });
+        // 200+50+100 = 350 vs 3*100 = 300.
+        expect(Math.round(rectOf(honored).height) - Math.round(rectOf(uniform).height)).toBe(50);
+    });
+
+    test("a short rowSpacings falls back to itemSpacing.y, and the trailing gap counts", () => {
+        // Device R4 vs R5: with itemSpacing.y=50, no array gives 3 gaps of 50; rowSpacings=[10]
+        // gives 10 + 50 + 50. The two differ by exactly 40, whatever the caption zone contributes.
+        const noArray = makeGrid(3, {
+            numColumns: new Int32(1),
+            numRows: new Int32(3),
+            itemSpacing: vector([0, 50]),
+        });
+        const shortArray = makeGrid(3, {
+            numColumns: new Int32(1),
+            numRows: new Int32(3),
+            itemSpacing: vector([0, 50]),
+            rowSpacings: vector([10]),
+        });
+        expect(Math.round(rectOf(noArray).height) - Math.round(rectOf(shortArray).height)).toBe(40);
+
+        // And the trailing gap is included: 3 rows of 100 with 3 gaps of 50, not 2.
+        const noSpacing = makeGrid(3, {
+            numColumns: new Int32(1),
+            numRows: new Int32(3),
+            itemSpacing: vector([0, 0]),
+        });
+        expect(Math.round(rectOf(noArray).height) - Math.round(rectOf(noSpacing).height)).toBe(150);
+    });
+});


### PR DESCRIPTION
Device-measured on a **Streaming Stick, Roku OS 15.2, HD 1280x720**. The engine now reproduces **every measured width and every x/y offset exactly**.

## How this was measured

A first attempt (`out/layout-measure-probe`, case `P`) was **inconclusive** — the device reported `{x=-14 y=306 w=438 h=324}`, which decomposed into neither candidate answer, because poster size, focus margins and gap spacing were all unknown simultaneously across two rows. Two replacement probes isolate one unknown per fixture:

- **`out/postergrid-spacing-probe`** — five single-row cases solving margins → `basePosterSize` vs `columnWidths` → plain `itemSpacing` gaps → the short-array discriminator (candidates 40px apart).
- **`out/postergrid-rows-probe`** — six single-column cases doing the same for the row axis (candidates ≥50px apart).

The resulting model retroactively explains the original `438`, which is the strongest evidence it is a real model rather than curve-fitting.

```
width  = Σ over ALL N cols of (basePosterSize.x + colSpacing_i) + 2*marginX
height = Σ over ALL N rows of (rowHeight_i      + rowSpacing_i) + 2*marginY
spacing_i = (column|row)Spacings[i] ?? itemSpacing.(x|y)
marginX = marginY = 14 (HD)
```

## Four rules, each of which the engine had wrong

1. **Short spacing arrays fall back to `itemSpacing` — they do not repeat the last entry.** `columnSpacings=[10]` across 3 columns measured **438** (`10 + 50 + 50`); repeating gives 358. This is the question the whole exercise started from, and **the reference was right**. Note `LayoutGroup.itemSpacings` **is** device-confirmed to repeat, so the two genuinely differ — which is exactly why it was measured rather than reasoned by analogy.

   The fallback *value* was wrong too: it came from the array's **first entry** (`defaultColumnSpacing`), which silently made any short array behave like a repeat.

2. **The gap AFTER the last track counts**, on both axes — matching the reference's "the spacing after each row" wording. 3 columns of 100 at `itemSpacing.x = 50` measure 478, not 428.

3. **The axes are not symmetric.** `columnWidths` is **ignored** (cell width always comes from `basePosterSize.x`) while `rowHeights` **is** honored. I deliberately did not assume symmetry — the row probe's README called this out in advance, and it was right to.

4. **`rectMargins` is 14/14**, not `ArrayGrid`'s shared 24/4. The FHD value (21) is *inferred* from the standard 1.5× design-resolution scale and is **marked as an inference, not a measurement**.

## A general fix the probes exposed

`Group.updateBoundingRects` built `rectToParent` from the node's **translation**, discarding `drawRect.x/y`. Identical for an ordinary node — but a grid's `updateRect` outsets `drawRect` by its focus margins, and a device reports that outset. So a grid's reported rect carried the widened width/height with **un-offset x/y**.

Confirmed on two node types: device `LabelList` reports `x=-24` and `PosterGrid` `x=-14, y=-14`, where the engine reported `0`.

This shifts one CLI expectation by the RowList focus outset (4px, `-15` → `-19`). Both rows move equally, so the invariant that test exists for — a newly focused row reports the **same band** as row 0, not its stacked position — is unchanged. `-15` was never a device-verified number; the comment now records why the absolute value moved.

## Not fixed, deliberately: the caption zone

A device reserves a caption zone **even with `caption1NumLines = 0`** — a 100-tall poster yields a **136**-tall cell (+36), and one caption line makes it 168 (+32/line). The engine reserves 0 with no lines and 44 with one, so PosterGrid heights are ~36 short.

It is **not** the empty-caption background: setting `showBackgroundForEmptyCaptions=false` changed nothing on device, which killed my hypothesis. The mechanism is unknown, only HD was measured, and two data points cannot model ≥2 lines. A flat `+36` would **over-correct** the one-caption case, where the engine's line height is already 12 too tall — so this is recorded in the invariants doc rather than approximated.

## Testing

`test/extensions/scenegraph/PosterGridExtent.test.js` — 7 tests, every expected number a device reading. **Six fail on the parent commit:**

```
one-column grid outsets the reported rect     expected 100 to be 128
columnWidths is ignored                        expected 200 to be 128
gap AFTER the last column counts               expected 400 to be 478
short columnSpacings falls back                expected 320 to be 438
full columnSpacings + trailing fall-back gap   expected 330 to be 408
short rowSpacings falls back + trailing gap    expected  80 to be 40
```

The seventh (`rowHeights` is honored) passes on both — the engine already had that right, and it guards against "unifying" the two axes.

Full suite green: **2441 passed / 196 files**. Lint, prettier and `tsc` clean.

Invariants recorded in `.claude/docs/scenegraph-invariants.md`, including the asymmetry, the fall-back-vs-repeat distinction against `LayoutGroup`, and the unresolved caption zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)