### PR TITLE
fix(scenegraph): Overhang default logo overlaps title/divider on resolution-mismatched device

### DIFF
--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -142,8 +142,15 @@ export class Group extends Node {
         return (this.getValueJS("visible") as boolean) ?? true;
     }
 
-    protected addPoster(uri: string, translation: number[], width?: number, height?: number) {
+    protected addPoster(uri: string, translation: number[], width?: number, height?: number, noScaling?: boolean) {
         const poster = SGNodeFactory.createNode(SGNodeType.Poster) as Poster;
+        if (noScaling) {
+            // Must be set before the uri load below: Poster.loadUri() bakes bitmapWidth/bitmapHeight
+            // from the current noScaling state on its very first (synchronous) run, so setting this
+            // afterward leaves a stale, resolution-scaled bitmapWidth that disagrees with the
+            // unscaled size noScaling actually draws at.
+            poster.forceNoScaling();
+        }
         if (uri) {
             poster.setValue("uri", new BrsString(uri));
         }

--- a/src/extensions/scenegraph/nodes/Overhang.ts
+++ b/src/extensions/scenegraph/nodes/Overhang.ts
@@ -75,7 +75,7 @@ export class Overhang extends Group {
             this.setValueSilent("height", new Float(this.height));
             this.backRect = this.addRectangle("color", [0, 0], this.width, this.height);
             this.backPoster = this.addPoster("", [0, 0], this.width, this.height);
-            this.logo = this.addPoster(defaultLogo, [102, 63]);
+            this.logo = this.addPoster(defaultLogo, [102, 63], undefined, undefined, true);
             this.leftDivider = this.addPoster(divider, [261, 59], 12, 51);
             this.title = this.addLabel("titleColor", [297, 58], 0, 50, 45, "bottom");
             this.optionsIcon = this.addPoster(this.optionsOff, [1421, 67], 30, 30);
@@ -89,7 +89,7 @@ export class Overhang extends Group {
             this.setValueSilent("height", new Float(this.height));
             this.backRect = this.addRectangle("color", [0, 0], this.width, this.height);
             this.backPoster = this.addPoster("", [0, 0], this.width, this.height);
-            this.logo = this.addPoster(defaultLogo, [68, 42]);
+            this.logo = this.addPoster(defaultLogo, [68, 42], undefined, undefined, true);
             this.leftDivider = this.addPoster(divider, [174, 39], 8, 34);
             this.title = this.addLabel("titleColor", [196, 39], 0, 35, 30, "bottom");
             this.optionsIcon = this.addPoster(this.optionsOff, [959, 46], 20, 20);
@@ -97,7 +97,6 @@ export class Overhang extends Group {
             this.rightDivider = this.addPoster(divider, [1109, 39], 8, 34);
             this.clockText = this.addLabel("clockColor", [1133, 44], 0, 27, 22, "center");
         }
-        this.logo.noScaling = true;
         this.backRect.setValueSilent("visible", BrsBoolean.False);
         this.optionsText.setValue("text", new BrsString(BrsDevice.getTerm("for Options")));
         this.clockText.setValue("text", new BrsString(BrsDevice.getTime()));

--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -39,6 +39,14 @@ export class Poster extends Group {
     protected uri: string = "";
     protected bitmap?: RoBitmap;
     noScaling: boolean = false;
+    /**
+     * Set by `forceNoScaling()` for built-in Posters whose asset was already picked for the
+     * correct resolution (e.g. Overhang's default logo, TrickPlayBar's ticker). Unlike
+     * `noScaling` itself — which `loadUri()` recomputes from the `uri_resolution_autosub` match
+     * on every load, clobbering any value set beforehand or in between loads — this flag persists
+     * and keeps `noScaling` pinned `true` across every subsequent `uri` change.
+     */
+    private forcedNoScaling: boolean = false;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.Poster) {
         super([], name);
@@ -46,6 +54,11 @@ export class Poster extends Group {
 
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
+    }
+
+    forceNoScaling() {
+        this.forcedNoScaling = true;
+        this.noScaling = true;
     }
 
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
@@ -177,7 +190,7 @@ export class Poster extends Group {
                 }
             }
             const subSearch = sgRoot.autoSub.search.toLowerCase();
-            this.noScaling = subSearch !== "" && uri.toLowerCase().includes(subSearch);
+            this.noScaling = this.forcedNoScaling || (subSearch !== "" && uri.toLowerCase().includes(subSearch));
             if (this.noScaling) {
                 super.setValue("bitmapWidth", new Float(this.bitmap.width));
                 super.setValue("bitmapHeight", new Float(this.bitmap.height));

--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -50,8 +50,13 @@ export class TrickPlayBar extends Group {
         const barBmpUri = `common:/images/${this.resolution}/trickplaybar.9.png`;
         this.backBack = this.addPoster(barBmpUri, [0, 0], this.barW, this.barH);
         this.barProgress = this.addPoster(barBmpUri, [0, 0], 1, this.barH);
-        this.barTicker = this.addPoster(`common:/images/${this.resolution}/trickplayticker.png`, [0, 0]);
-        this.barTicker.noScaling = true;
+        this.barTicker = this.addPoster(
+            `common:/images/${this.resolution}/trickplayticker.png`,
+            [0, 0],
+            undefined,
+            undefined,
+            true
+        );
         this.position = this.addLabel("textColor", [0, this.barH * 2], 0, this.barH * 2);
         this.backBack.setValueSilent("opacity", new Float(0.3));
         this.barProgress.setValueSilent("visible", BrsBoolean.False);

--- a/test/extensions/scenegraph/OverhangLayout.test.js
+++ b/test/extensions/scenegraph/OverhangLayout.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, Float, RoArray, Interpreter } = core;
+const { BrsDevice, BrsString, Float, RoArray, Interpreter } = core;
 
 const vector = (values) => new RoArray(values.map((v) => new Float(v)));
 
@@ -53,5 +53,56 @@ describe("Overhang honors its own translation", () => {
         const rect = overhang.getBoundingRect("toParent", interpreter);
         expect(Math.round(rect.x)).toBe(0);
         expect(Math.round(rect.y)).toBe(0);
+    });
+});
+
+/**
+ * Regression for the default logo overlapping the title/separator when the simulated device's
+ * display mode (BrsDevice.getDisplayMode()) disagrees with the scene's resolution (here: an app
+ * that never declares `ui_resolutions=fhd`, so the scene stays HD, run on a device in 1080p).
+ *
+ * Poster.loadUri() used to bake `bitmapWidth` from `scaleToResolution()` (a resolution-mismatch
+ * scale factor) on the logo's very first synchronous load, then Overhang set `noScaling = true`
+ * only afterward — too late to affect that already-baked value. At render time `noScaling` made
+ * the logo draw at its true native pixel size while `alignChildren()` positioned the divider/title
+ * off the stale, incorrectly-scaled `bitmapWidth`, so they landed inside the actually-wider logo.
+ */
+describe("Overhang default logo does not overlap the divider/title on a resolution-mismatched device", () => {
+    let interpreter;
+    let originalDisplayMode;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+        originalDisplayMode = BrsDevice.deviceInfo.displayMode;
+    });
+
+    afterAll(() => {
+        BrsDevice.setDeviceInfo({ displayMode: originalDisplayMode });
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("logo bitmapWidth matches its native asset size and the divider clears it", () => {
+        BrsDevice.setDeviceInfo({ displayMode: "1080p" });
+
+        const overhang = SGNodeFactory.createNode("Overhang");
+        overhang.setValue("title", new BrsString("Title"));
+        overhang.renderNode(interpreter, [0, 0], 0, 1);
+
+        const [, , logo, leftDivider] = overhang.getNodeChildren();
+        const logoX = logo.getValueJS("translation")[0];
+        const logoWidth = logo.getValueJS("bitmapWidth");
+        const dividerX = leftDivider.getValueJS("translation")[0];
+
+        // The HD default logo asset is 90px wide; a resolution mismatch used to scale this to 60.
+        expect(logoWidth).toBe(90);
+        expect(dividerX).toBeGreaterThanOrEqual(logoX + logoWidth);
     });
 });


### PR DESCRIPTION
## Summary
- `Poster.loadUri()` recomputes `noScaling` from an unrelated URI auto-substitution check on every load, clobbering any value a caller set beforehand or right after — so `Overhang`'s default logo baked a resolution-mismatch-scaled `bitmapWidth` on its first load, then rendered at native size once `noScaling` was (too late) forced true, leaving the divider/title positioned as if the logo were narrower than it actually drew.
- This only surfaces when the simulated device's display mode disagrees with the scene's declared resolution (e.g. running FHD against an app that never opts into `ui_resolutions=fhd`, which defaults to HD) — matching the reported "overlap in FHD, fine in HD" symptom.
- Adds `Poster.forceNoScaling()`, a persistent flag `loadUri()` always honors, and threads it through a new `addPoster(..., noScaling)` parameter so the flag is in effect *before* the first load. Applied to `Overhang`'s default logo and `TrickPlayBar`'s ticker, which had the identical latent ordering bug.

## Test plan
- [x] `npm run lint` / `npm run prettier` clean on changed files
- [x] `npx vitest run test/extensions/scenegraph/OverhangLayout.test.js` — added a regression case asserting the logo's `bitmapWidth` matches its native asset size and the divider clears it when the device display mode mismatches the scene resolution
- [x] `npm test` — full suite, 2547 tests passing, no regressions
- [x] Manual repro script confirming logo/divider positions before and after the fix in both HD and FHD device modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)