### PR TITLE
fix(scenegraph): ScrollingLabel reports full maxWidth as measured width

### DIFF
--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -248,10 +248,15 @@ export class ScrollingLabel extends Label {
         // during layout, the value derives purely from stored state, and setValue only notifies
         // on a genuine change — idempotent.
         this.setEllipsized(isEllipsized);
-        const measuredWidth = this.needsScrolling ? maxWidth : this.fullTextWidth;
+        // The measured/reported width is always the constrained (maxWidth) box, not the actual
+        // text width — device-documented: horizAlign positions text "relative to the maximum
+        // width of the label as specified by the maxWidth field," regardless of whether the
+        // current text is short enough that no scrolling is needed. Reporting the shorter
+        // fullTextWidth here (only clamping to maxWidth while actively scrolling) under-measures
+        // the node to a sibling LayoutGroup, which then positions later siblings too close.
         return {
             text: textToDraw,
-            width: measuredWidth,
+            width: constrainedWidth,
             height: textHeight,
             ellipsized: isEllipsized,
         };

--- a/test/extensions/scenegraph/LayoutGroup.test.js
+++ b/test/extensions/scenegraph/LayoutGroup.test.js
@@ -1,8 +1,10 @@
+const fs = require("fs");
+const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsString, Float, RoArray } = core;
+const { BrsDevice, BrsString, Float, Int32, RoArray } = core;
 
 /** Minimal interpreter accepted by renderNode → renderChildren when draw2D is absent. */
 const fakeInterpreter = {};
@@ -71,5 +73,59 @@ describe("LayoutGroup re-imposes child alignment after an external translation c
         // Primary axis stays stacked at 0; the custom cross axis keeps the app's value.
         expect(child.getValueJS("translation")[0]).toBeCloseTo(0);
         expect(child.getValueJS("translation")[1]).toBeCloseTo(100);
+    });
+});
+
+/**
+ * Regression: a ScrollingLabel column whose text currently fits within maxWidth (no scrolling
+ * needed) must still reserve the FULL maxWidth for a sibling LayoutGroup to measure — matching the
+ * device-documented behavior that horizAlign positions text "relative to the maximum width of the
+ * label as specified by the maxWidth field," not the actual rendered text width. Jellyfin-roku's
+ * AlbumTrackList uses this exact shape (Track / Title(ScrollingText, maxWidth-only) / Length /
+ * Plays columns): the bug reported the Length/Plays columns rendering too close to Title because
+ * the engine measured the ScrollingLabel's short, non-scrolling text instead of its reserved box.
+ */
+describe("LayoutGroup positions siblings after a non-scrolling ScrollingLabel's full maxWidth", () => {
+    beforeAll(() => {
+        // ScrollingLabel resolves its font from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("a trailing fixed-width sibling is offset by maxWidth, not the shorter text width", () => {
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("horiz"));
+        layout.setValue("itemSpacings", vector([20]));
+
+        const track = SGNodeFactory.createNode("Rectangle");
+        track.setValue("width", new Float(80));
+        track.setValue("height", new Float(50));
+
+        const title = SGNodeFactory.createNode("ScrollingLabel");
+        title.setValue("font", new BrsString("font:SmallSystemFont"));
+        title.setValue("maxWidth", new Int32(1280));
+        // Short text: well under maxWidth, so no scrolling is needed — this is the case that
+        // previously under-measured the node to its actual (much narrower) text width.
+        title.setValue("text", new BrsString("Track Title"));
+
+        const length = SGNodeFactory.createNode("Rectangle");
+        length.setValue("width", new Float(120));
+        length.setValue("height", new Float(50));
+
+        layout.appendChildToParent(track);
+        layout.appendChildToParent(title);
+        layout.appendChildToParent(length);
+
+        // Measurement pass (no draw2D) so the layout converges to a fixed point.
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        // "Length" must sit after Track (80) + spacing (20) + the full reserved Title column
+        // (1280) + spacing (20), regardless of how short the actual title text is.
+        const expectedX = 80 + 20 + 1280 + 20;
+        expect(length.getValueJS("translation")[0]).toBeCloseTo(expectedX);
     });
 });


### PR DESCRIPTION
## Summary
- `ScrollingLabel.renderLabel` only reported `maxWidth` as its measured bounding-rect width while text was actively scrolling; when the text fit within `maxWidth` it instead reported the shorter actual text width.
- A sibling `LayoutGroup` measuring that node for positioning purposes then placed later children right after the short text instead of after the reserved column, so they render too close to the `ScrollingLabel`.
- Roku's device docs state that `horizAlign` positions text relative to `maxWidth` regardless of whether scrolling is active, so the reported measured width should always be the `maxWidth`-constrained box, not the actual (possibly shorter) text width.

## Test plan
- [x] `npx vitest run test/extensions/scenegraph` — 77 files / 791 tests pass
- [x] Added a `LayoutGroup` regression test reproducing the sibling-positioning bug directly; confirmed it fails without the fix and passes with it
- [x] `npm run lint` clean
- [x] `npm run prettier:write` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)