### PR TITLE
fix(interpreter): support roRegex "x" (extended/free-spacing) flag

### DIFF
--- a/src/core/brsTypes/components/RoRegex.ts
+++ b/src/core/brsTypes/components/RoRegex.ts
@@ -7,7 +7,8 @@ import { RuntimeError, RuntimeErrorDetail } from "../../error/BrsError";
 
 export class RoRegex extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
-    // 'x' flag is not implemented yet.
+    // JS RegExp has no native equivalent to the "x" (extended/free-spacing) flag, so it's handled
+    // by preprocessing the pattern in stripFreeSpacing() rather than being forwarded to new RegExp().
     readonly supportedFlags = "gims";
     private jsRegex: RegExp;
 
@@ -26,7 +27,12 @@ export class RoRegex extends BrsComponent implements BrsValue {
                     : RuntimeErrorDetail.TypeMismatch;
             throw new RuntimeError(errorDetail);
         }
-        this.jsRegex = new RegExp(expression.getValue(), this.parseFlags(flags.getValue()));
+        const rawFlags = flags.getValue();
+        let pattern = expression.getValue();
+        if (rawFlags.includes("x")) {
+            pattern = RoRegex.stripFreeSpacing(pattern);
+        }
+        this.jsRegex = new RegExp(pattern, this.parseFlags(rawFlags));
 
         this.registerMethods({
             ifRegex: [this.isMatch, this.match, this.replace, this.replaceAll, this.split, this.matchAll],
@@ -68,6 +74,54 @@ export class RoRegex extends BrsComponent implements BrsValue {
      */
     private parseReplacementPattern(pattern: string): string {
         return pattern.replaceAll("\\", "$");
+    }
+
+    private static readonly whitespacePattern = /\s/;
+
+    /**
+     * Implements the "x" (extended/free-spacing) flag, which JS RegExp has no native flag for:
+     * strips unescaped whitespace and "#...newline" comments from the pattern, leaving whitespace
+     * and "#" untouched when escaped (e.g. "\ ", "\#") or inside a character class ("[...]").
+     *
+     * Unlike PCRE, JS RegExp has no "leading ']' is literal" convention for character classes, so
+     * an unescaped "]" always closes the class here, even immediately after "[" or "[^" - matching
+     * how `new RegExp()` will itself interpret the (stripped) pattern.
+     * @param pattern Original pattern, as passed to CreateObject
+     * @returns Pattern with free-spacing whitespace and comments removed
+     */
+    private static stripFreeSpacing(pattern: string): string {
+        let result = "";
+        let inClass = false;
+        for (let i = 0; i < pattern.length; i++) {
+            const char = pattern[i];
+            if (char === "\\" && i + 1 < pattern.length) {
+                result += char + pattern[i + 1];
+                i++;
+                continue;
+            }
+            if (inClass) {
+                result += char;
+                if (char === "]") {
+                    inClass = false;
+                }
+                continue;
+            }
+            if (char === "[") {
+                inClass = true;
+                result += char;
+                continue;
+            }
+            if (RoRegex.whitespacePattern.test(char)) {
+                continue;
+            }
+            if (char === "#") {
+                const newline = pattern.indexOf("\n", i);
+                i = newline === -1 ? pattern.length : newline;
+                continue;
+            }
+            result += char;
+        }
+        return result;
     }
 
     /** Returns whether the string matched the regex or not */

--- a/test/brsTypes/components/RoRegex.test.js
+++ b/test/brsTypes/components/RoRegex.test.js
@@ -189,4 +189,49 @@ describe("RoRegex", () => {
             expect(thirdElement.get(new Int32(0)).value).toBe("789");
         });
     });
+
+    describe("x flag (extended/free-spacing)", () => {
+        it("ignores whitespace and newlines in the pattern", () => {
+            let regx = new RoRegex(new BrsString("(\\d{3})  -  (\\d{4})\n"), new BrsString("x"));
+            let isMatch = regx.getMethod("ismatch");
+
+            let result = isMatch.call(interpreter, new BrsString("555-1234"));
+            expect(result).toBe(BrsBoolean.True);
+        });
+
+        it("strips '#' comments up to the next newline", () => {
+            let regx = new RoRegex(new BrsString("\\d+ # matches one or more digits\nfoo"), new BrsString("x"));
+            let isMatch = regx.getMethod("ismatch");
+
+            let result = isMatch.call(interpreter, new BrsString("123foo"));
+            expect(result).toBe(BrsBoolean.True);
+        });
+
+        it("keeps escaped whitespace and '#' as literal characters", () => {
+            let regx = new RoRegex(new BrsString("a\\ b\\#c"), new BrsString("x"));
+            let isMatch = regx.getMethod("ismatch");
+
+            let result = isMatch.call(interpreter, new BrsString("a b#c"));
+            expect(result).toBe(BrsBoolean.True);
+
+            let noMatch = isMatch.call(interpreter, new BrsString("ab#c"));
+            expect(noMatch).toBe(BrsBoolean.False);
+        });
+
+        it("keeps whitespace literal inside a character class", () => {
+            let regx = new RoRegex(new BrsString("[a b]+"), new BrsString("x"));
+            let isMatch = regx.getMethod("ismatch");
+
+            let result = isMatch.call(interpreter, new BrsString("a b"));
+            expect(result).toBe(BrsBoolean.True);
+        });
+
+        it("combines with other flags, e.g. case-insensitive", () => {
+            let regx = new RoRegex(new BrsString("hello   world"), new BrsString("xi"));
+            let isMatch = regx.getMethod("ismatch");
+
+            let result = isMatch.call(interpreter, new BrsString("HELLOWORLD"));
+            expect(result).toBe(BrsBoolean.True);
+        });
+    });
 });

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -389,6 +389,7 @@ describe("end to end brightscript functions", () => {
             "[ aby, by ]",
             " ]",
             "${variable}variable",
+            "555-1234 is match of free-spacing phone pattern: true",
         ]);
     });
 

--- a/test/e2e/resources/components/roRegex.brs
+++ b/test/e2e/resources/components/roRegex.brs
@@ -43,4 +43,8 @@ sub main()
 	capitalize=match[1]
 	variable=match[2]
 	print match[0]; match[1]; match[2]
+
+    ' support for the "x" (extended/free-spacing) flag
+    regex = createObject("roRegex", "(\d{3})  -  (\d{4}) # phone number" + chr(10), "x")
+    print "555-1234 is match of free-spacing phone pattern: " regex.ismatch("555-1234")
 end sub


### PR DESCRIPTION
## Summary
- `roRegex`'s documented `"x"` flag (Perl/PCRE extended/free-spacing mode) was silently dropped — `parseFlags` filtered it out with no error and no effect, since JS `RegExp` has no native equivalent flag.
- Implemented it by preprocessing the pattern string before compiling: unescaped whitespace and `#...newline` comments are stripped, while whitespace/`#` stay literal when escaped (`\ `, `\#`) or inside a character class (`[...]`), matching the documented spec.
- Character-class tracking follows JS `RegExp`'s own grammar (an unescaped `]` always closes the class) rather than PCRE's "leading `]` is literal" convention, since the stripped pattern is compiled by JS's engine, not PCRE's.

## Test plan
- [x] `npx vitest run test/brsTypes/components/RoRegex.test.js` — new `"x flag"` describe block (whitespace/newline stripping, comment stripping, escaped literals preserved, character-class whitespace preserved, combined with another flag)
- [x] `npx vitest run test/e2e/BrsComponents.test.js -t roRegex` — new e2e example
- [x] `npm run lint` / `npm run prettier:write`
- [x] `npm test` — full suite (203 files, 2552 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)