### PR TITLE
feat(brs): add `logLevel` parameter to filter output messages in `OutputProxy`

### DIFF
--- a/src/core/device/OutputProxy.ts
+++ b/src/core/device/OutputProxy.ts
@@ -6,6 +6,8 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { LogLevel } from "../common";
+
 /** Proxies a `stdout`-like stream to provide current-column tracking. */
 export class OutputProxy {
     currentLineLength = 0;
@@ -14,8 +16,13 @@ export class OutputProxy {
      * Creates a new proxy that tracks the current column of the provided stream.
      * @param outputStream the stream to proxy writes to
      * @param post whether to post messages to the parent thread. defaults to true
+     * @param logLevel the minimum log level to display
      */
-    constructor(private readonly outputStream: NodeJS.WriteStream, private readonly post: boolean = true) {}
+    constructor(
+        private readonly outputStream: NodeJS.WriteStream,
+        private readonly post: boolean = true,
+        private readonly logLevel: LogLevel = LogLevel.Warning
+    ) {}
 
     /**
      * Writes a string's worth of data to the proxied stream and updates the current output column.
@@ -24,6 +31,12 @@ export class OutputProxy {
     write(str: string) {
         let content = str;
         const level = str.split(",")[0];
+        if (
+            (level === "debug" && this.logLevel > LogLevel.Debug) ||
+            (level === "warning" && this.logLevel > LogLevel.Warning)
+        ) {
+            return;
+        }
         if (["print", "error", "warning", "debug"].includes(level)) {
             content = str.slice(level.length + 1);
             if (this.post) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -97,7 +97,7 @@ if (typeof onmessage !== "undefined") {
             loadExtensions(event.data);
             executeFile(event.data, {}, true);
         } else if (isTaskPayload(event.data)) {
-            postMessage(`debug,[core] Task payload received: ${event.data.taskData.id}:${event.data.taskData.name}`);
+            BrsDevice.stdout.write(`debug,[core] Task payload received: ${event.data.taskData.id}:${event.data.taskData.name}`);
             loadExtensions(event.data);
             executeTask(event.data);
         } else if (typeof event.data === "string" && event.data === "getVersion") {
@@ -106,7 +106,7 @@ if (typeof onmessage !== "undefined") {
             // Setup Control Shared Array
             BrsDevice.setSharedArray(new Int32Array(event.data));
         } else {
-            postMessage(`warning,[core] Invalid message received: ${event.data}`);
+            BrsDevice.stderr.write(`warning,[core] Invalid message received: ${event.data}`);
         }
     };
 }
@@ -138,7 +138,7 @@ function loadExtensions(payload: AppPayload | TaskPayload) {
  */
 function loadExtension(moduleId: SupportedExtension, modulePath: string) {
     if (!modulePath) {
-        postMessage(`warning,[core] No module path provided for ${moduleId} extension.`);
+        BrsDevice.stderr.write(`warning,[core] No module path provided for ${moduleId} extension.`);
         return;
     }
     try {
@@ -164,12 +164,12 @@ function loadExtension(moduleId: SupportedExtension, modulePath: string) {
             registerExtension(() => extension);
             loadedExtensions.add(moduleId);
             const extensionInfo: ExtensionInfo = { name: moduleId, library: modulePath, version: extension.version };
-            postMessage(extensionInfo);
+            BrsDevice.stdout.write(`info,[core] Extension loaded: ${moduleId}`);
         } else {
-            postMessage(`warning,[core] The loaded library does not contain ${moduleId} Extension.`);
+            BrsDevice.stderr.write(`warning,[core] The loaded library does not contain ${moduleId} Extension.`);
         }
     } catch (err: any) {
-        postMessage(`warning,[core] Failed to load ${moduleId} extension: ${err.message}`);
+        BrsDevice.stderr.write(`warning,[core] Failed to load ${moduleId} extension: ${err.message}`);
     }
 }
 
@@ -287,18 +287,18 @@ if (!isMainThread && parentPort) {
         if (isAppPayload(data)) {
             loadNodeExtensions(data);
             executeFile(data, {}, true).catch((err: any) => {
-                postMessage(`error,[core] Error executing app: ${err.message}`);
+                BrsDevice.stderr.write(`error,[core] Error executing app: ${err.message}`);
                 postMessage(`end,${AppExitReason.Crashed}`);
             });
         } else if (isTaskPayload(data)) {
-            postMessage(`debug,[core] Task payload received: ${data.taskData.id}:${data.taskData.name}`);
+            BrsDevice.stdout.write(`debug,[core] Task payload received: ${data.taskData.id}:${data.taskData.name}`);
             loadNodeExtensions(data);
             executeTask(data);
         } else if (isTypeOf(data, "SharedArrayBuffer")) {
             // Setup Control Shared Array (realm-safe check: the buffer may come from a VM sandbox)
             BrsDevice.setSharedArray(new Int32Array(data));
         } else {
-            postMessage(`warning,[core] Invalid message received: ${data}`);
+            BrsDevice.stderr.write(`warning,[core] Invalid message received: ${data}`);
         }
     });
 }
@@ -324,7 +324,7 @@ function loadNodeExtensions(payload: AppPayload | TaskPayload) {
         }
         const modulePath = payload.device.extensions?.get(extension) ?? "";
         if (!modulePath) {
-            postMessage(`warning,[core] No module path provided for ${extension} extension.`);
+            BrsDevice.stderr.write(`warning,[core] No module path provided for ${extension} extension.`);
             continue;
         }
         try {
@@ -341,10 +341,10 @@ function loadNodeExtensions(payload: AppPayload | TaskPayload) {
                 };
                 postMessage(extensionInfo);
             } else {
-                postMessage(`warning,[core] The loaded library does not contain ${extension} Extension.`);
+                BrsDevice.stderr.write(`warning,[core] The loaded library does not contain ${extension} Extension.`);
             }
         } catch (err: any) {
-            postMessage(`warning,[core] Failed to load ${extension} extension: ${err.message}`);
+            BrsDevice.stderr.write(`warning,[core] Failed to load ${extension} extension: ${err.message}`);
         }
     }
 }
@@ -370,7 +370,7 @@ export function registerCallback(messageCallback: any, sharedBuffer?: SharedArra
  */
 export function getReplInterpreter(payload: Partial<AppPayload>) {
     if (!payload.device?.assets) {
-        postMessage("error,Invalid REPL configuration: Missing assets");
+        BrsDevice.stderr.write("error,Invalid REPL configuration: Missing assets");
         return null;
     }
     if (payload.device) {
@@ -383,7 +383,7 @@ export function getReplInterpreter(payload: Partial<AppPayload>) {
         BrsDevice.setupFileSystem(payload);
         BrsDevice.loadLocaleTerms();
     } catch (err: any) {
-        postMessage(`error,[repl] Error mounting File System: ${err.message}`);
+        BrsDevice.stderr.write(`error,[repl] Error mounting File System: ${err.message}`);
         return null;
     }
     const replInterpreter = new Interpreter();
@@ -425,7 +425,7 @@ export function executeLine(contents: string, interpreter: Interpreter) {
         }
     } catch (err: any) {
         if (!(err instanceof BrsError)) {
-            postMessage(`error,Interpreter execution error: ${err.message}`);
+            BrsDevice.stderr.write(`error,Interpreter execution error: ${err.message}`);
         }
     }
 }
@@ -739,7 +739,7 @@ export async function executeFile(
         BrsDevice.setupFileSystem(payload);
         BrsDevice.loadLocaleTerms();
     } catch (err: any) {
-        postMessage(`error,[core] Error mounting File System: ${err.message}`);
+        BrsDevice.stderr.write(`error,[core] Error mounting File System: ${err.message}`);
         return { exitReason: AppExitReason.Crashed };
     }
     // Setup the interpreter
@@ -783,7 +783,7 @@ export async function executeTask(payload: TaskPayload, customOptions?: Partial<
         BrsDevice.setupFileSystem(payload);
         BrsDevice.loadLocaleTerms();
     } catch (err: any) {
-        postMessage(`error,[core] Error mounting File System on Task: ${err.message}`);
+        BrsDevice.stderr.write(`error,[core] Error mounting File System on Task: ${err.message}`);
         return;
     }
     // Setup the interpreter
@@ -796,7 +796,7 @@ export async function executeTask(payload: TaskPayload, customOptions?: Partial<
         try {
             restoreEncryptedFiles(sourceResult.pcode, sourceResult.iv, taskPassword);
         } catch (err: any) {
-            postMessage(`error,Error unpacking the app on Task: ${err.message}`);
+            BrsDevice.stderr.write(`error,Error unpacking the app on Task: ${err.message}`);
         }
     }
     await runBeforeExecuteHooks(interpreter, payload);
@@ -815,7 +815,7 @@ export async function executeTask(payload: TaskPayload, customOptions?: Partial<
         if (BrsDevice.registry.isDirty) {
             BrsDevice.flushRegistry();
         }
-        postMessage(`debug,[core] Task ${payload.taskData.name} is done.`);
+        BrsDevice.stdout.write(`debug,[core] Task ${payload.taskData.name} is done.`);
     } catch (err: any) {
         if (TerminateReasons.includes(err.message)) {
             const reason = err.message === "debug-exit" ? AppExitReason.Stopped : AppExitReason.UserNav;
@@ -969,7 +969,7 @@ function setupPackageFiles(payload: AppPayload | TaskPayload): SourceResult {
                 result.sourceMap.set(pkgPath, fsys.readFileSync(pkgPath, "utf8"));
             }
         } catch (err: any) {
-            postMessage(`error,Error accessing file ${filePath.url} - ${err.message}`);
+            BrsDevice.stderr.write(`error,Error accessing file ${filePath.url} - ${err.message}`);
         }
     }
     return result;
@@ -997,7 +997,7 @@ function setupTranslations(interpreter: Interpreter) {
         }
         if (trType !== "") {
             if (xmlText.trim().length === 0) {
-                postMessage("error,Error parsing translation XML: Empty input");
+                BrsDevice.stderr.write("error,Error parsing translation XML: Empty input");
                 return;
             }
             try {
@@ -1031,12 +1031,12 @@ function setupTranslations(interpreter: Interpreter) {
                     }
                 }
             } catch (err: any) {
-                postMessage(`error,Error parsing XML: ${err?.message ?? err}`);
+                BrsDevice.stderr.write(`error,Error parsing XML: ${err?.message ?? err}`);
             }
         }
     } catch (err: any) {
         const badPath = `pkg:/locale/${locale}/`;
-        postMessage(`error,Invalid path: ${badPath} - ${err.message}`);
+        BrsDevice.stderr.write(`error,Invalid path: ${badPath} - ${err.message}`);
     }
 }
 
@@ -1089,7 +1089,7 @@ function collectComponentFiles(fsys: typeof BrsDevice.fileSystem): {
             files[rel] = fsys.readFileSync(fsPath, "utf8") as string;
             packedFiles.push(rel);
         } catch (err: any) {
-            postMessage(`error,Error reading component file ${fsPath} - ${err.message}`);
+            BrsDevice.stderr.write(`error,Error reading component file ${fsPath} - ${err.message}`);
         }
     }
     return { files, packedFiles };
@@ -1170,7 +1170,7 @@ async function runEncrypted(
             return { exitReason: AppExitReason.NoPassword };
         }
     } catch (err: any) {
-        postMessage(`error,Error unpacking the app: ${err.message}`);
+        BrsDevice.stderr.write(`error,Error unpacking the app: ${err.message}`);
         return { exitReason: AppExitReason.UnpackFail };
     }
     // Execute the decrypted source code
@@ -1179,7 +1179,7 @@ async function runEncrypted(
         const exitReason = await executeApp(interpreter, allStatements, payload);
         return { exitReason: exitReason };
     } catch (err: any) {
-        postMessage(`error,Error executing the app: ${err.message}`);
+        BrsDevice.stderr.write(`error,Error executing the app: ${err.message}`);
         return { exitReason: AppExitReason.Crashed };
     }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -97,7 +97,9 @@ if (typeof onmessage !== "undefined") {
             loadExtensions(event.data);
             executeFile(event.data, {}, true);
         } else if (isTaskPayload(event.data)) {
-            BrsDevice.stdout.write(`debug,[core] Task payload received: ${event.data.taskData.id}:${event.data.taskData.name}`);
+            BrsDevice.stdout.write(
+                `debug,[core] Task payload received: ${event.data.taskData.id}:${event.data.taskData.name}`
+            );
             loadExtensions(event.data);
             executeTask(event.data);
         } else if (typeof event.data === "string" && event.data === "getVersion") {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -166,7 +166,7 @@ function loadExtension(moduleId: SupportedExtension, modulePath: string) {
             registerExtension(() => extension);
             loadedExtensions.add(moduleId);
             const extensionInfo: ExtensionInfo = { name: moduleId, library: modulePath, version: extension.version };
-            BrsDevice.stdout.write(`info,[core] Extension loaded: ${moduleId}`);
+            postMessage(extensionInfo);
         } else {
             BrsDevice.stderr.write(`warning,[core] The loaded library does not contain ${moduleId} Extension.`);
         }

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -269,8 +269,8 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     constructor(options?: Partial<ExecutionOptions>, useMainEnv: boolean = false) {
         this._environment = useMainEnv ? MainEnvironment : new Environment(new RoAssociativeArray([]));
         Object.assign(this.options, options);
-        BrsDevice.stdout = new OutputProxy(this.options.stdout, this.options.post);
-        BrsDevice.stderr = new OutputProxy(this.options.stderr, this.options.post);
+        BrsDevice.stdout = new OutputProxy(this.options.stdout, this.options.post, BrsDevice.deviceInfo.logLevel);
+        BrsDevice.stderr = new OutputProxy(this.options.stderr, this.options.post, BrsDevice.deviceInfo.logLevel);
         if (this.options.root) {
             BrsDevice.fileSystem.setRoot(this.options.root);
         }

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -809,7 +809,9 @@ function restoreNodeFields(source: any, node: Node, nodeMap?: Map<string, Node>)
         }
         const brsValue = brsValueOf(value, undefined, nodeMap);
         if (brsValue instanceof Node) {
-            BrsDevice.stdout.write(`debug,[thread:${sgRoot.threadId}] Restoring Node ${node.nodeSubtype} field "${key}"`);
+            BrsDevice.stdout.write(
+                `debug,[thread:${sgRoot.threadId}] Restoring Node ${node.nodeSubtype} field "${key}"`
+            );
         }
         node.setValueSilent(key, brsValue);
     }

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -809,7 +809,7 @@ function restoreNodeFields(source: any, node: Node, nodeMap?: Map<string, Node>)
         }
         const brsValue = brsValueOf(value, undefined, nodeMap);
         if (brsValue instanceof Node) {
-            postMessage(`debug,[thread:${sgRoot.threadId}] Restoring Node ${node.nodeSubtype} field "${key}"`);
+            BrsDevice.stdout.write(`debug,[thread:${sgRoot.threadId}] Restoring Node ${node.nodeSubtype} field "${key}"`);
         }
         node.setValueSilent(key, brsValue);
     }

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -867,7 +867,7 @@ export class Task extends Node {
         const id = nextRendezvousId();
         const location = sgRoot.interpreter?.formatLocation() ?? "pkg:/unknown(??)";
         const detail = BrsDevice.deviceInfo.logLevel === LogLevel.Debug ? ` ${action} ${type}.${key}` : "";
-        BrsDevice.stdout.write(`debug,${getNow()} [sg.node.BLOCK] Rendezvous[${id}]${detail} at ${location}\r\n`);
+        BrsDevice.stdout.write(`print,${getNow()} [sg.node.BLOCK] Rendezvous[${id}]${detail} at ${location}\r\n`);
         return id;
     }
 
@@ -889,7 +889,7 @@ export class Task extends Node {
         const detail = BrsDevice.deviceInfo.logLevel === LogLevel.Debug ? ` ${action} ${type}.${key}` : "";
         const duration = elapsedMs > 0 ? ` in ${(elapsedMs / 1000).toFixed(3)} s` : "";
         BrsDevice.stdout.write(
-            `debug,${getNow()} [sg.node.UNBLOCK] Rendezvous[${id}]${detail} completed${duration}\r\n`
+            `print,${getNow()} [sg.node.UNBLOCK] Rendezvous[${id}]${detail} completed${duration}\r\n`
         );
     }
 


### PR DESCRIPTION
Several messages from the interpreter were not being filtered based on the defined Log Level, so a filter was added in the `OutputProxy` object. Also changed the reporting of rendezvous to use `print` instead of `debug` as these messages should be printed regardless of the log level, those have a separate flag to be enabled.