### PR TITLE
fix(scenegraph): report a grid item's sub-rect as the bare item component

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -430,6 +430,14 @@ discarding `drawRect.x/y`. Identical for an ordinary node, but a grid's `updateR
 by its focus margins — and a device reports that outset — so a grid's reported rect had the widened
 width/height with un-offset x/y. It now derives the position from `drawRect` too.
 
+The lesson below ("fixing two of three spaces is worse than fixing none, because the disagreement is
+silent") has a corollary that this fix went on to demonstrate: **a *compensating* error in a consumer is
+equally silent, and repairing the producer is what surfaces it.** The leaked `+marginY` above was being
+cancelled downstream by a `-focusMargins().top` subtraction in `RowList.getSubBoundingRect` (see the
+grid-sub-rect section below). Both were wrong; together they read as correct. So when you fix a geometry
+producer, audit its consumers for adjustments that were calibrated against the broken value — the tell is
+a consumer-side correction whose magnitude happens to match the producer's error.
+
 **All three coordinate spaces have to move together.** `rectLocal` stayed at `{0,0}` in the first cut,
 so `localBoundingRect()`/`localSubBoundingRect()` disagreed with the parent and scene rects by the
 margin (`Node.getSubBoundingRect` bases its `"local"` variant on `rectLocal`). Local is parent-space
@@ -460,6 +468,78 @@ short of a device. This is **not** the empty-caption background — setting
 mechanism is unknown, only HD was measured, and two data points cannot model ≥2 lines, so it is
 deliberately unfixed rather than approximated with a constant (a flat +36 would over-correct the
 one-caption case, where the engine's line height is already 12 too tall).
+
+## A grid's reported rect is outset — its item sub-rects are NOT
+
+Three outsets meet on `subBoundingRect("item<r>_<c>")` and only two of them exist. Keep them apart:
+
+| outset | applied by | shows up in |
+| --- | --- | --- |
+| `rectMargins()` → `marginX`/`marginY` | `ArrayGrid.updateRect` | the **grid's own** reported rect (device-measured) |
+| `focusMargins(bmp)` → the 9-patch's declared content margins | `ArrayGrid.renderFocus` | the **drawn** focus frame — paint only, nothing reports it |
+| *(none)* | — | an **item sub-rect** |
+
+The calibrated invariant is **`subBoundingRect("item<r>_<c>")` == the item component's own rect** — the
+bare poster, in all three coordinate spaces, focused cell included. `PosterGridItem` corroborates it
+independently (its sub-rect lands exactly on its poster). Pinned end-to-end over
+{HD,FHD} × {`RowList`,`ZoomRowList`} × translations by `RowListItemSubRect.test.js`, which asserts the
+*composition* rather than either mechanism, plus the CLI fixture `rowlist-subrect-app` (which derives its
+own expectation from its declared `translation`/`rowItemSize`, so no pixel constant can drift).
+
+**The grid's own outset does not leak into an item sub-rect only because it cancels.**
+`Node.getSubBoundingRect` re-expresses the item rect as `base.y + (subScene.y - this.rectToScene.y)`,
+where `base` is `rectToParent`/`rectLocal`. That subtraction cancels the outset **only if `base` and
+`rectToScene` carry it identically** (`Node.ts:1219-1226`). Any future per-space adjustment must therefore
+be applied to all three spaces, or it reappears as a residue in every sub-rect.
+
+### Worked example: two compensating errors that read as correct
+
+An app positioned a home-screen preview overlay from a `RowList`'s focused-item sub-rect. Three PRs each
+chased the same device symptom ("the overlay sits too low"), and two of them subtracted the *same* outset:
+
+| state | `sub.y − focusedPoster.y` |
+| --- | --- |
+| `marginY` = 33/22 (square, unmeasured) | +33 |
+| `marginY` → 6/4 (device-measured) | +6 |
+| plus a `− focusMargins(bmp).top` in `RowList.getSubBoundingRect` | **0** ← aligned, by two errors cancelling |
+| minus the `+marginY` leak, once `updateBoundingRects` was fixed | **−6** ← regression: overlay one margin too high |
+
+Why it stayed invisible: the cancellation was *exact* for that app, whose focus 9-patch declares 6px
+content margins — the same number as `RowList`'s FHD `marginY`. The default `focus_grid.9.png` declares
+19px, so the CLI fixture (HD, `marginY` 4) had visibly *un*-cancelled arithmetic all along, and that
+expectation was simply moved (`−15` → `−19`) rather than questioned. The footprint outset's own regression
+test asserted only the *shape* of the outset (`top > 0`), never a pixel count, so it never disagreed with
+a device either.
+
+Two facts settled which side was wrong: `sceneSubBoundingRect` was *already* `poster − top` before the
+producer fix (the three spaces silently disagreed by `marginY`, and the fix only made `toParent`/`local`
+agree with the space that already leaked), and `PosterGridItem`'s sub-rect independently moved onto its
+poster. The consumer-side subtraction was deleted; `RowList` now inherits `Node.getSubBoundingRect`
+verbatim, like `MarkupGrid`, `MarkupList`, `LabelList` and `ZoomRowList`. Its `resolveSubpart` override
+stays — mapping `item<row>_<col>` into the 2-D `rowItemComps[row][col]` is what makes the API work at all
+(the flat `itemComps[]` stays empty on row lists) — and carries a negative comment recording that the
+outset must not come back.
+
+Do not "fix" a misplaced focused-item overlay by adjusting this rect: the painted frame legitimately sits
+outside the reported rect, and that asymmetry is what makes the wrong fix look right.
+
+### Known fallout from the `updateBoundingRects` fix, still awaiting device measurements
+
+Each needs its own probe and PR; none is fixed:
+
+- **`LayoutGroup` displaces grid children.** `chooseActiveRect` (`LayoutGroup.ts:521-522`) prefers
+  `child.rectToParent` and `measureChild` derives `primaryStart`/`crossStart` from it, so a child now
+  measured with its outset gets *positioned* by it. Measured: a `LabelList` in a vertical LayoutGroup moved
+  from `translation [0,50]` to `[24,54]` — exactly `(marginX, marginY)`, and **stable**, so
+  `LayoutConvergence.test.js` does not catch it. A LayoutGroup positions by *paint* geometry, so the fix is
+  a paint-rect hook subtracted in `measureChild`, not a revert.
+- **`renderTracking` flips on the ancestor.** `updateParentRects` (`Group.ts:674-696`) unions the moved
+  `rectToParent` into the parent: a plain `Group` wrapping a `LabelList` went `{0,0,348,216}`/`"full"` →
+  `{-24,-4,348,216}`/`"partial"`. Apps gating viewable-impression work on `renderTracking == "full"`
+  silently stop firing.
+- **Two untested side effects**, both arguably now *correct* by the fix's own rationale and worth locking
+  in with a test rather than reverting: `SimpleLabel` reports the anchored glyph box (a center/center label
+  at `[500,300]` reports `{473,288}`), and `PosterGridItem`'s sub-rect landed on its poster (`sub.y` 4 → 0).
 
 ## `ArrayGrid.scrollingStatus` — a lazy pulse, ordered ahead of the focus settle
 

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -324,7 +324,7 @@ export class PosterGrid extends ArrayGrid {
         // DEVICE-MEASURED: the gap AFTER the last row counts, exactly as it does after the last
         // column — 3 rows of 100 with `itemSpacing.y = 50` measured 3 x 100 + 3 x 50 + margins, not
         // 2 gaps. So the loop's accumulated `itemRect.y` is used as-is, with nothing backed out (the
-        // early-break path above adds the row height without a gap, so it needs no adjustment).
+        // loop breaks AFTER advancing, so the scene-edge exit already includes that trailing gap too).
         const margin = this.rectMargins();
         const height = renderedRows === 0 ? 0 : itemRect.y - startY + margin.y * 2;
         this.updateRect(rect, displayRows, [Math.max(...columnWidths), maxCellHeight || baseSize[1]], {

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -95,12 +95,16 @@ export class RowList extends ArrayGrid {
 
         if (this.resolution === "FHD") {
             this.marginX = 33;
-            // Vertical bounding-rect outset. A real device reports a RowList's boundingRect (and its
-            // item subBoundingRects) outset by only ~6px on the Y axis — the focus 9-patch's own
-            // content margins drive the focus RING (see ArrayGrid.focusMargins, which prefers the
-            // bitmap's declared margins over this value), so marginY here affects ONLY the reported
-            // rects, not the drawn focus frame. A larger square value pushed subBoundingRect.y down,
-            // so an app placing a focused-item overlay from it sat the overlay too low.
+            // Vertical outset of THIS NODE's own reported rect (rectMargins -> ArrayGrid.updateRect).
+            // A real device reports a RowList's boundingRect outset by only ~6px on the Y axis, where
+            // the square 33 this used to hold was far too tall. It affects ONLY the reported rect, not
+            // the drawn focus frame: the focus RING uses the focus 9-patch's own declared content
+            // margins (ArrayGrid.focusMargins prefers them over this value).
+            //
+            // It does NOT reach an item subBoundingRect: Node.getSubBoundingRect re-expresses the item
+            // rect against this node's rectToParent/rectToScene, both of which now carry the outset
+            // identically, so it cancels. See resolveSubpart below — that cancellation is the whole
+            // reason the footprint outset that used to live here was wrong.
             this.marginY = 6;
         } else {
             this.marginX = 22;
@@ -422,43 +426,30 @@ export class RowList extends ArrayGrid {
      * whole-list rect. On a real device `subBoundingRect("item<row>_<col>")` returns the focused
      * poster's rect, which apps use to place a focused-item overlay; without this override the overlay
      * cannot track the row's item layout. See `resolveRowItemSubpart` for the id mapping.
+     *
+     * Resolution is ALL this node contributes: there is intentionally no `getSubBoundingRect` override.
+     * `Node.getSubBoundingRect` re-expresses the resolved item component's own rect, and a device reports
+     * exactly that — the bare poster — for both the focused and the unfocused cells. Three separate
+     * outsets are easy to conflate here, so keep them apart:
+     *
+     *  - the DRAWN focus frame is outset (`ArrayGrid.renderFocus` -> `focusMargins`, the 9-patch's own
+     *    declared content margins). That is paint only; nothing reports it.
+     *  - THIS NODE's own reported rect is outset (`rectMargins` -> `ArrayGrid.updateRect`, `marginX`/
+     *    `marginY`). It does not reach an item sub-rect: `Node.getSubBoundingRect` computes
+     *    `base.y + (subScene.y - this.rectToScene.y)`, and `base` (`rectToParent`/`rectLocal`) and
+     *    `rectToScene` carry that outset identically, so it cancels.
+     *  - an ITEM sub-rect is outset by nothing at all.
+     *
+     * Do NOT re-add a focus-footprint outset here. One was added once (subtracting the 9-patch top
+     * margin from the focused cell) to make an overlay land on the poster; it was double-counting from
+     * the day it landed, silently cancelled by a `rectToParent` bug that dropped the `rectMargins`
+     * outset from `base` and left a `+marginY` residue in the expression above. Fixing that bug — so
+     * the outset cancels as it should — surfaced the double subtraction as an overlay drawn one focus
+     * margin too HIGH. If a focused-item overlay looks misplaced, the paint path or the app's own
+     * offset is the suspect, not this rect.
      */
     protected resolveSubpart(itemNumber: string): Node | undefined {
         return resolveRowItemSubpart(itemNumber, this.rowItemComps, this.focusIndex, this.rowFocus);
-    }
-
-    /**
-     * Returns a sub part's bounding rect, extending the FOCUSED item's rect upward by the focus-feedback
-     * top margin. On a real device the focused cell's reported rect spans the focus-feedback footprint
-     * (the focus 9-patch outsets above the poster), not the bare poster — so an app that places a
-     * focused-item overlay from this rect lands the overlay on the poster. The item component's own
-     * `rectToScene` is the poster rect (it renders at `itemRect`; the focus frame is drawn separately,
-     * outset by `focusMargins`), so without this the overlay sits one focus-line too low and the poster
-     * shows above it. The outset is keyed to the focus bitmap being present, NOT `drawFocusFeedback`: a
-     * device reserves the footprint region whenever a focus bitmap is set even if the app suppresses the
-     * drawn frame (a common pattern for apps that render their own focus indicator). Only the focused
-     * cell has the footprint, so only its rect is adjusted; other sub parts pass through.
-     */
-    getSubBoundingRect(type: string, itemNumber: string, interpreter?: Interpreter): Rect {
-        const rect = super.getSubBoundingRect(type, itemNumber, interpreter);
-        const subpart = this.resolveSubpart(itemNumber);
-        const focusedItem = this.rowItemComps[this.focusIndex]?.[this.rowFocus[this.focusIndex] ?? 0];
-        // Reserve the focus-feedback footprint whenever a focus bitmap is set (the focus indicator,
-        // or its footprint when the list is unfocused). Keyed on the bitmap URI, NOT drawFocusFeedback,
-        // so it still applies when an app suppresses the drawn frame but relies on the reserved footprint
-        // (e.g. to place its own indicator). Both URIs are consulted because subBoundingRect reflects the
-        // focused item regardless of whether the list node currently holds live focus.
-        const bmpUri = this.getValueJS("focusBitmapUri") ? "focusBitmapUri" : "focusFootprintBitmapUri";
-        if (subpart && subpart === focusedItem && this.getValueJS(bmpUri)) {
-            // Match the focus frame's own outset: the 9-patch's declared top margin, falling back to
-            // marginY when the bitmap hasn't loaded (mirrors ArrayGrid.focusMargins).
-            const bmp = this.getBitmap(bmpUri);
-            const top = bmp?.isValid() ? this.focusMargins(bmp).top : this.marginY;
-            if (top) {
-                return { ...rect, y: rect.y - top, height: rect.height + top };
-            }
-        }
-        return rect;
     }
 
     private getRowItemSize(rowIndex: number): number[] {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -956,16 +956,18 @@ describe.concurrent("cli", () => {
         // reports the settled band position — matching a real device where the observer fires
         // post-layout. Without the refresh, row 1 reads its stacked y (band + one row height).
         //
-        // The absolute y includes the grid's focus outset (RowList marginY), which the reported rect
-        // now carries: Group.updateBoundingRects used to build rectToParent from the node's
-        // translation and drop the outset that updateRect applies. A device does report it —
-        // measured on LabelList (x=-24) and PosterGrid (x=-14, y=-14). Both rows moved by the same
-        // 4px, so the invariant this test exists for ("SAME BAND") is unchanged.
+        // The reported y is the item component's own position — the grid's translation, here 120.
+        // An item sub-rect carries NO outset: not the grid's own reported outset (RowList marginY,
+        // applied by ArrayGrid.updateRect and cancelled in Node.getSubBoundingRect because base and
+        // rectToScene both carry it), and not the drawn focus 9-patch frame. Both printed booleans
+        // derive from the fixture's declared translation/rowItemSize, so nothing here can drift.
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== RowList SubRect Repro ===",
-            "band row0 y = -19",
-            "focused row1 y = -19",
+            "band row0 y =  120",
+            "focused row1 y =  120",
             "SAME BAND: true",
+            "ON POSTER: true",
+            "SIZE IS POSTER: true",
             "=== RowList SubRect Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
             "",

--- a/test/cli/resources/rowlist-subrect-app/source/main.brs
+++ b/test/cli/resources/rowlist-subrect-app/source/main.brs
@@ -7,6 +7,9 @@ sub Main()
     grid.rowItemSize = [[300, 200]]
     grid.itemSpacing = [0, 0]
     grid.numRows = 2
+    ' Off-origin so the reported item y is distinguishable from the grid's own origin and from
+    ' any outset applied to the grid's own rect (the item rect must carry neither).
+    grid.translation = [40, 120]
 
     content = CreateObject("roSGNode", "ContentNode")
     for r = 0 to 1
@@ -32,5 +35,11 @@ sub Main()
 
     same = Abs(rect1.y - band.y) < 50
     print "SAME BAND: "; same
+
+    ' The reported item rect is the bare item component, so it derives entirely from the
+    ' fixture's own declared inputs: it sits at the grid's translation and is exactly one
+    ' row item tall. Neither the grid's own rect outset nor the focus 9-patch reaches it.
+    print "ON POSTER: "; rect1.y = grid.translation[1]
+    print "SIZE IS POSTER: "; rect1.height = grid.rowItemSize[0][1]
     print "=== RowList SubRect Repro Complete ==="
 end sub

--- a/test/extensions/scenegraph/RowListItemSubRect.test.js
+++ b/test/extensions/scenegraph/RowListItemSubRect.test.js
@@ -1,0 +1,221 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, getBrsValueFromFieldType, ComponentDefinition } = scenegraph;
+const { BrsDevice, BrsBoolean, BrsString, Int32, Interpreter } = core;
+
+/**
+ * `subBoundingRect("item<row>_<col>")` on a row-based grid reports the ITEM COMPONENT's own rect —
+ * the bare poster — in every coordinate space. Three separate outsets meet on this path and only two
+ * of them are real:
+ *
+ *   1. `rectMargins()` -> `ArrayGrid.updateRect` outsets THE GRID's own reported rect by
+ *      marginX/marginY (device-measured; see PosterGridExtent.test.js and Group.updateBoundingRects).
+ *   2. `focusMargins()` -> `ArrayGrid.renderFocus` outsets THE DRAWN 9-patch focus frame by the
+ *      bitmap's declared content margins. Paint only — nothing reports it.
+ *   3. An ITEM sub-rect gets NEITHER.
+ *
+ * (1) does not leak into (3) only because `Node.getSubBoundingRect` computes
+ * `base.y + (subScene.y - this.rectToScene.y)` and `base` (rectToParent/rectLocal) and `rectToScene`
+ * carry the outset identically, so it cancels. A `rectToParent` bug used to drop it from `base`,
+ * leaving a `+marginY` residue — which in turn hid a `-focusMargins().top` subtraction that had been
+ * added to `RowList.getSubBoundingRect`. The two cancelled for one particular focus bitmap and read
+ * as correct; fixing the residue surfaced the double subtraction as a focused-item overlay drawn one
+ * focus margin too high.
+ *
+ * This file therefore pins the COMPOSITION, not any single mechanism: SubBoundingRect.test.js works
+ * on injected rects, so it cannot catch a drift between the outset a grid applies to itself and the
+ * cancellation that keeps it out of an item rect. Everything here goes through a real render.
+ */
+describe("row grids report an item sub-rect as the bare item component", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        // ZoomRowList refuses to render without a resolvable custom itemComponentName
+        // (validateRenderPrerequisites -> customNodeExists), so register a minimal one. It extends
+        // Rectangle rather than Group so it fills the cell the grid sizes it to — a bare Group has no
+        // geometry of its own and would report a degenerate (zero-sized) rect, which every assertion
+        // below would then pass trivially.
+        const def = new ComponentDefinition("pkg:/components/SubRectItem.xml");
+        def.name = "SubRectItem";
+        def.xmlNode = { attr: { name: "SubRectItem", extends: "Rectangle" } };
+        sgRoot.setNodeDefMap(new Map([["subrectitem", def]]));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+        sgRoot.setNodeDefMap(new Map());
+    });
+
+    /** Two rows of three items. */
+    function buildContent() {
+        const root = SGNodeFactory.createNode("ContentNode");
+        for (let r = 0; r < 2; r++) {
+            const row = SGNodeFactory.createNode("ContentNode");
+            for (let c = 0; c < 3; c++) {
+                const item = SGNodeFactory.createNode("ContentNode");
+                item.setValue("title", new BrsString(`R${r}C${c}`));
+                row.appendChildToParent(item);
+            }
+            root.appendChildToParent(row);
+        }
+        return root;
+    }
+
+    /**
+     * Creates and renders a row grid at the given resolution. The node type's margins are read in its
+     * constructor, so the scene's resolution must be set BEFORE the node is created (poking
+     * `sgRoot._resolution` does not work).
+     */
+    function renderGrid(type, resolution, translation, options = {}) {
+        const previousScene = sgRoot.scene;
+        const scene = SGNodeFactory.createNode("Scene");
+        sgRoot.setScene(scene);
+        scene.setResolution(resolution);
+        try {
+            const grid = SGNodeFactory.createNode(type);
+            grid.setValue("itemComponentName", new BrsString("SubRectItem"));
+            grid.setValue("numRows", new Int32(2));
+            grid.setValue("translation", getBrsValueFromFieldType("vector2d", `[${translation.join(",")}]`));
+            grid.setValue("itemSize", getBrsValueFromFieldType("vector2d", "[300,200]"));
+            grid.setValue("itemSpacing", getBrsValueFromFieldType("vector2d", "[0,0]"));
+            if (type === "RowList") {
+                grid.setValue("rowItemSize", getBrsValueFromFieldType("vector2darray", "[[300,200]]"));
+            }
+            for (const [name, value] of Object.entries(options)) {
+                grid.setValue(name, value);
+            }
+            grid.setValue("content", buildContent());
+            // Focus row 0 / col 1. Both node types are fixed-focus: the focused row is laid out AT the
+            // focus band, so focusing row 1 would scroll row 0 out of a 2-row window and leave it with
+            // no item components to compare against.
+            grid.setValue("jumpToRowItem", getBrsValueFromFieldType("intarray", "[0,1]"));
+            grid.setNodeFocus(true);
+
+            // Records the 9-patch focus frames; every other draw/clip call is a no-op.
+            const frames = [];
+            const draw2D = new Proxy(
+                {},
+                {
+                    get: (_t, prop) => (prop === "drawNinePatch" ? (_bmp, rect) => frames.push({ ...rect }) : () => 0),
+                }
+            );
+            grid.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+            return { grid, frames };
+        } finally {
+            sgRoot.setScene(previousScene ?? SGNodeFactory.createNode("Scene"));
+        }
+    }
+
+    const round = (rect) => ({
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+    });
+
+    for (const resolution of ["HD", "FHD"]) {
+        for (const type of ["RowList", "ZoomRowList"]) {
+            for (const translation of [
+                [0, 0],
+                [100, 300],
+            ]) {
+                const label = `${type} @ ${resolution} at [${translation}]`;
+
+                test(`${label}: an item sub-rect is the item component's own rect in all three spaces`, () => {
+                    const { grid } = renderGrid(type, resolution, translation);
+                    // The focused cell (row 0 / col 1) and non-focused ones; the focused cell is the
+                    // case an outset was once applied to, so all of them must agree.
+                    for (const [id, item] of [
+                        ["item0_0", grid.rowItemComps[0][0]],
+                        ["item1_1", grid.rowItemComps[1][1]],
+                        ["item0_1", grid.rowItemComps[0][1]],
+                        ["focusItem", grid.rowItemComps[0][1]],
+                        ["focusIndicator", grid.rowItemComps[0][1]],
+                    ]) {
+                        expect(item).toBeDefined();
+                        const poster = round(item.rectToScene);
+                        // A degenerate item rect would satisfy everything below vacuously.
+                        expect(poster.width).toBeGreaterThan(0);
+                        expect(poster.height).toBeGreaterThan(0);
+                        expect(round(grid.getSubBoundingRect("toScene", id, interpreter))).toEqual(poster);
+                        expect(round(grid.getSubBoundingRect("toParent", id, interpreter))).toEqual(poster);
+                        // Local space is parent space minus the node's own translation.
+                        expect(round(grid.getSubBoundingRect("local", id, interpreter))).toEqual({
+                            ...poster,
+                            x: poster.x - translation[0],
+                            y: poster.y - translation[1],
+                        });
+                    }
+                });
+
+                test(`${label}: the focus bitmap does not influence the reported item rect`, () => {
+                    const withFocus = renderGrid(type, resolution, translation);
+                    const focused = round(withFocus.grid.getSubBoundingRect("toScene", "focusItem", interpreter));
+
+                    // Suppressing the drawn frame changes nothing...
+                    const noDraw = renderGrid(type, resolution, translation, {
+                        drawFocusFeedback: BrsBoolean.False,
+                    });
+                    expect(round(noDraw.grid.getSubBoundingRect("toScene", "focusItem", interpreter))).toEqual(focused);
+
+                    // ...and neither does removing the focus bitmaps entirely. This forecloses
+                    // re-deriving any part of the reported rect from the 9-patch's margins.
+                    const noBitmap = renderGrid(type, resolution, translation, {
+                        focusBitmapUri: new BrsString(""),
+                        focusFootprintBitmapUri: new BrsString(""),
+                    });
+                    expect(round(noBitmap.grid.getSubBoundingRect("toScene", "focusItem", interpreter))).toEqual(
+                        focused
+                    );
+                });
+
+                // Only RowList reports its own extent (renderContent -> updateRect). ZoomRowList never
+                // calls updateRect, so its own rect stays zero-sized — a separate, pre-existing gap.
+                const ownRectTest = type === "RowList" ? test : test.skip;
+                ownRectTest(`${label}: the grid's OWN rect stays outset by marginX/marginY`, () => {
+                    // The counterpart of the assertion above: the grid's own reported rect IS outset
+                    // (device-measured), so "the item rect carries no outset" must not be achieved by
+                    // dropping the grid's outset — which is how a revert of that fix would look.
+                    const { grid } = renderGrid(type, resolution, translation);
+                    const own = round(grid.getBoundingRect("toParent", interpreter));
+                    const firstItem = round(grid.rowItemComps[0][0].rectToScene);
+                    expect(grid.marginX).toBeGreaterThan(0);
+                    expect(grid.marginY).toBeGreaterThan(0);
+                    expect(own.x).toBe(firstItem.x - grid.marginX);
+                    expect(own.y).toBe(firstItem.y - grid.marginY);
+                });
+
+                test(`${label}: the DRAWN focus frame is outset even though the reported rect is not`, () => {
+                    // What made the double subtraction plausible: the painted frame really does sit
+                    // above the poster. It is drawn geometry, not reported geometry — the two are
+                    // allowed (required) to differ, so do not "correct" one to match the other.
+                    const { grid, frames } = renderGrid(type, resolution, translation);
+                    const poster = round(grid.rowItemComps[0][1].rectToScene);
+                    const bmp = grid.getBitmap("focusBitmapUri");
+                    expect(bmp?.isValid()).toBe(true);
+                    const margins = grid.focusMargins(bmp);
+                    expect(margins.top).toBeGreaterThan(0);
+
+                    const frame = frames.find(
+                        (f) => Math.round(f.x) === poster.x - margins.left && Math.round(f.y) === poster.y - margins.top
+                    );
+                    expect(frame).toBeDefined();
+                    expect(Math.round(frame.width)).toBe(poster.width + margins.left + margins.right);
+                    expect(Math.round(frame.height)).toBe(poster.height + margins.top + margins.bottom);
+
+                    // ...and the reported rect for that same cell is still the bare poster.
+                    expect(round(grid.getSubBoundingRect("toScene", "focusItem", interpreter))).toEqual(poster);
+                });
+            }
+        }
+    }
+});

--- a/test/extensions/scenegraph/SubBoundingRect.test.js
+++ b/test/extensions/scenegraph/SubBoundingRect.test.js
@@ -111,33 +111,29 @@ describe("ifSGNodeBoundingRect sub-part methods", () => {
         });
     }
 
-    // RowList extends the FOCUSED cell's rect upward by the focus-feedback top margin so an app that
-    // offsets its overlay by the focus footprint lands the overlay on the poster (the item component's
-    // own rect is the bare poster; the focus 9-patch frame is drawn outset above it). Only the focused
-    // cell draws the frame, so only its rect is adjusted.
-    test("RowList outsets the focused item's rect by the focus-feedback top margin", () => {
+    // A device reports the FOCUSED cell's sub-rect as the bare poster — the same rect it reports for a
+    // non-focused cell. The focus 9-patch frame is drawn outset around the poster, and the list's OWN
+    // boundingRect is outset by rectMargins, but neither reaches an item sub-rect. An outset used to be
+    // subtracted here (the 9-patch's top margin, to make an overlay land on the poster); it was double
+    // counting, silently cancelled by a rectToParent bug that dropped the rectMargins outset from the
+    // base rect. This pins the un-outset result so the subtraction is not re-introduced.
+    test("RowList reports the focused item's bare poster rect, not the focus-feedback footprint", () => {
         const list = new RowList();
         buildRowGrid(list);
         const focusedPoster = list.rowItemComps[1][2].rectToScene;
 
         for (const id of ["item1_2", "item1", "focusItem", "focusIndicator"]) {
-            const r = list.getSubBoundingRect("toScene", id);
-            const top = focusedPoster.y - r.y;
-            expect(top).toBeGreaterThan(0); // outset above the poster
-            expect(r.x).toBe(focusedPoster.x);
-            expect(r.width).toBe(focusedPoster.width);
-            expect(r.height).toBe(focusedPoster.height + top); // grows by the same top margin
+            expect(list.getSubBoundingRect("toScene", id)).toEqual(focusedPoster);
         }
 
-        // A non-focused cell is NOT outset — it reports its bare poster rect.
+        // A non-focused cell reports its bare poster rect too — focus makes no difference.
         expect(list.getSubBoundingRect("toScene", "item0_0")).toEqual(list.rowItemComps[0][0].rectToScene);
 
-        // The outset is keyed to the focus bitmap, not drawFocusFeedback: suppressing the drawn frame
-        // still reserves the footprint (apps that render their own focus indicator rely on this).
+        // Nothing about the focus feedback influences the reported rect: neither suppressing the drawn
+        // frame nor clearing both focus bitmaps changes it.
         list.setValue("drawFocusFeedback", core.BrsBoolean.False);
-        expect(list.getSubBoundingRect("toScene", "item1_2").y).toBeLessThan(focusedPoster.y);
+        expect(list.getSubBoundingRect("toScene", "item1_2")).toEqual(focusedPoster);
 
-        // With no focus bitmap there is no footprint, so the focused cell reports its bare poster rect.
         list.setValue("focusBitmapUri", new core.BrsString(""));
         list.setValue("focusFootprintBitmapUri", new core.BrsString(""));
         expect(list.getSubBoundingRect("toScene", "item1_2")).toEqual(focusedPoster);


### PR DESCRIPTION
## Problem

`subBoundingRect("item<row>_<col>")` on a `RowList` subtracted the focus 9-patch's top content margin from the focused cell. An app placing a focused-item overlay (poster/video preview) from that rect drew it **one focus margin too high** — a regression surfaced by #1138.

## Root cause: a double subtraction that #1138 exposed

Three PRs each chased the same device symptom ("the overlay sits too low"), and two of them subtracted the *same* outset:

| state | `sub.y − focusedPoster.y` |
| --- | --- |
| `RowList.marginY` = 33/22 (square, unmeasured) | +33 |
| `marginY` → 6/4 (device-measured, #1029) | +6 |
| plus `− focusMargins(bmp).top` in `RowList.getSubBoundingRect` (#1030) | **0** ← aligned, by two errors cancelling |
| minus the `+marginY` leak, once `updateBoundingRects` was fixed (#1138) | **−6** ← the regression |

`Group.updateBoundingRects` built `rectToParent` from the node's *translation*, discarding the `rectMargins` outset that `ArrayGrid.updateRect` applies. `Node.getSubBoundingRect` re-expresses a sub-rect as `base.y + (subScene.y − this.rectToScene.y)`; with `base` un-outset and `rectToScene` outset, a `+marginY` residue survived and silently cancelled #1030's subtraction. #1138 made `base` carry the outset too — correct — which left #1030 uncompensated.

The cancellation was invisible because it was *exact* for the app in question, whose focus 9-patch declares 6px content margins — the same number as `RowList`'s FHD `marginY`. The default `focus_grid.9.png` declares 19px, so the CLI fixture (HD, `marginY` 4) had visibly un-cancelled arithmetic all along; that expectation was moved (`−15` → `−19`) rather than questioned. #1030's own regression test asserted only the *shape* of the outset (`top > 0`), never a pixel count, so it never disagreed with a device either.

## Which side is wrong

Two facts settle it:

- `sceneSubBoundingRect` was **already** `poster − top` before #1138 — the three coordinate spaces silently disagreed by `marginY`, and #1138 only made `toParent`/`local` agree with the space that already leaked.
- #1138 independently moved `PosterGridItem`'s sub-rect onto its poster (`sub.y` 4 → 0).

So **`subBoundingRect("item<r>_<c>")` == the item component's own rect** is the engine-wide calibrated invariant, and #1030's footprint outset was double-counting from the day it landed.

## Three outsets, only two of which exist

| outset | applied by | shows up in |
| --- | --- | --- |
| `rectMargins()` → `marginX`/`marginY` | `ArrayGrid.updateRect` | the **grid's own** reported rect (device-measured) |
| `focusMargins(bmp)` → the 9-patch's declared margins | `ArrayGrid.renderFocus` | the **drawn** focus frame — paint only, nothing reports it |
| *(none)* | — | an **item sub-rect** |

The grid's own outset doesn't leak into an item sub-rect because it *cancels*: `base` and `rectToScene` carry it identically. Any future per-space adjustment must be applied to all three spaces or it reappears as a residue.

## Change

- **Delete** `RowList.getSubBoundingRect`. `RowList` now inherits `Node.getSubBoundingRect` verbatim, like `MarkupGrid`, `MarkupList`, `LabelList` and `ZoomRowList` (none has an override).
- **Keep** `resolveSubpart` — mapping `item<row>_<col>` into the 2-D `rowItemComps[row][col]` is #1029's real, independent fix and is what makes the API work at all (the flat `itemComps[]` stays empty on row lists). It now carries a comment separating the three outsets and recording that the footprint subtraction must not come back.
- Also fixes **`ZoomRowList`** for free: it has `hasNinePatch`, `marginY` 18/12 and `resolveSubpart`, but never had the `−top` compensation, so post-#1138 it reported `poster − marginY` with no test coverage at all.
- One stale comment from #1138's refactor corrected in `PosterGrid.ts` (the early-break path *does* include the trailing gap now).

## Tests

- `SubBoundingRect.test.js` — #1030's expectation reversed **in place** (same fixture, same id loop, opposite assertion), so the diff reads as a deliberate reversal. The invariance sub-assertions flip too: clearing `drawFocusFeedback` and both bitmap URIs must leave the rect *unchanged*.
- `rowlist-subrect-app` — moved off-origin (`translation = [40,120]`) and now asserts its own invariant in BrightScript (`rect.y = grid.translation[1]`, `rect.height = grid.rowItemSize[0][1]`) instead of printing a magic pixel, so no constant can drift.
- **New `RowListItemSubRect.test.js`** — pins the *composition* through a real render over {HD,FHD} × {RowList,ZoomRowList} × translations {[0,0],[100,300]}, because `SubBoundingRect.test.js` works on injected rects and cannot catch a drift between the outset a grid applies to itself and the cancellation that keeps it out of an item rect. Four assertions per configuration:
  1. the sub-rect equals the item component's own rect in all three spaces;
  2. bitmap independence (`drawFocusFeedback` off, both URIs cleared) — forecloses re-deriving any part of the rect from the 9-patch;
  3. the grid's **own** rect stays outset by `marginX`/`marginY` — guards #1138 from being reverted as a "fix" for this symptom;
  4. the **drawn** 9-patch frame *is* outset on all four sides while the reported rect is the bare poster — this is what stops the next reader from "correcting" the reported rect to match what they see painted, which is exactly how #1030 happened.

Validated as a genuine regression test, not a tautology: with only `RowList.ts` reverted, 12 of its tests fail.

4 tests are `skip`ped for `ZoomRowList`'s own-extent assertion — it never calls `updateRect`, so it reports no extent of its own. Separate pre-existing gap, noted in the test.

## Verification

- `npm run lint` clean; full suite **2495 passed / 4 skipped / 2 todo** across 200 files.
- `PosterGridExtent.test.js` all 10 green — this fix does not touch #1138.
- End-to-end confirmed by the reporter: the home-screen preview overlay aligns with the focused row again.

## Documented

`.claude/docs/scenegraph-invariants.md` gains **"A grid's reported rect is outset — its item sub-rects are NOT"**: the three outsets and who owns each, the cancellation condition, the table above as a worked example, and the deferred #1138 fallout recorded as unfixed (LayoutGroup child displacement by exactly `(marginX, marginY)`; ancestor `renderTracking` flipping `"full"` → `"partial"`; two side effects worth locking in with tests). The "Related general fix" paragraph gains the corollary this fix demonstrated: **a compensating error in a consumer is equally silent, and repairing the producer is what surfaces it** — so when you fix a geometry producer, audit its consumers for adjustments calibrated against the broken value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)