### PR TITLE
feat(cli): add --log-level flag and a loglevel REPL command

### DIFF
--- a/docs/run-as-cli.md
+++ b/docs/run-as-cli.md
@@ -48,6 +48,7 @@ Options:
   -l, --log [filename]      Redirect the text output to a log file (default: brs-cli.log).
   -s, --snapshot [filename] Enable Ctrl+S to save the current screen as a PNG image.
   -c, --colors <level>      Define the console color level (0 to disable). (default: 3)
+  -g, --log-level <level>   Set console log verbosity: debug, warning or error. (default: "warning")
   -d, --debug               Developer mode: micro debugger on crash + resource tracking.
   -z, --log-rendezvous      Trace SceneGraph cross-thread rendezvous (like Roku's logrendezvous).
   -e, --ecp                 Enable the ECP server for control simulation.
@@ -85,6 +86,7 @@ Any valid BrightScript expression is compiled and run live. In addition, the REP
 | --- | --- |
 | `print` or `?` | Print a variable value or expression |
 | `var` or `vars [scope]` | Display variables and their types/values (`scope` is `global`, `module` or `function`) |
+| `loglevel [level]` | Show the current log level, or set it (`level` is `debug`, `warning` or `error`) |
 | `vol` or `vols` | Display the file system mounted volumes |
 | `mnt` or `mount <path>` | Mount the `ext1:` volume from a directory or zip file |
 | `umt` or `umount` | Unmount the `ext1:` volume |
@@ -107,6 +109,33 @@ $ brs-cli --colors 0
 | `1` | Basic color support (16 colors) |
 | `2` | 256 color support |
 | `3` | Truecolor support (16 million colors) |
+
+## Setting the Log Level
+
+By default the CLI keeps console output at `warning` level, matching a Roku device out of the box.
+Pass `--log-level debug` to also print `debug`-level lines (e.g. the extra action/target detail on
+[rendezvous tracing](#tracing-cross-thread-rendezvous)), or `--log-level error` to silence
+`warning`-level lines too:
+
+```console
+$ brs-cli --log-level debug app.zip
+```
+
+In the REPL, use `loglevel` (no argument) to show the current level, or `loglevel <level>` to change
+it for the session:
+
+```console
+brs> loglevel
+Current log level: warning
+brs> loglevel debug
+Log level set to: debug
+```
+
+| Level | Description |
+| :---: | :--- |
+| `debug` | Everything: `debug`, `warning` and `error` lines |
+| `warning` | `warning` and `error` lines only (default) |
+| `error` | `error` lines only |
 
 ### Executing files
 

--- a/docs/run-as-cli.md
+++ b/docs/run-as-cli.md
@@ -113,9 +113,9 @@ $ brs-cli --colors 0
 ## Setting the Log Level
 
 By default the CLI keeps console output at `warning` level, matching a Roku device out of the box.
-Pass `--log-level debug` to also print `debug`-level lines (e.g. the extra action/target detail on
-[rendezvous tracing](#tracing-cross-thread-rendezvous)), or `--log-level error` to silence
-`warning`-level lines too:
+Pass `--log-level debug` to add the `threadID` in every print, and show `debug`-level lines (e.g. the extra
+action/target detail on [rendezvous tracing](#tracing-cross-thread-rendezvous)), or `--log-level error` to
+silence `warning`-level lines too:
 
 ```console
 $ brs-cli --log-level debug app.zip

--- a/docs/run-as-cli.md
+++ b/docs/run-as-cli.md
@@ -45,11 +45,11 @@ Options:
   -a, --ascii <columns>     Enable ASCII screen mode with # of columns.
   -u, --unicode             Render ASCII screen mode using Unicode block characters.
   -i, --image [percent]     Render the screen as images on the terminal with optional width % (default: 100).
-  -l, --log [filename]      Redirect the text output to a log file (default: brs-cli.log).
   -s, --snapshot [filename] Enable Ctrl+S to save the current screen as a PNG image.
   -c, --colors <level>      Define the console color level (0 to disable). (default: 3)
-  -g, --log-level <level>   Set console log verbosity: debug, warning or error. (default: "warning")
   -d, --debug               Developer mode: micro debugger on crash + resource tracking.
+  -l, --log [filename]      Redirect the text output to a log file (default: brs-cli.log).
+  -g, --log-level <level>   Set console log verbosity: debug, warning or error. (default: "warning")
   -z, --log-rendezvous      Trace SceneGraph cross-thread rendezvous (like Roku's logrendezvous).
   -e, --ecp                 Enable the ECP server for control simulation.
   -n, --no-sg               Disable the SceneGraph extension.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,7 @@ import {
     DataType,
     ExtVolInitialSize,
     ExtVolMaxSize,
+    LogLevel,
 } from "../core/common";
 import SharedObject from "../core/SharedObject";
 import { encryptPackage } from "../core/packageEncryption";
@@ -91,6 +92,7 @@ program
     .option("-l, --log [filename]", "Redirect the text output to a log file (default: brs-cli.log).")
     .option("-s, --snapshot [filename]", "Enable Ctrl+S to save the current screen as a PNG image.")
     .option("-c, --colors <level>", "Define the console color level (0 to disable).", defaultLevel)
+    .option("-g, --log-level <level>", "Set console log verbosity: debug, warning or error.", "warning")
     .option("-d, --debug", "Developer mode: micro debugger on crash + resource tracking.", false)
     .option("-z, --log-rendezvous", "Trace SceneGraph cross-thread rendezvous (like Roku's logrendezvous).", false)
     .option("-e, --ecp", "Enable the ECP server for control simulation.", false)
@@ -131,6 +133,7 @@ program
             deviceData.connectionInfo.dns = dns.getServers();
             deviceData.debugOnCrash = program.debug ?? false;
             deviceData.logRendezvous = program.logRendezvous ?? false;
+            deviceData.logLevel = program.logLevel;
             if (program.registry) {
                 deviceData.registry = getRegistry();
             }
@@ -155,6 +158,33 @@ program
     .parse(process.argv);
 
 /**
+ * Parses a `--log-level`/`loglevel` REPL value into a `LogLevel`, accepting the level name
+ * (`debug`, `warning`/`warn`, `error`) or its underlying numeric value.
+ * @param value The raw value to parse, or undefined.
+ * @returns The parsed LogLevel, or undefined when `value` is not a recognized level.
+ */
+function parseLogLevel(value?: string): LogLevel | undefined {
+    const normalized = value?.trim().toLowerCase();
+    if (normalized === "debug" || normalized === "0") {
+        return LogLevel.Debug;
+    } else if (normalized === "warning" || normalized === "warn" || normalized === "1") {
+        return LogLevel.Warning;
+    } else if (normalized === "error" || normalized === "2") {
+        return LogLevel.Error;
+    }
+    return undefined;
+}
+
+/**
+ * Formats a `LogLevel` back into the lower-case name accepted by `--log-level`/`loglevel`.
+ * @param level The LogLevel to format.
+ * @returns The level's name (`debug`, `warning` or `error`).
+ */
+function logLevelName(level: LogLevel): string {
+    return LogLevel[level].toLowerCase();
+}
+
+/**
  * Validates and normalizes CLI parameters.
  * Sets default values for color level, ASCII mode, and validates file paths.
  * @returns True if all parameters are valid, false otherwise
@@ -164,6 +194,17 @@ function checkParameters() {
         chalk.level = Math.trunc(program.colors) as chalk.Level;
     } else {
         console.warn(chalk.yellow(`Invalid color level! Valid range is 0-3, keeping default: ${defaultLevel}.`));
+    }
+    const logLevel = parseLogLevel(program.logLevel);
+    if (logLevel === undefined) {
+        console.warn(
+            chalk.yellow(
+                `Invalid log level "${program.logLevel}"! Valid values are debug, warning, error, using default: warning.`
+            )
+        );
+        program.logLevel = LogLevel.Warning;
+    } else {
+        program.logLevel = logLevel;
     }
     if (program.ascii) {
         if (isNumber(program.ascii)) {
@@ -577,6 +618,23 @@ async function repl() {
             process.stdout.write("\x1Bc");
         } else if (["help", "hint"].includes(line.toLowerCase().trim())) {
             printHelp();
+        } else if (["loglevel", "log-level"].includes(line.split(" ")[0]?.toLowerCase().trim())) {
+            const arg = line.split(" ")[1]?.trim();
+            if (arg) {
+                const parsed = parseLogLevel(arg);
+                if (parsed === undefined) {
+                    process.stdout.write(
+                        chalk.yellowBright(`\nInvalid log level "${arg}". Valid values: debug, warning, error.\n`)
+                    );
+                } else {
+                    BrsDevice.deviceInfo.logLevel = parsed;
+                    process.stdout.write(chalk.greenBright(`\nLog level set to: ${logLevelName(parsed)}\n`));
+                }
+            } else {
+                process.stdout.write(
+                    chalk.cyanBright(`\nCurrent log level: ${logLevelName(BrsDevice.deviceInfo.logLevel)}\n`)
+                );
+            }
         } else if (["vol", "vols"].includes(line.toLowerCase().trim())) {
             const vols = BrsDevice.fileSystem.volumesSync();
             process.stdout.write(chalk.cyanBright(`\nMounted volumes:\n\n`));
@@ -814,6 +872,7 @@ function printHelp() {
     helpMsg += "REPL Command List:\r\n";
     helpMsg += "   print|?           Print variable value or expression\r\n";
     helpMsg += "   var|vars [scope]  Display variables and their types/values\r\n";
+    helpMsg += "   loglevel [level]  Show or set the log level (debug, warning, error)\r\n";
     helpMsg += "   vol|vols          Display file system mounted volumes\r\n";
     helpMsg += "   mnt|mount <path>  Mount ext1: volume from directory or zip file\r\n";
     helpMsg += "   umt|umount        Unmount ext1: volume\r\n";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -89,11 +89,11 @@ program
         "-i, --image [percent]",
         "Render the screen as images on the terminal with optional width % (default: 100)."
     )
-    .option("-l, --log [filename]", "Redirect the text output to a log file (default: brs-cli.log).")
     .option("-s, --snapshot [filename]", "Enable Ctrl+S to save the current screen as a PNG image.")
     .option("-c, --colors <level>", "Define the console color level (0 to disable).", defaultLevel)
-    .option("-g, --log-level <level>", "Set console log verbosity: debug, warning or error.", "warning")
     .option("-d, --debug", "Developer mode: micro debugger on crash + resource tracking.", false)
+    .option("-l, --log [filename]", "Redirect the text output to a log file (default: brs-cli.log).")
+    .option("-g, --log-level <level>", "Set console log verbosity: debug, warning or error.", "warning")
     .option("-z, --log-rendezvous", "Trace SceneGraph cross-thread rendezvous (like Roku's logrendezvous).", false)
     .option("-e, --ecp", "Enable the ECP server for control simulation.", false)
     .option("-n, --no-sg", "Disable the SceneGraph extension.")


### PR DESCRIPTION
## Summary
- The engine already gates extra debug output behind `deviceInfo.logLevel` (e.g. the rendezvous `[sg.node.BLOCK]`/`[sg.node.UNBLOCK]` lines' action/target detail), but there was no way to change it from the CLI — only a `/// #if DEBUG` build-time flag on the browser API side.
- Adds `-g, --log-level <level>` (`debug`/`warning`/`error`, defaults to `warning` — matching a Roku device out of the box), validated the same way `--colors` is (falls back to the default with a warning on an invalid value).
- Adds a `loglevel` REPL command: no argument prints the current level, `loglevel <level>` sets it for the session.
- Documents both in `docs/run-as-cli.md` (`--help` block, REPL command table, new "Setting the Log Level" section), and cross-links it from the rendezvous-tracing section where the level actually changes output.

## Test plan
- [x] `npm run lint` / `npm run prettier:write` clean
- [x] `npx vitest run test/cli/` — 91 tests passing, no regressions
- [x] Manually verified `--help` output, an invalid `--log-level` value falling back to `warning` with a warning printed, and the `loglevel`/`loglevel debug`/`loglevel bogus` REPL round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)