### PR TITLE
test(probes): Add LayoutGroup layoutDirection and itemSpacings probes

### DIFF
--- a/test/simulator/probes/layoutalign-probe/README.md
+++ b/test/simulator/probes/layoutalign-probe/README.md
@@ -1,0 +1,199 @@
+# LayoutGroup `horizAlignment` / `vertAlignment` probe
+
+Companion to [`layoutgroup-probe`](../layoutgroup-probe/), which measured `layoutDirection` on
+hardware and found the engine had it wrong: the field is an **enum**, an unrecognized value is
+**rejected** (reads back `""`), and that rejected state lays out **horizontally** — the opposite of
+the documented `vert` default. That fix shipped in brs-engine PR #1122.
+
+`horizAlignment` and `vertAlignment` are the same shape of field: a documented closed set of string
+values (`left`/`center`/`right`/`custom`, `top`/`center`/`bottom`/`custom`). brs-engine currently
+falls back to `left`/`top` for anything it doesn't recognize — an assumption that has not been
+checked against a device, and that the `layoutDirection` result says not to trust.
+
+## The two questions
+
+1. **Storage** — is an unrecognized value stored verbatim, canonicalized to lowercase, or rejected
+   to `""`? Is matching case-sensitive? Does an invalid write **clobber** an already-valid one? Is a
+   value valid for the *sibling* field accepted (`horizAlignment="top"`)?
+2. **Geometry** — what does the layout actually *do* for each value, including rejected ones, and
+   for `custom` on the axis where Roku documents it as invalid?
+
+## Method
+
+Each case is a `LayoutGroup` holding two deliberately **different** children, plus a 2×2 marker
+rectangle placed at exactly the group's translation:
+
+```
+child 0: 30 x  8, own translation [7, 13]
+child 1: 50 x 16, own translation [11, 17]
+itemSpacings: [4]
+```
+
+Offsets are measured as `child.sceneBoundingRect() − marker.sceneBoundingRect()`, so nothing depends
+on how the device computes a LayoutGroup's *own* bounding rect. The children carry non-zero
+translations of their own so a `custom` (unmanaged) axis is distinguishable from an aligned one.
+
+Those offsets are then **classified** into the behavior the geometry demonstrates — `left`/`top`,
+`center`, `right`/`bottom`, `custom`, or `other` — computed from the child sizes rather than
+hard-coded. So each row reads as *"`centre` → stored `""` → behaves `left`"* with no coordinate
+arithmetic required of the reader.
+
+### Four case groups
+
+Each field's meaning depends on `layoutDirection`: the field controlling the **layout axis** aligns
+the run *as a whole* (primary), while the field controlling the other axis aligns **each child
+independently** (cross). All four combinations are covered:
+
+| | layoutDirection | field varied | axis |
+| --- | --- | --- | --- |
+| A | `vert` | `horizAlignment` | cross |
+| B | `horiz` | `horizAlignment` | primary |
+| C | `vert` | `vertAlignment` | primary |
+| D | `horiz` | `vertAlignment` | cross |
+
+12 spellings per group (48 cases): the documented values, case variants (`LEFT`, `Center`), a
+plausible misspelling (`centre`), a plausible synonym (`middle`), the empty string, junk (`bogus`), a
+value belonging to the **sibling** field (`top` in `horizAlignment`), and a `center` **then** `bogus`
+double write to test clobbering.
+
+`layoutDirection` itself is always set to a valid value here, so the enum behavior found by the other
+probe cannot interfere.
+
+## What the docs say
+
+From `external/dev-doc/.../LayoutGroup.md`, alignment sets the LayoutGroup's **local coordinate
+origin**:
+
+- **cross axis** — `left`/`top` aligns those edges of each child at the origin; `center` aligns each
+  child's center on the origin; `right`/`bottom` aligns those edges at the origin; `custom` means the
+  app sets each child's translation on that axis.
+- **primary axis** — the origin sits at the start / center / end of the whole run.
+- `custom` is documented as valid **only on the cross axis**: "If the layoutDirection is `horiz`,
+  custom is not a valid setting; `left` is used instead" (and the mirror for `vertAlignment`).
+
+That documented `custom` fallback is itself worth confirming — it is exactly the kind of "invalid
+value falls back to the default" claim that turned out to be wrong for `layoutDirection`.
+
+## Running it
+
+**On a Roku device** (developer mode enabled):
+
+```bash
+curl -f -u "rokudev:<devpassword>" -F "mysubmit=Install" \
+  -F "archive=@/Users/marcelocabral/Projects/Samples/layoutalign-probe.zip" \
+  "http://<roku-ip>/plugin_install"
+```
+
+Results render on screen (each row shows its own mini-layout beside its numbers) and print to the
+console:
+
+```bash
+telnet <roku-ip> 8085
+```
+
+The probe re-runs three times, 1.2s apart, then stops.
+
+**In the simulator**, for the side-by-side comparison:
+
+```bash
+brs-cli --root /Users/marcelocabral/Projects/Samples/layoutalign-probe
+```
+
+## Result
+
+Run on hardware 2026-07-30, stable across all three passes. Two findings — one expected, one not.
+
+### 1. Storage: the same rejecting enum as `layoutDirection`
+
+| Written | Reads back |
+| --- | --- |
+| `left` / `center` / `right` / `custom` (and `top`/`bottom`) | verbatim |
+| `LEFT`, `TOP`, `Center` | canonical lowercase — `"left"`, `"top"`, `"center"` |
+| `centre`, `middle`, `bogus`, `""` | `""` (rejected) |
+| a value valid for the **sibling** field (`horizAlignment="top"`) | `""` (rejected) |
+| `center` then `bogus` | `""` — the invalid write **clobbers** the valid one |
+
+So the two alignment fields do **not** share one value table, and near-misses get no leniency. The
+engine stored everything verbatim and was wrong on all of these.
+
+### 2. Geometry: a rejected CROSS-axis alignment collapses the whole layout
+
+Valid values behaved exactly as documented, and exactly as the engine already had them — including
+`custom` falling back to `left`/`top` on the primary axis. But look at the rejected rows in groups
+**A** and **D** (where the varied field governs the *cross* axis):
+
+```
+A) layoutDirection=vert   horizAlignment (cross)
+  left     "left"   left   c0=(0,0)   c1=(0,12)     <- normal: stacked 8+4 apart
+  bogus    ""       left   c0=(0,0)   c1=(0,0)      <- both children ON the origin
+```
+
+A `left` fallback would still stack the children on the primary axis (`c1=(0,12)`). The device puts
+**both at (0,0)** — it abandons the layout entirely: no stacking, no item spacing, and the children's
+own translations (`[7,13]` and `[11,17]`) are discarded too. The primary-axis alignment is ignored
+even though it is perfectly valid.
+
+Groups **B** and **C**, where the varied field governs the *primary* axis, do **not** do this — a
+rejected value there simply falls back to `left`/`top`. So the trigger is specifically a rejected
+**cross-axis** alignment.
+
+This looks like a device bug. brs-engine now reproduces it anyway (`collapseChildren`), on the
+grounds that an app with a typo'd alignment piles its children on the origin on hardware — and a
+simulator that quietly laid them out neatly would hide the breakage until it shipped.
+
+**Verdict:** storage was wrong for every non-canonical value; geometry was right for all valid values
+and wrong for the rejected cross-axis case. Fixed in `src/extensions/scenegraph/nodes/LayoutGroup.ts`
+(`canonicalizeEnumField`, `isCrossAlignmentRejected`, `collapseChildren`), pinned by
+`test/extensions/scenegraph/LayoutAlignment.test.js`. Re-running this channel under `brs-cli` after
+the fix reproduces all 48 device rows exactly.
+
+## brs-engine baseline BEFORE the fix (what was wrong)
+
+Captured from `brs-cli` on `fix/layoutgroup-direction-enum` before the alignment work. Condensed:
+
+| Spelling | Stored | A (vert/horiz cross) | B (horiz/horiz primary) | C (vert/vert primary) | D (horiz/vert cross) |
+| --- | --- | --- | --- | --- | --- |
+| `left` / `top` | verbatim | left | left | top | top |
+| `center` | verbatim | center | center | center | center |
+| `right` / `bottom` | verbatim | right | right | bottom | bottom |
+| `custom` | verbatim | **custom** | left | top | **custom** |
+| `LEFT` / `TOP` | verbatim | left | left | top | top |
+| `Center` | verbatim | center | center | center | center |
+| `centre` | verbatim | left | left | top | top |
+| `middle` | verbatim | left | left | top | top |
+| (empty) | `""` | left | left | top | top |
+| `bogus` | verbatim | left | left | top | top |
+| sibling value | verbatim | left | left | top | top |
+| `center` then `bogus` | `"bogus"` | left | left | top | top |
+
+So brs-engine today: **stores every string verbatim** (never canonicalizes, never rejects), matches
+the documented values **case-insensitively**, falls back to **`left`/`top`** for everything else, and
+honors `custom` only on the cross axis (matching the documented fallback).
+
+Sample raw geometry (group A, `layoutDirection=vert`, cross axis) — this is what the classifier is
+reading:
+
+```
+  spelling            stored        behavior    c0 offset      c1 offset
+  left                "left"        left        (0,0)          (0,12)
+  center              "center"      center      (-15,0)        (-25,12)
+  right               "right"       right       (-30,0)        (-50,12)
+  custom              "custom"      custom      (7,0)          (11,12)
+```
+
+## A note on the `behavior` column and the collapse
+
+The classifier reports the collapsed rows as `left`/`top`, because both children sitting at the
+origin *does* satisfy "start-aligned" on the measured axis. The collapse is only visible in the raw
+`c1` offset — `(0,0)` where a real `left` gives `(0,12)`. That is why the raw offsets are printed
+next to every verdict rather than the verdict alone: the classification is a convenience, the
+coordinates are the evidence. Worth remembering if this channel is extended.
+
+## Still unmeasured
+
+- Both alignment fields rejected **at once** — the engine applies the cross-axis collapse, which is
+  an extrapolation, not a measurement.
+- The LayoutGroup's **own** bounding rect in the collapsed state. The engine reports the union of the
+  children at the origin (max width × max height); the probe never read the group's own rect.
+- `itemSpacings` and `addItemSpacingAfterChild` value handling (negative spacings, short arrays,
+  non-numeric entries) — a third probe's worth of questions.

--- a/test/simulator/probes/layoutalign-probe/components/MainScene.brs
+++ b/test/simulator/probes/layoutalign-probe/components/MainScene.brs
@@ -1,0 +1,304 @@
+' LayoutGroup horizAlignment / vertAlignment probe.
+'
+' Companion to the layoutgroup-probe channel, which established that layoutDirection is an ENUM
+' whose REJECTED state (unrecognized value) reads back "" and lays out horizontally -- the opposite
+' of the documented "vert" default. This channel asks the same two questions of the alignment
+' fields, whose values are also documented as a closed set:
+'
+'   1. Storage  - is an unrecognized value stored verbatim, canonicalized, or rejected to ""?
+'                 Is matching case-sensitive? Is a value from the SIBLING field accepted
+'                 (horizAlignment="top")?
+'   2. Geometry - what does the layout actually DO for each value, including rejected ones and
+'                 "custom" on the axis where Roku documents it as invalid?
+'
+' Method. Each case is a LayoutGroup with two deliberately DIFFERENT children, plus a 2x2 marker
+' rectangle placed at exactly the group's translation. Offsets are measured as
+' child.sceneBoundingRect() - marker.sceneBoundingRect(), so nothing depends on how the device
+' computes a LayoutGroup's own bounding rect. Both children also carry a non-zero translation of
+' their own, so a "custom" (unmanaged) axis is distinguishable from an aligned one.
+'
+'   child 0: 30 x 8,  own translation [7, 13]
+'   child 1: 50 x 16, own translation [11, 17]
+'   itemSpacings: [4]
+'
+' Those offsets are then CLASSIFIED into the behavior the geometry shows -- start / center / end /
+' custom -- computed from the child sizes rather than hard-coded, so a row reads as
+' "centre -> stored "" -> behaves left" without anyone having to interpret raw coordinates.
+'
+' Four case groups, because each field's meaning depends on layoutDirection: the field controlling
+' the layout axis aligns the RUN AS A WHOLE (primary), while the field controlling the other axis
+' aligns EACH CHILD independently (cross).
+'
+'   A  layoutDirection=vert   horizAlignment  (cross)
+'   B  layoutDirection=horiz  horizAlignment  (primary)
+'   C  layoutDirection=vert   vertAlignment   (primary)
+'   D  layoutDirection=horiz  vertAlignment   (cross)
+
+sub init()
+    m.top.backgroundURI = ""
+    m.top.backgroundColor = "0x0E1015FF"
+
+    m.rowPitch = 34
+    m.markerX = 760
+    m.probesRun = 0
+
+    m.childA = { w: 30, h: 8, tx: 7, ty: 13, color: "0xE05555FF" }
+    m.childB = { w: 50, h: 16, tx: 11, ty: 17, color: "0x5599E0FF" }
+    m.spacing = 4
+
+    di = CreateObject("roDeviceInfo")
+    m.top.findNode("subtitle").text = di.GetModelDisplayName() + " (" + di.GetModel() + ")  Roku OS " + di.GetOSVersion().major + "." + di.GetOSVersion().minor
+
+    buildAllGroups()
+
+    m.timer = m.top.findNode("probeTimer")
+    m.timer.observeField("fire", "onProbe")
+    m.timer.control = "start"
+end sub
+
+' Spellings tried for horizAlignment. Beyond the documented set: case variants, a plausible
+' misspelling, a plausible synonym, the empty string, junk, and a value that is valid for the
+' SIBLING field ("top") -- which tells us whether the two fields share one value table.
+function horizValues() as object
+    return [
+        { label: "left", assign: true, value: "left" },
+        { label: "center", assign: true, value: "center" },
+        { label: "right", assign: true, value: "right" },
+        { label: "custom", assign: true, value: "custom" },
+        { label: "LEFT", assign: true, value: "LEFT" },
+        { label: "Center", assign: true, value: "Center" },
+        { label: "centre", assign: true, value: "centre" },
+        { label: "middle", assign: true, value: "middle" },
+        { label: "(empty)", assign: true, value: "" },
+        { label: "bogus", assign: true, value: "bogus" },
+        { label: "top", assign: true, value: "top" },
+        { label: "center then bogus", assign: true, value: "center", second: "bogus" }
+    ]
+end function
+
+function vertValues() as object
+    return [
+        { label: "top", assign: true, value: "top" },
+        { label: "center", assign: true, value: "center" },
+        { label: "bottom", assign: true, value: "bottom" },
+        { label: "custom", assign: true, value: "custom" },
+        { label: "TOP", assign: true, value: "TOP" },
+        { label: "Center", assign: true, value: "Center" },
+        { label: "centre", assign: true, value: "centre" },
+        { label: "middle", assign: true, value: "middle" },
+        { label: "(empty)", assign: true, value: "" },
+        { label: "bogus", assign: true, value: "bogus" },
+        { label: "left", assign: true, value: "left" },
+        { label: "center then bogus", assign: true, value: "center", second: "bogus" }
+    ]
+end function
+
+function groupDefs() as object
+    return [
+        { key: "A", direction: "vert", fieldName: "horizAlignment", axis: "cross", measure: "x", values: horizValues() },
+        { key: "B", direction: "horiz", fieldName: "horizAlignment", axis: "primary", measure: "x", values: horizValues() },
+        { key: "C", direction: "vert", fieldName: "vertAlignment", axis: "primary", measure: "y", values: vertValues() },
+        { key: "D", direction: "horiz", fieldName: "vertAlignment", axis: "cross", measure: "y", values: vertValues() }
+    ]
+end function
+
+sub buildAllGroups()
+    m.groups = []
+    colLeft = m.top.findNode("colLeft")
+    colRight = m.top.findNode("colRight")
+
+    defs = groupDefs()
+    slotLeft = 0
+    slotRight = 0
+
+    for each groupDef in defs
+        if groupDef.key = "A" or groupDef.key = "B"
+            slotLeft = buildGroup(groupDef, colLeft, slotLeft)
+        else
+            slotRight = buildGroup(groupDef, colRight, slotRight)
+        end if
+        m.groups.push(groupDef)
+    end for
+end sub
+
+' Lays one case group into a column starting at the given row slot; returns the next free slot.
+function buildGroup(groupDef as object, column as object, startSlot as integer) as integer
+    slot = startSlot
+
+    header = createLabel(column, slot, "0x66E08AFF")
+    header.text = groupDef.key + ")  layoutDirection=" + groupDef.direction + "   " + groupDef.fieldName + "   (" + groupDef.axis + " axis)"
+    slot = slot + 1
+
+    groupDef.rows = []
+    for each spelling in groupDef.values
+        layoutGroup = CreateObject("roSGNode", "LayoutGroup")
+        layoutGroup.layoutDirection = groupDef.direction
+        layoutGroup.itemSpacings = [m.spacing]
+        if spelling.assign then layoutGroup.setField(groupDef.fieldName, spelling.value)
+        ' A second write probes whether an invalid value clobbers an already-valid one.
+        if spelling.second <> invalid then layoutGroup.setField(groupDef.fieldName, spelling.second)
+
+        addChild(layoutGroup, m.childA)
+        addChild(layoutGroup, m.childB)
+
+        originY = slot * m.rowPitch + 14
+        layoutGroup.translation = [m.markerX, originY]
+
+        ' Reference point for every offset: a sibling at the group's exact translation.
+        marker = CreateObject("roSGNode", "Rectangle")
+        marker.width = 2
+        marker.height = 2
+        marker.color = "0xFFFFFFFF"
+        marker.translation = [m.markerX, originY]
+
+        column.appendChild(marker)
+        column.appendChild(layoutGroup)
+
+        groupDef.rows.push({
+            spelling: spelling,
+            layoutGroup: layoutGroup,
+            marker: marker,
+            text: createLabel(column, slot, "0xDDDDDDFF")
+        })
+        slot = slot + 1
+    end for
+
+    ' Blank slot between groups.
+    return slot + 1
+end function
+
+sub addChild(layoutGroup as object, spec as object)
+    bar = CreateObject("roSGNode", "Rectangle")
+    bar.width = spec.w
+    bar.height = spec.h
+    bar.color = spec.color
+    bar.translation = [spec.tx, spec.ty]
+    layoutGroup.appendChild(bar)
+end sub
+
+function createLabel(column as object, slot as integer, color as string) as object
+    label = CreateObject("roSGNode", "Label")
+    label.translation = [0, slot * m.rowPitch]
+    label.width = 740
+    label.color = color
+    column.appendChild(label)
+    return label
+end function
+
+sub onProbe()
+    m.probesRun = m.probesRun + 1
+
+    print ""
+    print "===== LayoutGroup alignment probe - pass "; m.probesRun; " ====="
+    print "children: c0 = 30x8 @ [7,13]   c1 = 50x16 @ [11,17]   itemSpacings [4]"
+    print "offsets are relative to the LayoutGroup's own origin (marker rectangle)"
+
+    for each groupDef in m.groups
+        print ""
+        print groupDef.key + ")  layoutDirection=" + groupDef.direction + "   " + groupDef.fieldName + "   (" + groupDef.axis + " axis, measured on " + groupDef.measure + ")"
+        print "  spelling            stored        behavior    c0 offset      c1 offset"
+        print "  ------------------  ------------  ----------  -------------  -------------"
+
+        for each row in groupDef.rows
+            stored = row.layoutGroup.getField(groupDef.fieldName)
+            offsetA = offsetOf(row.layoutGroup.getChild(0), row.marker)
+            offsetB = offsetOf(row.layoutGroup.getChild(1), row.marker)
+            behavior = classify(groupDef, offsetA, offsetB)
+
+            line = padRight(row.spelling.label, 20) + padRight(quoted(stored), 14) + padRight(behavior, 12)
+            line = line + padRight(point(offsetA), 15) + point(offsetB)
+
+            row.text.text = padRight(row.spelling.label, 19) + padRight(quoted(stored), 12) + padRight(behavior, 11) + point(offsetA) + " " + point(offsetB)
+            row.text.color = behaviorColor(behavior)
+
+            print "  "; line
+        end for
+    end for
+
+    print ""
+    print "behavior is derived from geometry, not from the stored string:"
+    print "  start  = left/top edges at the origin        center = children centered on the origin"
+    print "  end    = right/bottom edges at the origin    custom = child's own translation kept"
+
+    if m.probesRun >= 3 then m.timer.control = "stop"
+end sub
+
+function offsetOf(child as object, marker as object) as object
+    childRect = child.sceneBoundingRect()
+    markerRect = marker.sceneBoundingRect()
+    return { x: childRect.x - markerRect.x, y: childRect.y - markerRect.y }
+end function
+
+' Classifies the measured geometry into the alignment behavior it demonstrates. Expectations are
+' computed from the child specs, so the classifier stays correct if the child sizes are changed.
+function classify(groupDef as object, offsetA as object, offsetB as object) as string
+    if groupDef.measure = "x"
+        sizeA = m.childA.w
+        sizeB = m.childB.w
+        ownA = m.childA.tx
+        ownB = m.childB.tx
+        valueA = offsetA.x
+        valueB = offsetB.x
+        startName = "left"
+        endName = "right"
+    else
+        sizeA = m.childA.h
+        sizeB = m.childB.h
+        ownA = m.childA.ty
+        ownB = m.childB.ty
+        valueA = offsetA.y
+        valueB = offsetB.y
+        startName = "top"
+        endName = "bottom"
+    end if
+
+    if groupDef.axis = "cross"
+        ' Each child is aligned independently against the origin.
+        if near(valueA, 0) and near(valueB, 0) then return startName
+        if near(valueA, -sizeA / 2) and near(valueB, -sizeB / 2) then return "center"
+        if near(valueA, -sizeA) and near(valueB, -sizeB) then return endName
+        if near(valueA, ownA) and near(valueB, ownB) then return "custom"
+        return "other"
+    end if
+
+    ' Primary axis: the whole run is placed as a unit, children packed with itemSpacings.
+    total = sizeA + m.spacing + sizeB
+    if near(valueA, 0) and near(valueB, sizeA + m.spacing) then return startName
+    if near(valueA, -total / 2) and near(valueB, -total / 2 + sizeA + m.spacing) then return "center"
+    if near(valueA, -total) and near(valueB, -total + sizeA + m.spacing) then return endName
+    if near(valueA, ownA) and near(valueB, ownB) then return "custom"
+    return "other"
+end function
+
+function behaviorColor(behavior as string) as string
+    if behavior = "other" then return "0xFF6666FF"
+    if behavior = "custom" then return "0xE0A050FF"
+    return "0xDDDDDDFF"
+end function
+
+function near(a as float, b as float) as boolean
+    return abs(a - b) < 0.75
+end function
+
+function point(offset as object) as string
+    return "(" + num(offset.x) + "," + num(offset.y) + ")"
+end function
+
+function num(value as float) as string
+    rounded = cint(value)
+    if abs(value - rounded) < 0.01 then return rounded.toStr()
+    return str(value).trim()
+end function
+
+function quoted(value as dynamic) as string
+    if value = invalid then return "<invalid>"
+    return chr(34) + value.toStr() + chr(34)
+end function
+
+function padRight(text as string, width as integer) as string
+    result = text
+    while len(result) < width
+        result = result + " "
+    end while
+    return result
+end function

--- a/test/simulator/probes/layoutalign-probe/components/MainScene.xml
+++ b/test/simulator/probes/layoutalign-probe/components/MainScene.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="MainScene" extends="Scene">
+  <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+
+  <children>
+    <Label id="title" text="LayoutGroup horizAlignment / vertAlignment - value probe" translation="[50, 22]" font="font:LargeBoldSystemFont" color="0xFFFFFFFF" />
+    <Label id="subtitle" translation="[50, 70]" font="font:SmallSystemFont" color="0xAAAAAAFF" />
+    <Label id="legend" translation="[50, 100]" font="font:SmallSystemFont" color="0x66CCFFFF"
+           text="behavior = what the geometry actually did, classified from the children's measured offsets. Full detail printed to the console." />
+
+    <!-- Cases are created in code; each column holds two case groups. -->
+    <Group id="colLeft" translation="[50, 140]" />
+    <Group id="colRight" translation="[990, 140]" />
+
+    <Timer id="probeTimer" repeat="true" duration="1.2" />
+  </children>
+</component>

--- a/test/simulator/probes/layoutalign-probe/manifest
+++ b/test/simulator/probes/layoutalign-probe/manifest
@@ -1,0 +1,14 @@
+#
+#  LayoutGroup horizAlignment / vertAlignment probe
+#  Determines how a real Roku device resolves alignment values, including invalid ones.
+#
+
+title=LayoutGroup Alignment Probe
+subtitle=horizAlignment / vertAlignment behavior
+major_version=1
+minor_version=0
+build_version=1
+
+ui_resolutions=fhd
+
+bs_const=DEBUG=false

--- a/test/simulator/probes/layoutalign-probe/source/main.brs
+++ b/test/simulator/probes/layoutalign-probe/source/main.brs
@@ -1,0 +1,14 @@
+sub Main()
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    screen.CreateScene("MainScene")
+    screen.show()
+
+    while true
+        msg = wait(0, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        end if
+    end while
+end sub

--- a/test/simulator/probes/layoutgroup-probe/README.md
+++ b/test/simulator/probes/layoutgroup-probe/README.md
@@ -1,0 +1,128 @@
+# LayoutGroup `layoutDirection` probe
+
+A one-screen Roku channel that answers a single question empirically:
+
+> **Which `layoutDirection` spellings does a real Roku device treat as horizontal, and what
+> does it do with a value it does not recognize?**
+
+The trigger was JellyRock's top menu. Two of its LayoutGroups spell the value `"horz"` instead of
+`"horiz"` (`components/ui/tabbar/JRTabBar.xml`, `components/ui/dropdown/JRDropdown.xml`), and in
+brs-engine they lay out vertically — the Favorites tab lands under Home, the user name under the
+avatar. Roku's reference docs list only `horiz` and `vert`, so brs-engine falls back to the
+documented default. Whether hardware does the same is what this channel measures.
+
+## What it tests
+
+Twelve cases, each a `LayoutGroup` holding three colored bars:
+
+| # | Spelling | Why it's here |
+| --- | --- | --- |
+| 0 | attribute absent | Baseline: the documented default (`vert`) |
+| 1 | `horiz` | Documented horizontal |
+| 2 | `vert` | Documented vertical |
+| 3 | `horz` | **The JellyRock value** |
+| 4 | `horizontal` | brs-engine accepts this beyond spec — does hardware? |
+| 5 | `vertical` | Same, vertical side |
+| 6 | `HORIZ` | Case sensitivity |
+| 7 | `Horiz` | Mixed case |
+| 8 | empty string | Degenerate value |
+| 9 | `bogus` | Unrecognized value with no near-miss |
+| 10 | `horiz` then `horz` | Is an invalid write **rejected** (keeps `horiz`) or **accepted and ignored**? |
+| 11 | `vert` then `horiz` | Control for case 10 — a valid re-write must re-layout |
+
+Cases 0–9 run **twice**, in two columns, because the XML parser and a runtime field write may
+validate differently:
+
+- **Left column** — the spelling is hard-coded as an XML attribute in `MainScene.xml`
+- **Right column** — the node is created in code and the field assigned from BrightScript
+
+Cases 10–11 are runtime-only (two sequential writes can't be expressed in XML).
+
+## How it decides
+
+It does not eyeball the boxes. After the layout settles, it reads the first two children's
+`sceneBoundingRect()` and reports which axis advanced:
+
+- `HORIZ` — children advanced along x
+- `VERT` — children advanced along y
+- `STACKED` / `MIXED` — neither or both (would itself be a finding)
+
+It also prints the **stored value** — what reading the field back returns. If that differs from
+what was written, the device *rejected* the value rather than storing it and ignoring it. That
+distinction matters for how brs-engine should behave.
+
+The probe re-runs three times (1.2s apart) so a pre-layout first read can't produce a false
+result, then stops. Results are drawn on screen **and** printed to the console.
+
+## Running it
+
+**On a Roku device** (developer mode enabled):
+
+```bash
+cd /Users/marcelocabral/Projects/Samples/layoutgroup-probe
+zip -r ../layoutgroup-probe.zip . -x '*.DS_Store' 'README.md'
+curl -f -u "rokudev:<devpassword>" -F "mysubmit=Install" -F "archive=@../layoutgroup-probe.zip" \
+  "http://<roku-ip>/plugin_install"
+```
+
+Then read the results on screen, or capture the console table:
+
+```bash
+telnet <roku-ip> 8085
+```
+
+A prebuilt `layoutgroup-probe.zip` sits next to this folder.
+
+**In the simulator**, for the side-by-side comparison:
+
+```bash
+brs-cli --root /Users/marcelocabral/Projects/Samples/layoutgroup-probe
+```
+
+## Result
+
+Run on hardware 2026-07-30. Stable across all three passes, and the XML and runtime columns agreed
+on every row — so the XML parser and a runtime field write validate identically.
+
+| # | Spelling | Stored | Laid out as | brs-engine before | brs-engine after |
+| --- | --- | --- | --- | --- | --- |
+| 0 | (absent) | `"vert"` | VERT | ✅ match | ✅ |
+| 1 | `horiz` | `"horiz"` | HORIZ | ✅ match | ✅ |
+| 2 | `vert` | `"vert"` | VERT | ✅ match | ✅ |
+| 3 | **`horz`** | `""` | **HORIZ** | ❌ `"horz"` / VERT | ✅ |
+| 4 | `horizontal` | `""` | HORIZ | ❌ `"horizontal"` / HORIZ | ✅ |
+| 5 | `vertical` | `""` | HORIZ | ❌ `"vertical"` / **VERT** | ✅ |
+| 6 | `HORIZ` | `"horiz"` | HORIZ | ❌ stored verbatim | ✅ |
+| 7 | `Horiz` | `"horiz"` | HORIZ | ❌ stored verbatim | ✅ |
+| 8 | (empty) | `""` | HORIZ | ❌ VERT | ✅ |
+| 9 | `bogus` | `""` | HORIZ | ❌ `"bogus"` / VERT | ✅ |
+| 10 | `horiz` then `horz` | `""` | HORIZ | ❌ `"horz"` / VERT | ✅ |
+| 11 | `vert` then `horiz` | `"horiz"` | HORIZ | ✅ match | ✅ |
+
+**The device rule.** `layoutDirection` is an enum, not free text:
+
+- `horiz` and `vert` match **case-insensitively** and are stored **lowercase-canonical** — writing
+  `"HORIZ"` reads back `"horiz"`.
+- Anything else is **rejected**, not stored-and-ignored: the field reads back `""`. A rejected write
+  **clobbers** a previously valid one (case 10).
+- The rejected/empty state lays out **HORIZONTALLY** — even though a never-written field keeps its
+  `"vert"` default and lays out vertically (case 0 vs case 8).
+- `horizontal` and `vertical` get no leniency; `vertical` laying out *horizontally* (case 5) is the
+  sharpest illustration that near-misses are not fuzzy-matched.
+
+**Verdict:** the divergence was brs-engine's, not JellyRock's. `layoutDirection="horz"` is a
+horizontal row on hardware, so the JellyRock tab bar and user dropdown were correct all along; the
+engine was mapping every unrecognized value to `vert` and stacking them. Fixed in
+`getLayoutDirection`/`canonicalizeDirection` in `src/extensions/scenegraph/nodes/LayoutGroup.ts`,
+pinned by `test/extensions/scenegraph/LayoutDirection.test.js`, and documented in
+`.claude/docs/scenegraph-invariants.md`.
+
+Re-running this channel under `brs-cli` after the fix reproduces the device table exactly, row for
+row, in both columns.
+
+## Possible follow-up probes
+
+The same enum question applies to the other LayoutGroup string fields, which this channel does not
+cover: `horizAlignment` / `vertAlignment` (`left`/`center`/`right`/`custom`, `top`/`center`/
+`bottom`/`custom`). brs-engine currently falls back to `left`/`top` for unrecognized values — worth
+measuring before trusting it, given how this one turned out.

--- a/test/simulator/probes/layoutgroup-probe/components/MainScene.brs
+++ b/test/simulator/probes/layoutgroup-probe/components/MainScene.brs
@@ -1,0 +1,177 @@
+' LayoutGroup.layoutDirection spelling probe.
+'
+' Purpose: determine empirically which layoutDirection spellings a real Roku device treats as
+' horizontal, which it treats as vertical, and whether an invalid value is REJECTED (the field
+' keeps its previous value) or ACCEPTED-AND-IGNORED (the field stores the junk string but the
+' layout falls back to the default).
+'
+' Each case is a LayoutGroup holding three Rectangles. After the layout settles, the probe reads
+' the first two children's sceneBoundingRect() and infers the direction from which axis advanced.
+' The inference is what matters -- the drawn boxes are just a visual cross-check.
+'
+' Two columns, because the XML parser and a runtime field write may validate differently:
+'   left  - layoutDirection hard-coded as an XML attribute
+'   right - layoutDirection assigned from BrightScript after the node is created
+
+sub init()
+    m.top.backgroundURI = ""
+    m.top.backgroundColor = "0x0E1015FF"
+
+    m.rowPitch = 76
+    m.probesRun = 0
+
+    m.xmlCol = m.top.findNode("xmlCol")
+    m.runtimeCol = m.top.findNode("runtimeCol")
+
+    di = CreateObject("roDeviceInfo")
+    m.top.findNode("subtitle").text = di.GetModelDisplayName() + " (" + di.GetModel() + ")  Roku OS " + di.GetOSVersion().major + "." + di.GetOSVersion().minor + "  |  results also printed to the console"
+
+    buildXmlColumn()
+    buildRuntimeColumn()
+
+    m.timer = m.top.findNode("probeTimer")
+    m.timer.observeField("fire", "onProbe")
+    m.timer.control = "start"
+end sub
+
+' Case table. Indexes 0-9 mirror the x0..x9 LayoutGroups declared in MainScene.xml -- keep the two
+' in sync. Indexes 10+ are runtime-only (they need two sequential writes, which XML cannot express).
+function caseList() as object
+    return [
+        { label: "(attribute absent)", assign: false, value: "" },
+        { label: "horiz", assign: true, value: "horiz" },
+        { label: "vert", assign: true, value: "vert" },
+        { label: "horz", assign: true, value: "horz" },
+        { label: "horizontal", assign: true, value: "horizontal" },
+        { label: "vertical", assign: true, value: "vertical" },
+        { label: "HORIZ", assign: true, value: "HORIZ" },
+        { label: "Horiz", assign: true, value: "Horiz" },
+        { label: "(empty string)", assign: true, value: "" },
+        { label: "bogus", assign: true, value: "bogus" },
+        { label: "horiz then horz", assign: true, value: "horiz", second: "horz" },
+        { label: "vert then horiz", assign: true, value: "vert", second: "horiz" }
+    ]
+end function
+
+' Left column: the LayoutGroups already exist in XML with their literal attribute. Position each
+' one, fill it with boxes, and add the result label that onProbe() will fill in.
+sub buildXmlColumn()
+    cases = caseList()
+    m.xmlRows = []
+
+    for i = 0 to 9
+        group = m.top.findNode("x" + i.toStr())
+        if group = invalid then
+            print "PROBE: missing XML node x"; i
+            continue for
+        end if
+        group.translation = [0, i * m.rowPitch + 30]
+        addBoxes(group)
+        m.xmlRows.push({ index: i, label: cases[i].label, group: group, text: addRowLabel(m.xmlCol, i) })
+    end for
+end sub
+
+' Right column: create each LayoutGroup from code and write layoutDirection as a field assignment.
+sub buildRuntimeColumn()
+    cases = caseList()
+    m.runtimeRows = []
+
+    for i = 0 to cases.count() - 1
+        c = cases[i]
+        group = CreateObject("roSGNode", "LayoutGroup")
+        group.itemSpacings = [5]
+        group.translation = [0, i * m.rowPitch + 30]
+
+        if c.assign then group.layoutDirection = c.value
+        if c.second <> invalid then group.layoutDirection = c.second
+
+        addBoxes(group)
+        m.runtimeCol.appendChild(group)
+        m.runtimeRows.push({ index: i, label: c.label, group: group, text: addRowLabel(m.runtimeCol, i) })
+    end for
+end sub
+
+' Three differently-colored bars. If the group lays out horizontally they form a row; if it lays
+' out vertically they form a stack -- the same failure shape as the JellyRock tab bar.
+sub addBoxes(group as object)
+    colors = ["0xE05555FF", "0x55D08AFF", "0x5599E0FF"]
+    for i = 0 to 2
+        bar = CreateObject("roSGNode", "Rectangle")
+        bar.width = 44
+        bar.height = 12
+        bar.color = colors[i]
+        group.appendChild(bar)
+    end for
+end sub
+
+function addRowLabel(column as object, index as integer) as object
+    label = CreateObject("roSGNode", "Label")
+    label.translation = [0, index * m.rowPitch]
+    label.width = 900
+    label.color = "0xDDDDDDFF"
+    column.appendChild(label)
+    return label
+end function
+
+' Re-runs on every timer tick: the first pass can read rects captured before the layout settled.
+' Three passes is plenty; the timer stops itself so the final state stays on screen.
+sub onProbe()
+    m.probesRun = m.probesRun + 1
+
+    print ""
+    print "===== LayoutGroup layoutDirection probe - pass "; m.probesRun; " ====="
+    print "idx  source    spelling               stored value        laid out as"
+    print "---  --------  ---------------------  ------------------  -----------"
+
+    reportRows(m.xmlRows, "xml")
+    reportRows(m.runtimeRows, "runtime")
+
+    print ""
+    print "HORIZ = children advanced along x   VERT = children advanced along y"
+    print "'stored value' is what reading back the field returns -- if it differs from the"
+    print "spelling that was written, the device REJECTED the value instead of ignoring it."
+
+    if m.probesRun >= 3 then m.timer.control = "stop"
+end sub
+
+sub reportRows(rows as object, source as string)
+    for each row in rows
+        stored = row.group.layoutDirection
+        verdict = detectDirection(row.group)
+
+        row.text.text = padRight(source, 9) + padRight(row.label, 23) + padRight(quoted(stored), 20) + verdict.text
+        row.text.color = verdict.color
+
+        print padRight(row.index.toStr(), 5); padRight(source, 10); padRight(row.label, 23); padRight(quoted(stored), 20); verdict.text
+    end for
+end sub
+
+' Infers the layout axis from the first two children's positions on screen. Reading the rendered
+' rects rather than the children's translation fields keeps this honest: it reports where the
+' device actually PUT the children, not what any field claims.
+function detectDirection(group as object) as object
+    if group.getChildCount() < 2 then return { text: "? (no children)", color: "0xFF6666FF" }
+
+    a = group.getChild(0).sceneBoundingRect()
+    b = group.getChild(1).sceneBoundingRect()
+    dx = b.x - a.x
+    dy = b.y - a.y
+
+    if dx > 1 and dy <= 1 then return { text: "HORIZ", color: "0x66E08AFF" }
+    if dy > 1 and dx <= 1 then return { text: "VERT", color: "0xE0A050FF" }
+    if dx <= 1 and dy <= 1 then return { text: "STACKED (dx=" + dx.toStr() + " dy=" + dy.toStr() + ")", color: "0xFF6666FF" }
+    return { text: "MIXED (dx=" + dx.toStr() + " dy=" + dy.toStr() + ")", color: "0xFF6666FF" }
+end function
+
+function quoted(value as dynamic) as string
+    if value = invalid then return "<invalid>"
+    return chr(34) + value.toStr() + chr(34)
+end function
+
+function padRight(text as string, width as integer) as string
+    result = text
+    while len(result) < width
+        result = result + " "
+    end while
+    return result
+end function

--- a/test/simulator/probes/layoutgroup-probe/components/MainScene.xml
+++ b/test/simulator/probes/layoutgroup-probe/components/MainScene.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="MainScene" extends="Scene">
+  <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+
+  <children>
+    <Label id="title" text="LayoutGroup.layoutDirection - spelling probe" translation="[55, 26]" font="font:LargeBoldSystemFont" color="0xFFFFFFFF" />
+    <Label id="subtitle" translation="[55, 78]" font="font:SmallSystemFont" color="0xAAAAAAFF" />
+    <Label id="hdrXml" text="DECLARED IN XML" translation="[55, 112]" font="font:SmallBoldSystemFont" color="0x66CCFFFF" />
+    <Label id="hdrRt" text="ASSIGNED FROM BRIGHTSCRIPT" translation="[980, 112]" font="font:SmallBoldSystemFont" color="0x66CCFFFF" />
+
+    <!--
+      Each LayoutGroup below carries a literal layoutDirection spelling. The value must be
+      hard-coded in XML (not assigned from code) so this column tests the XML parser's handling
+      of the attribute, which may differ from a runtime field write.
+      Case index is encoded in the id: x0..x9, matching caseList() in MainScene.brs.
+    -->
+    <Group id="xmlCol" translation="[55, 140]">
+      <LayoutGroup id="x0" itemSpacings="[5]" />
+      <LayoutGroup id="x1" layoutDirection="horiz" itemSpacings="[5]" />
+      <LayoutGroup id="x2" layoutDirection="vert" itemSpacings="[5]" />
+      <LayoutGroup id="x3" layoutDirection="horz" itemSpacings="[5]" />
+      <LayoutGroup id="x4" layoutDirection="horizontal" itemSpacings="[5]" />
+      <LayoutGroup id="x5" layoutDirection="vertical" itemSpacings="[5]" />
+      <LayoutGroup id="x6" layoutDirection="HORIZ" itemSpacings="[5]" />
+      <LayoutGroup id="x7" layoutDirection="Horiz" itemSpacings="[5]" />
+      <LayoutGroup id="x8" layoutDirection="" itemSpacings="[5]" />
+      <LayoutGroup id="x9" layoutDirection="bogus" itemSpacings="[5]" />
+    </Group>
+
+    <!-- Runtime cases are created in code and appended here. -->
+    <Group id="runtimeCol" translation="[980, 140]" />
+
+    <!-- Re-probes a few times: the first pass can read pre-layout rects. -->
+    <Timer id="probeTimer" repeat="true" duration="1.2" />
+  </children>
+</component>

--- a/test/simulator/probes/layoutgroup-probe/manifest
+++ b/test/simulator/probes/layoutgroup-probe/manifest
@@ -1,0 +1,14 @@
+#
+#  LayoutGroup layoutDirection probe
+#  Determines which layoutDirection spellings a real Roku device accepts.
+#
+
+title=LayoutGroup Direction Probe
+subtitle=layoutDirection spelling behavior
+major_version=1
+minor_version=0
+build_version=1
+
+ui_resolutions=fhd
+
+bs_const=DEBUG=false

--- a/test/simulator/probes/layoutgroup-probe/source/main.brs
+++ b/test/simulator/probes/layoutgroup-probe/source/main.brs
@@ -1,0 +1,14 @@
+sub Main()
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    screen.CreateScene("MainScene")
+    screen.show()
+
+    while true
+        msg = wait(0, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        end if
+    end while
+end sub

--- a/test/simulator/probes/layoutspacing-probe/README.md
+++ b/test/simulator/probes/layoutspacing-probe/README.md
@@ -1,0 +1,185 @@
+# LayoutGroup `itemSpacings` / spacing-placement probe
+
+Third in the series, and it closes the questions the first two left open.
+
+- [`layoutgroup-probe`](../layoutgroup-probe/) — `layoutDirection` is a rejecting enum whose empty
+  state lays out **horizontally** (brs-engine PR #1122).
+- [`layoutalign-probe`](../layoutalign-probe/) — same storage rule for the alignment fields, plus the
+  surprise that a rejected **cross-axis** alignment collapses every child onto the group origin.
+
+Both of those ended with "still unmeasured" lists. This channel measures them.
+
+## Section S — `itemSpacings` and where the space goes
+
+The load-bearing question: **the engine repeats the last array entry for every gap past the end of
+the array**, so `itemSpacings="[20]"` spaces every child by 20 no matter how many there are. That has
+never been checked against a device, and apps write single-element arrays with many children all the
+time. If hardware instead uses 0 once the array runs out, a great many layouts differ.
+
+14 cases, three children of 30×10 with no translations of their own, so spacing is the only variable:
+
+| Case | Asks |
+| --- | --- |
+| `[]`, `[0]` | baseline — no spacing |
+| `[4]` | **short array** — is the last entry repeated, or is the rest 0? |
+| `[4,9]` | exact fit for two gaps — which index maps to which gap? |
+| `[4,9,15]`, `[4,9,15,20]` | **extra entries** — appended as trailing space (changing the group's own size), or ignored? |
+| `[-6]` | negative — overlap, or clamped to 0? |
+| `[2.5]` | fractional — honored, rounded, or truncated? |
+| the same with `addItemSpacingAfterChild=false` | does the space go **before** each child, including the first — shifting the whole run? |
+| `[4]`, `[4,9]` with `layoutDirection=vert` | is the index mapping the same on the other axis? |
+
+Gaps are reported as the measured distance between consecutive children **minus** the child size, so
+`0` means touching and a negative number means overlapping. `local` is the group's own
+`localBoundingRect()`, which is where trailing space and run-shifting show up.
+
+## Section R — rejected-value combinations
+
+The engine currently **extrapolates** the cross-axis collapse to cases the alignment probe never
+measured. Extrapolation is exactly what this series keeps proving wrong, so all eight combinations
+are measured: each alignment field rejected alone, both rejected together, and a rejected
+`layoutDirection` (which resolves to `horiz`, making `vertAlignment` the cross field) combined with
+each.
+
+## Section F — does a device LayoutGroup even *have* `width`/`height`?
+
+Roku's reference does not declare `width`/`height` on `Group` or `LayoutGroup`, yet the engine writes
+both on every layout so parent nodes can measure the group. If hardware has no such fields, an app
+reading `lg.width` gets `invalid` on device and a number in the simulator — a silent behavioral
+difference that would never show up as a crash. Probed with `hasField()` plus the values themselves.
+
+## Running it
+
+**On a Roku device** (developer mode enabled):
+
+```bash
+curl -f -u "rokudev:<devpassword>" -F "mysubmit=Install" \
+  -F "archive=@/Users/marcelocabral/Projects/Samples/layoutspacing-probe.zip" \
+  "http://<roku-ip>/plugin_install"
+```
+
+```bash
+telnet <roku-ip> 8085
+```
+
+**In the simulator:**
+
+```bash
+brs-cli --root /Users/marcelocabral/Projects/Samples/layoutspacing-probe
+```
+
+## Result
+
+Run on hardware 2026-07-30, stable across all three passes. **23 of the 24 output lines matched the
+engine exactly.** The whole of Section S and the whole of Section R were already right — including
+every rule that had only ever been an assumption:
+
+- the **last entry repeats** for gaps past the end of the array (`[4]` → gaps `4,4`);
+- entries past the last gap are **dropped**, adding no trailing space (`[4,9,15]` lays out exactly
+  like `[4,9]`, same group rect);
+- negative spacings **overlap**, fractional spacings are used **as-is**;
+- `addItemSpacingAfterChild=false` inserts the space **before** each child including the first, so
+  the run shifts by `spacings[0]` and gaps come from the *following* entries;
+- and every rejected-value combination in Section R behaved as the engine extrapolated — the
+  cross-axis collapse rule holds for both-rejected and for a rejected `layoutDirection` too.
+
+The one divergence was **Section F**:
+
+```
+                        device                              engine (before)
+  hasField(width)       false                               true
+  hasField(height)      false                               true
+  width / height        invalid / invalid                   98 / 10
+  localBoundingRect()   (0,0,98,10)                         (0,0,98,10)
+```
+
+A real LayoutGroup has **no `width`/`height` fields at all** — only `localBoundingRect()` reports its
+size. The engine published its measurement as real node fields, so an app reading `lg.width` got a
+number in the simulator and `invalid` on hardware: a silent difference that never surfaces as a
+crash, just as wrong layout in whatever the app computed from it.
+
+**Fix:** the measurement moved to private `layoutWidth`/`layoutHeight`, surfaced by overriding
+`getDimensions()` — which is what every internal measurement path already used. One caller was
+reading the raw field instead (`StdDlgCustomItem.measureContentHeight`) and would have sized a dialog
+to 0 around a LayoutGroup; it now uses `getDimensions()` too. Pinned by
+`test/extensions/scenegraph/LayoutSpacing.test.js` and the field-absence cases in
+`LayoutAlignment.test.js`.
+
+After the fix, this channel's engine output reproduces all 24 device lines exactly.
+
+## brs-engine baseline BEFORE the fix
+
+Captured from `brs-cli` on `fix/layoutgroup-direction-enum` before the section-F work. Only the last
+two lines differ from the device.
+
+```
+S)  itemSpacings   (layoutDirection=horiz unless noted)
+  case                    c0       gaps          local rect
+  [] (default)            (0,0)    0,0           (0,0,90,10)
+  [0]                     (0,0)    0,0           (0,0,90,10)
+  [4]  <- short           (0,0)    4,4           (0,0,98,10)
+  [4,9]  <- exact         (0,0)    4,9           (0,0,103,10)
+  [4,9,15]  <- extra      (0,0)    4,9           (0,0,103,10)
+  [4,9,15,20]             (0,0)    4,9           (0,0,103,10)
+  [-6]  <- negative       (0,0)    -6,-6         (0,0,78,10)
+  [2.5]  <- fraction      (0,0)    2.5,2.5       (0,0,95,10)
+  [] addAfter=false       (0,0)    0,0           (0,0,90,10)
+  [4] addAfter=false      (4,0)    4,4           (4,0,98,10)
+  [4,9] addAfter=false    (4,0)    9,9           (4,0,108,10)
+  [4,9,15] addAft=false   (4,0)    9,15          (4,0,114,10)
+  [4] vert                (0,0)    4,4           (0,0,30,38)
+  [4,9] vert              (0,0)    4,9           (0,0,30,43)
+
+R)  rejected-value combinations   (itemSpacings [4])
+  case                    c0       c1       c2       local rect
+  vert  h=bogus           (0,0)    (0,0)    (0,0)    (0,0,30,10)
+  vert  v=bogus           (0,0)    (0,14)   (0,28)   (0,0,30,38)
+  vert  both bogus        (0,0)    (0,0)    (0,0)    (0,0,30,10)
+  horiz h=bogus           (0,0)    (34,0)   (68,0)   (0,0,98,10)
+  horiz v=bogus           (0,0)    (0,0)    (0,0)    (0,0,30,10)
+  horiz both bogus        (0,0)    (0,0)    (0,0)    (0,0,30,10)
+  dir=bogus  v=bogus      (0,0)    (0,0)    (0,0)    (0,0,30,10)
+  dir=bogus  h=bogus      (0,0)    (34,0)   (68,0)   (0,0,98,10)
+
+F)  width/height fields on a LayoutGroup
+  hasField(width)=true  hasField(height)=true
+  width=98  height=10  local=(0,0,98,10)
+```
+
+So brs-engine today:
+
+- **repeats the last spacing** for every gap past the end of the array (`[4]` → gaps 4,4);
+- **ignores extra entries** — `[4,9,15]` gives gaps 4,9 with no trailing space, same rect as `[4,9]`;
+- honors **negative** spacing as overlap and **fractional** spacing exactly;
+- with `addItemSpacingAfterChild=false`, inserts the space **before** each child including the first,
+  so the run shifts by `spacings[0]` and the gaps come from the *following* indices (`[4,9]` → c0 at
+  4, gaps 9,9);
+- uses the same index mapping for `vert`;
+- collapses on a rejected cross-axis alignment in every combination, including both-rejected and the
+  rejected-`layoutDirection` cases (this is the extrapolation to check);
+- **declares `width` and `height`** on a LayoutGroup and keeps them in sync with the layout.
+
+## Series conclusion
+
+Three probes, 94 measured cases, four engine bugs found:
+
+| Probe | Cases | Found |
+| --- | --- | --- |
+| `layoutgroup-probe` | 22 | `layoutDirection` is a rejecting enum; its empty state lays out **horizontally**, not `vert` |
+| `layoutalign-probe` | 48 | same storage rule for the alignment fields; a rejected **cross-axis** alignment **collapses** every child onto the origin |
+| `layoutspacing-probe` | 24 | a LayoutGroup has **no `width`/`height` fields** |
+
+The pattern worth keeping: in all three cases the engine's *reasonable* reading — "an unrecognized
+value falls back to the documented default", "a group that reports a size must have size fields" —
+was the wrong one, and the parts everyone would have called risky assumptions (repeating the last
+spacing entry, the exact `custom` fallback, before-vs-after spacing placement) turned out to be
+right. Measuring beats reasoning about the docs, and it is cheap: each probe took one channel and one
+paste of a telnet log.
+
+## Still unmeasured
+
+- Whether other node types invent fields the device lacks the way LayoutGroup did — `Group` itself is
+  the obvious next candidate, since the engine writes `width`/`height` on several nodes that Roku
+  documents without them.
+- `itemSpacings` entries that are not numbers (the field is a `floatarray`, so this is really a
+  field-coercion question, not a layout one).

--- a/test/simulator/probes/layoutspacing-probe/components/MainScene.brs
+++ b/test/simulator/probes/layoutspacing-probe/components/MainScene.brs
@@ -1,0 +1,292 @@
+' LayoutGroup itemSpacings / addItemSpacingAfterChild probe.
+'
+' Third in the series. layoutgroup-probe established that layoutDirection is a rejecting enum whose
+' empty state lays out horizontally; layoutalign-probe established the same storage rule for the
+' alignment fields and found that a rejected CROSS-axis alignment collapses every child onto the
+' group origin. Both left questions open, and this channel closes them.
+'
+' SECTION S - itemSpacings and where the spacing is inserted
+'
+'   The engine repeats the LAST array entry for every gap past the end of the array, so
+'   itemSpacings="[20]" spaces every child by 20. That is an assumption, never measured, and it is
+'   load-bearing: apps routinely write a single-element array with many children. If the device
+'   instead uses 0 once the array runs out, a great many layouts differ.
+'
+'   Also probed: an array LONGER than the number of gaps (is the extra entry appended as trailing
+'   space, changing the group's own size?), negative and fractional spacings, the empty array, and
+'   addItemSpacingAfterChild=false -- which in the engine inserts the space BEFORE each child,
+'   including the first, shifting the whole run. Whether the device shifts the run is visible in the
+'   first child's offset.
+'
+' SECTION R - rejected-value combinations the alignment probe did not cover
+'
+'   The engine extrapolates the cross-axis collapse to the case where BOTH alignment fields are
+'   rejected, and to a rejected layoutDirection combined with a rejected alignment. Extrapolation is
+'   exactly what this series keeps proving wrong, so measure it.
+'
+' SECTION F - does a device LayoutGroup even HAVE width/height?
+'
+'   Group does not declare width/height in Roku's reference, yet the engine writes both on every
+'   layout so parents can measure the group. If the device has no such fields, an app reading
+'   lg.width gets invalid on hardware and a number here -- a silent behavioral difference. Measured
+'   with hasField(), alongside localBoundingRect() for the sizes that actually matter.
+'
+' Method matches the earlier probes: a 2x2 marker rectangle sits at each group's exact translation,
+' and every offset is child.sceneBoundingRect() - marker.sceneBoundingRect().
+
+sub init()
+    m.top.backgroundURI = ""
+    m.top.backgroundColor = "0x0E1015FF"
+
+    m.rowPitch = 44
+    m.markerX = 640
+    m.probesRun = 0
+
+    m.childSize = { w: 30, h: 10 }
+    m.childColors = ["0xE05555FF", "0x55D08AFF", "0x5599E0FF"]
+
+    di = CreateObject("roDeviceInfo")
+    m.top.findNode("subtitle").text = di.GetModelDisplayName() + " (" + di.GetModel() + ")  Roku OS " + di.GetOSVersion().major + "." + di.GetOSVersion().minor
+
+    buildSpacingSection()
+    buildRejectedSection()
+
+    m.timer = m.top.findNode("probeTimer")
+    m.timer.observeField("fire", "onProbe")
+    m.timer.control = "start"
+end sub
+
+' Each case: the itemSpacings array to set, whether addItemSpacingAfterChild is left at its default
+' (true) or turned off, and the layout direction.
+function spacingCases() as object
+    return [
+        { label: "[] (default)", spacings: [], addAfter: true, direction: "horiz" },
+        { label: "[0]", spacings: [0], addAfter: true, direction: "horiz" },
+        { label: "[4]  <- short", spacings: [4], addAfter: true, direction: "horiz" },
+        { label: "[4,9]  <- exact", spacings: [4, 9], addAfter: true, direction: "horiz" },
+        { label: "[4,9,15]  <- extra", spacings: [4, 9, 15], addAfter: true, direction: "horiz" },
+        { label: "[4,9,15,20]", spacings: [4, 9, 15, 20], addAfter: true, direction: "horiz" },
+        { label: "[-6]  <- negative", spacings: [-6], addAfter: true, direction: "horiz" },
+        { label: "[2.5]  <- fraction", spacings: [2.5], addAfter: true, direction: "horiz" },
+        { label: "[] addAfter=false", spacings: [], addAfter: false, direction: "horiz" },
+        { label: "[4] addAfter=false", spacings: [4], addAfter: false, direction: "horiz" },
+        { label: "[4,9] addAfter=false", spacings: [4, 9], addAfter: false, direction: "horiz" },
+        { label: "[4,9,15] addAft=false", spacings: [4, 9, 15], addAfter: false, direction: "horiz" },
+        { label: "[4] vert", spacings: [4], addAfter: true, direction: "vert" },
+        { label: "[4,9] vert", spacings: [4, 9], addAfter: true, direction: "vert" }
+    ]
+end function
+
+' Rejected-value combinations. "bogus" is rejected by every one of the three enum fields.
+function rejectedCases() as object
+    return [
+        { label: "vert  h=bogus", direction: "vert", horiz: "bogus", vert: invalid },
+        { label: "vert  v=bogus", direction: "vert", horiz: invalid, vert: "bogus" },
+        { label: "vert  both bogus", direction: "vert", horiz: "bogus", vert: "bogus" },
+        { label: "horiz h=bogus", direction: "horiz", horiz: "bogus", vert: invalid },
+        { label: "horiz v=bogus", direction: "horiz", horiz: invalid, vert: "bogus" },
+        { label: "horiz both bogus", direction: "horiz", horiz: "bogus", vert: "bogus" },
+        { label: "dir=bogus  v=bogus", direction: "bogus", horiz: invalid, vert: "bogus" },
+        { label: "dir=bogus  h=bogus", direction: "bogus", horiz: "bogus", vert: invalid }
+    ]
+end function
+
+sub buildSpacingSection()
+    column = m.top.findNode("colLeft")
+    m.spacingRows = []
+    slot = 0
+
+    header = createLabel(column, slot, "0x66E08AFF")
+    header.text = "S)  itemSpacings   (3 children, each 30x10)"
+    slot = slot + 1
+
+    for each testCase in spacingCases()
+        layoutGroup = CreateObject("roSGNode", "LayoutGroup")
+        layoutGroup.layoutDirection = testCase.direction
+        layoutGroup.itemSpacings = testCase.spacings
+        layoutGroup.addItemSpacingAfterChild = testCase.addAfter
+        addChildren(layoutGroup, 3)
+
+        m.spacingRows.push(placeCase(column, slot, layoutGroup, testCase.label))
+        slot = slot + 1
+    end for
+end sub
+
+sub buildRejectedSection()
+    column = m.top.findNode("colRight")
+    m.rejectedRows = []
+    slot = 0
+
+    header = createLabel(column, slot, "0x66E08AFF")
+    header.text = "R)  rejected-value combinations   (spacings [4])"
+    slot = slot + 1
+
+    for each testCase in rejectedCases()
+        layoutGroup = CreateObject("roSGNode", "LayoutGroup")
+        layoutGroup.layoutDirection = testCase.direction
+        layoutGroup.itemSpacings = [4]
+        if testCase.horiz <> invalid then layoutGroup.horizAlignment = testCase.horiz
+        if testCase.vert <> invalid then layoutGroup.vertAlignment = testCase.vert
+        addChildren(layoutGroup, 3)
+
+        m.rejectedRows.push(placeCase(column, slot, layoutGroup, testCase.label))
+        slot = slot + 1
+    end for
+
+    ' Section F shares the right column, below the rejected rows.
+    slot = slot + 1
+    m.fieldHeader = createLabel(column, slot, "0x66E08AFF")
+    m.fieldHeader.text = "F)  does a LayoutGroup have width/height fields?"
+    slot = slot + 1
+    m.fieldRows = [createLabel(column, slot, "0xDDDDDDFF"), createLabel(column, slot + 1, "0xDDDDDDFF")]
+
+    ' A plain laid-out group to interrogate for section F.
+    m.fieldProbe = CreateObject("roSGNode", "LayoutGroup")
+    m.fieldProbe.layoutDirection = "horiz"
+    m.fieldProbe.itemSpacings = [4]
+    addChildren(m.fieldProbe, 3)
+    m.fieldProbe.translation = [m.markerX, (slot + 2) * m.rowPitch + 16]
+    column.appendChild(m.fieldProbe)
+end sub
+
+' Positions one case group with its marker and result label; returns the row record.
+function placeCase(column as object, slot as integer, layoutGroup as object, label as string) as object
+    originY = slot * m.rowPitch + 16
+    layoutGroup.translation = [m.markerX, originY]
+
+    marker = CreateObject("roSGNode", "Rectangle")
+    marker.width = 2
+    marker.height = 2
+    marker.color = "0xFFFFFFFF"
+    marker.translation = [m.markerX, originY]
+
+    column.appendChild(marker)
+    column.appendChild(layoutGroup)
+
+    return { label: label, layoutGroup: layoutGroup, marker: marker, text: createLabel(column, slot, "0xDDDDDDFF") }
+end function
+
+sub addChildren(layoutGroup as object, count as integer)
+    for i = 0 to count - 1
+        bar = CreateObject("roSGNode", "Rectangle")
+        bar.width = m.childSize.w
+        bar.height = m.childSize.h
+        bar.color = m.childColors[i]
+        layoutGroup.appendChild(bar)
+    end for
+end sub
+
+function createLabel(column as object, slot as integer, color as string) as object
+    label = CreateObject("roSGNode", "Label")
+    label.translation = [0, slot * m.rowPitch]
+    label.width = 620
+    label.color = color
+    column.appendChild(label)
+    return label
+end function
+
+sub onProbe()
+    m.probesRun = m.probesRun + 1
+
+    print ""
+    print "===== LayoutGroup spacing probe - pass "; m.probesRun; " ====="
+    print "3 children, each 30x10, no translations of their own"
+    print "c0/c1/c2 = offsets from the group origin;  g = measured gap between consecutive children"
+    print "local = localBoundingRect() of the LayoutGroup itself"
+
+    print ""
+    print "S)  itemSpacings   (layoutDirection=horiz unless noted)"
+    print "  case                    c0       gaps          local rect"
+    print "  ----------------------  -------  ------------  ------------------------"
+    for each row in m.spacingRows
+        print "  "; padRight(row.label, 24); padRight(point(offsetOf(row, 0)), 9); padRight(gapsOf(row), 14); rectText(row.layoutGroup)
+        row.text.text = padRight(row.label, 22) + padRight(point(offsetOf(row, 0)), 9) + padRight(gapsOf(row), 13) + rectText(row.layoutGroup)
+    end for
+
+    print ""
+    print "R)  rejected-value combinations   (itemSpacings [4])"
+    print "  case                    c0       c1       c2       local rect"
+    print "  ----------------------  -------  -------  -------  ------------------------"
+    for each row in m.rejectedRows
+        offsets = padRight(point(offsetOf(row, 0)), 9) + padRight(point(offsetOf(row, 1)), 9) + padRight(point(offsetOf(row, 2)), 9)
+        print "  "; padRight(row.label, 24); offsets; rectText(row.layoutGroup)
+        row.text.text = padRight(row.label, 22) + offsets + rectText(row.layoutGroup)
+    end for
+
+    print ""
+    print "F)  width/height fields on a LayoutGroup"
+    fieldLine = "  hasField(width)=" + boolText(m.fieldProbe.hasField("width")) + "  hasField(height)=" + boolText(m.fieldProbe.hasField("height"))
+    valueLine = "  width=" + describe(m.fieldProbe.width) + "  height=" + describe(m.fieldProbe.height) + "  local=" + rectText(m.fieldProbe)
+    print fieldLine
+    print valueLine
+    m.fieldRows[0].text = fieldLine
+    m.fieldRows[1].text = valueLine
+
+    if m.probesRun >= 3 then m.timer.control = "stop"
+end sub
+
+function offsetOf(row as object, index as integer) as object
+    child = row.layoutGroup.getChild(index)
+    if child = invalid then return { x: 0, y: 0 }
+    childRect = child.sceneBoundingRect()
+    markerRect = row.marker.sceneBoundingRect()
+    return { x: childRect.x - markerRect.x, y: childRect.y - markerRect.y }
+end function
+
+' Gap between consecutive children along the layout axis: the distance between them minus the child
+' size, so a result of 0 means they are touching and a negative result means they overlap.
+function gapsOf(row as object) as string
+    onX = (row.layoutGroup.layoutDirection <> "vert")
+    if onX
+        size = m.childSize.w
+    else
+        size = m.childSize.h
+    end if
+
+    values = []
+    for i = 0 to 1
+        a = offsetOf(row, i)
+        b = offsetOf(row, i + 1)
+        if onX
+            values.push(b.x - a.x - size)
+        else
+            values.push(b.y - a.y - size)
+        end if
+    end for
+    return num(values[0]) + "," + num(values[1])
+end function
+
+function rectText(layoutGroup as object) as string
+    r = layoutGroup.localBoundingRect()
+    return "(" + num(r.x) + "," + num(r.y) + "," + num(r.width) + "," + num(r.height) + ")"
+end function
+
+function describe(value as dynamic) as string
+    if value = invalid then return "invalid"
+    return num(value)
+end function
+
+function boolText(value as dynamic) as string
+    if value = true then return "true"
+    if value = false then return "false"
+    return "invalid"
+end function
+
+function point(offset as object) as string
+    return "(" + num(offset.x) + "," + num(offset.y) + ")"
+end function
+
+function num(value as dynamic) as string
+    if value = invalid then return "invalid"
+    rounded = cint(value)
+    if abs(value - rounded) < 0.01 then return rounded.toStr()
+    return str(value).trim()
+end function
+
+function padRight(text as string, width as integer) as string
+    result = text
+    while len(result) < width
+        result = result + " "
+    end while
+    return result
+end function

--- a/test/simulator/probes/layoutspacing-probe/components/MainScene.xml
+++ b/test/simulator/probes/layoutspacing-probe/components/MainScene.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="MainScene" extends="Scene">
+  <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+
+  <children>
+    <Label id="title" text="LayoutGroup itemSpacings / addItemSpacingAfterChild - value probe" translation="[50, 22]" font="font:LargeBoldSystemFont" color="0xFFFFFFFF" />
+    <Label id="subtitle" translation="[50, 70]" font="font:SmallSystemFont" color="0xAAAAAAFF" />
+    <Label id="legend" translation="[50, 100]" font="font:SmallSystemFont" color="0x66CCFFFF"
+           text="3 children, each 30x10, no translations of their own. g = measured gap between consecutive children. Full detail printed to the console." />
+
+    <Group id="colLeft" translation="[50, 140]" />
+    <Group id="colRight" translation="[990, 140]" />
+
+    <Timer id="probeTimer" repeat="true" duration="1.2" />
+  </children>
+</component>

--- a/test/simulator/probes/layoutspacing-probe/manifest
+++ b/test/simulator/probes/layoutspacing-probe/manifest
@@ -1,0 +1,14 @@
+#
+#  LayoutGroup itemSpacings / addItemSpacingAfterChild probe
+#  Plus the two questions the alignment probe left open.
+#
+
+title=LayoutGroup Spacing Probe
+subtitle=itemSpacings, spacing placement, group rect
+major_version=1
+minor_version=0
+build_version=1
+
+ui_resolutions=fhd
+
+bs_const=DEBUG=false

--- a/test/simulator/probes/layoutspacing-probe/source/main.brs
+++ b/test/simulator/probes/layoutspacing-probe/source/main.brs
@@ -1,0 +1,14 @@
+sub Main()
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    screen.CreateScene("MainScene")
+    screen.show()
+
+    while true
+        msg = wait(0, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        end if
+    end while
+end sub


### PR DESCRIPTION
- Implemented MainScene.brs and MainScene.xml for layoutDirection spelling probe to test various layoutDirection values and their effects on LayoutGroup behavior.
- Created manifest file for layoutDirection probe with versioning and metadata.
- Developed main.brs for initializing the probe and handling screen events.
- Added README.md for layoutspacing-probe detailing the purpose and methodology of the itemSpacings probe.
- Implemented MainScene.brs and MainScene.xml for itemSpacings probe to evaluate spacing behavior in LayoutGroup.
- Created manifest file for itemSpacings probe with versioning and metadata.
- Developed main.brs for initializing the itemSpacings probe and handling screen events.