### PR TITLE
fix(scenegraph): report an alias field's own name in observer events

### DIFF
--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1258,7 +1258,7 @@ export class Node extends RoSGNode implements BrsValue {
         if (field instanceof Field) {
             const host = interpreter.environment.hostNode;
             const alias = this.aliases.get(name.toLowerCase());
-            const obsFieldName = new BrsString(alias?.targets[0]?.fieldName ?? field.getName());
+            const obsFieldName = new BrsString(alias?.aliasName ?? field.getName());
             const infoArray = infoFields instanceof RoArray ? infoFields : undefined;
             let observer: Callable | RoMessagePort | BrsInvalid = BrsInvalid.Instance;
             if (isBrsString(funcOrPort)) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -405,6 +405,27 @@ describe.concurrent("cli", () => {
         ]);
     }, 30000);
 
+    it("SceneGraph Alias Field Observer Event Name Test", async () => {
+        // Regression: Node.addObserver cached the alias's *target* field name (e.g. "text")
+        // instead of the alias's own declared name (e.g. "aliasField") into the observer's
+        // eventParams, so msg.getField() reported the wrong name for any observer registered
+        // on an alias field via observeField()/observeFieldScoped().
+        let command = ["node", brsCliPath, "-r alias-observer-event-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Testing Alias Field Observer Event Name ===",
+            "field: aliasField",
+            "data: Hello, World!",
+            "=== Test Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     it("applies an interface field's default value through its alias targets", async () => {
         // Regression: addFields applied a field's XML default only on the non-alias branch, so an
         // aliased field with a default (e.g. `height` value="42" aliased to a child's height) never

--- a/test/cli/resources/alias-observer-event-app/components/alias-observer-test.xml
+++ b/test/cli/resources/alias-observer-event-app/components/alias-observer-test.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="AliasObserverTest" extends="Scene">
+  <interface>
+    <!-- Alias field: observing it by its own name must report that name, not the target's -->
+    <field id="aliasField" alias="child.text" />
+  </interface>
+  <children>
+    <Label id="child" translation="[0, 0]" />
+  </children>
+</component>

--- a/test/cli/resources/alias-observer-event-app/manifest
+++ b/test/cli/resources/alias-observer-event-app/manifest
@@ -1,0 +1,4 @@
+title=Alias Observer Event Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/alias-observer-event-app/source/main.brs
+++ b/test/cli/resources/alias-observer-event-app/source/main.brs
@@ -1,0 +1,27 @@
+sub Main()
+    print "=== Testing Alias Field Observer Event Name ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("AliasObserverTest")
+    screen.show()
+
+    ' Observe the alias by its own declared name, via a message port (matches real-world usage).
+    scene.observeField("aliasField", port)
+
+    ' Trigger the alias's shared field through the target child.
+    child = scene.findNode("child")
+    child.text = "Hello, World!"
+
+    msg = wait(0, port)
+    if type(msg) = "roSGNodeEvent"
+        print "field: "; msg.getField()
+        print "data: "; msg.getData()
+    else
+        print "no event received"
+    end if
+
+    print "=== Test Complete ==="
+end sub


### PR DESCRIPTION
## Summary
- `observeField()`/`observeFieldScoped()` on an interface **alias** field cached the alias's *target* field name into the resulting `roSGNodeEvent` instead of the alias's own declared name, so `GetField()` on the delivered event returned the wrong value.
- Apps that dispatch handling by comparing `msg.GetField()` against the alias's declared name (a common pattern for routing message-port events) would silently get misrouted to whatever handler matches the target field's name instead — producing behavior that diverges from a real Roku device, where the alias's own name is reported correctly.
- Fix: `Node.addObserver` now uses the alias's own declared name (`alias.aliasName`) when present, falling back to the field's own name otherwise. One-line change in `src/extensions/scenegraph/nodes/Node.ts`.
- Added a regression test fixture (`test/cli/resources/alias-observer-event-app/`) that observes an alias field via a message port and asserts the delivered event reports the alias's own name, plus a matching `cli.test.js` case.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run prettier:write` — no unrelated changes
- [x] `npm run build:cli && npm run build:sg`
- [x] `npx vitest run test/cli/cli.test.js -t "Alias"` — new + existing alias tests pass
- [x] `npm test` — full suite: 200 files / 2541 tests passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)