### PR TITLE
fix(scenegraph): stale item visuals after in-place ArrayGrid/RowList content reorder

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -221,6 +221,33 @@ When `addFields` builds a custom component's fields, a `<field>` whose name alre
 the XML default is applied by the subsequent `setValueSilent`. Regression:
 `duplicate-system-field-app` in `test/cli/cli-scenegraph.test.js`.
 
+## `ArrayGrid`/`RowList` item-component caches are position-keyed, not content-keyed
+
+`ArrayGrid.itemComps[]` and `RowList.rowItemComps[][]` are reused across frames, indexed purely by
+screen **position** (index / row+col) — cleared only on a full `content` field **reassignment**
+(`ArrayGrid.setValue`, `content` branch). Whether a cached item component gets its `itemContent`
+re-pushed was gated solely on the content child's **own** `.changed` flag
+(`ArrayGrid.renderItemComponent`, `RowList`'s row-cell render path):
+
+```ts
+if (content.changed) {
+    itemComp.setValue("itemContent", content, true);
+    content.changed = false;
+}
+```
+
+That misses in-place reordering. `removeChild`/`insertChild`/`appendChild`-as-move
+(`ContentNode.appendChildToParent`, `Node.insertChildAtIndex`, `Node.removeChildrenAtIndex`) mark
+`.changed` and call `makeDirty()` on the **container** node so `renderNodeContent`'s top-level check
+correctly rebuilds the flattened `this.content[]`/`this.metadata[]` model (`refreshContent`) — but the
+individual `ContentNode` objects that land at new positions in that array never had their own
+`.changed` set. So after a reorder, `this.content[index]` can be a *different* object than the one the
+position-keyed cache slot was last told about, and the app never sees its updated field/content until
+something else (a focus move touching unrelated fields on that slot) coincidentally papers over it.
+Fix: also compare the cached item component's live `itemContent` value (a plain reference read) against
+the content object now assigned to that slot, and push whenever the two differ — not only when
+`content.changed`. Regression: `ArrayGridItemReorder.test.js`.
+
 ## Per-node memory: lazy fields and lazy methods (large content trees)
 
 A large EPG (e.g. the SGDEX **TimeGridView** sample) creates thousands of `ContentNode`s. Two

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -627,7 +627,12 @@ export class ArrayGrid extends Group {
         // was applied would stay frozen at the wrong (full-width) size — stretching the item.
         this.itemComps[index].setValue("width", new Float(itemRect.width), false);
         this.itemComps[index].setValue("height", new Float(itemRect.height), false);
-        if (content.changed) {
+        // itemComps[] is keyed by POSITION, not by content identity. A reorder (removeChild/
+        // insertChild/appendChild-as-move) only dirties the container ContentNode, never the moved
+        // child itself, so content.changed alone misses "this slot now holds a different object".
+        // Compare against what the cached item component was last told, too.
+        const currentContent = this.itemComps[index].getValue("itemContent");
+        if (content.changed || currentContent !== content) {
             this.itemComps[index].setValue("itemContent", content, true);
             content.changed = false;
         }

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -1053,7 +1053,11 @@ export class RowList extends ArrayGrid {
         // otherwise a button focused on the first render never shows its focused state once the list
         // is focused afterwards (focusPercent stays 1, so a focusPercent observer never re-fires).
         itemComp.setValue("itemHasFocus", BrsBoolean.from(focused && nodeFocus), false);
-        if (content.changed) {
+        // rowItemComps[][] is keyed by POSITION, not by content identity — see the matching comment
+        // in ArrayGrid.renderItemComponent. A reorder only dirties the container ContentNode, so
+        // content.changed alone misses "this cell now holds a different object".
+        const currentContent = itemComp.getValue("itemContent");
+        if (content.changed || currentContent !== content) {
             itemComp.setValue("itemContent", content, true);
             content.changed = false;
         }

--- a/test/extensions/scenegraph/ArrayGridItemReorder.test.js
+++ b/test/extensions/scenegraph/ArrayGridItemReorder.test.js
@@ -1,0 +1,108 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { BrsDevice, BrsString, Float, RoArray } = core;
+
+/** Builds a flat root → items ContentNode tree (no sections), e.g. ["A", "B", "C"]. */
+function buildFlatContent(titles) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (const title of titles) {
+        const item = SGNodeFactory.createNode("ContentNode");
+        item.setValue("title", new BrsString(title));
+        root.appendChildToParent(item);
+    }
+    return root;
+}
+
+/** Builds a root → rows → items ContentNode tree; `rows` is an array of arrays of item titles. */
+function buildRowContent(rows) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (const items of rows) {
+        const rowNode = SGNodeFactory.createNode("ContentNode");
+        for (const title of items) {
+            const itemNode = SGNodeFactory.createNode("ContentNode");
+            itemNode.setValue("title", new BrsString(title));
+            rowNode.appendChildToParent(itemNode);
+        }
+        root.appendChildToParent(rowNode);
+    }
+    return root;
+}
+
+/**
+ * Regression: an app that filters a list by mutating its existing `content` tree in place
+ * (removeChild/insertChild on individual children, never reassigning the `content` field itself —
+ * exactly how jellyfin-roku's MovieDetails screen filters its action-button MarkupList) saw the
+ * PREVIOUS item's visuals rendered at a position until the user navigated focus onto it.
+ *
+ * Root cause: itemComps[]/rowItemComps[][] are position-keyed caches of item components, reused
+ * across frames. Whether a cached item gets its itemContent re-pushed was gated solely on the
+ * content child's OWN `.changed` flag — but removeChild/insertChild/appendChild-as-move only dirty
+ * the CONTAINER ContentNode, never the child being relocated. So after a reorder, the object now
+ * sitting at a given index/cell is different from the one the cached item component was last told
+ * about, yet its own `.changed` is false, and the itemContent push was silently skipped.
+ */
+describe("ArrayGrid/RowList item component reuse invalidates on content reorder, not just content.changed", () => {
+    beforeAll(() => {
+        // List/grid nodes have font-typed defaults; mount the common: volume once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    test("MarkupList: an item removed in front of a cached slot is replaced, not left stale", () => {
+        const list = SGNodeFactory.createNode("MarkupList");
+        const root = buildFlatContent(["A", "B", "C"]);
+        list.setValue("content", root);
+
+        const itemRect = { x: 0, y: 0, width: 100, height: 40 };
+        const fakeInterpreter = {};
+
+        // Populate itemComps[0..2] bound to A, B, C.
+        list.renderItemComponent(fakeInterpreter, 0, itemRect, 0, 1);
+        list.renderItemComponent(fakeInterpreter, 1, itemRect, 0, 1);
+        const item0 = list.itemComps[0];
+        expect(item0.getValue("itemContent").getValueJS("title")).toBe("A");
+
+        // The app removes the first button in place (mirrors MovieDetails.bs's
+        // updatePlayButtons/removeTelevisionGoToButtons pattern), shifting B/C up by one index. This
+        // dirties the container (root), not the moved B/C nodes themselves.
+        root.removeChildrenAtIndex(0, 1);
+        list.refreshContent();
+
+        list.renderItemComponent(fakeInterpreter, 0, itemRect, 0, 1);
+
+        // Same cached component (position-keyed reuse)...
+        expect(list.itemComps[0]).toBe(item0);
+        // ...but now showing what actually occupies index 0 (B), not the stale A.
+        expect(item0.getValue("itemContent").getValueJS("title")).toBe("B");
+    });
+
+    test("RowList: a column removed in front of a cached slot is replaced, not left stale", () => {
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("itemSize", new RoArray([new Float(100), new Float(40)]));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Float(100), new Float(40)])]));
+        const root = buildRowContent([["A", "B", "C"]]);
+        list.setValue("content", root);
+
+        // First render creates rowItemComps[0][0..2] bound to A, B, C.
+        list.renderNode({}, [0, 0], 0, 1);
+        const item0 = list.rowItemComps[0][0];
+        expect(item0.getValue("itemContent").getValueJS("title")).toBe("A");
+
+        // Remove the first item within row 0, shifting B/C left by one column. This dirties the row
+        // container, not the moved B/C nodes.
+        const row0 = root.getNodeChildren()[0];
+        row0.removeChildrenAtIndex(0, 1);
+
+        // A plain re-render picks up the container-level dirty mark and re-parses via refreshContent.
+        list.renderNode({}, [0, 0], 0, 1);
+
+        // Same cached component (position-keyed reuse)...
+        expect(list.rowItemComps[0][0]).toBe(item0);
+        // ...but now showing what actually occupies column 0 (B), not the stale A.
+        expect(item0.getValue("itemContent").getValueJS("title")).toBe("B");
+    });
+});


### PR DESCRIPTION
## Summary
- `ArrayGrid.itemComps[]` / `RowList.rowItemComps[][]` are position-keyed caches of item components, reused across frames. Whether a cached item got its `itemContent` re-pushed was gated solely on the content child's own `.changed` flag.
- `removeChild`/`insertChild`/`appendChild`-as-move only dirty the **container** `ContentNode`, never the moved child, so after a reorder a cache slot could keep rendering the item that used to occupy that position instead of the one now there — until an unrelated focus move happened to paper over it.
- Fix: also compare the cached item component's live `itemContent` against the content object now assigned to that slot, and push whenever they differ, not only on `content.changed`. Applies to `ArrayGrid` (covers `MarkupList`, `MarkupGrid`) and `RowList` (covers `ZoomRowList`).

## Test plan
- [x] New regression test `test/extensions/scenegraph/ArrayGridItemReorder.test.js` (MarkupList + RowList cases); verified both fail on pre-fix code and pass with the fix.
- [x] Full scenegraph extension suite (79 files / 806 tests) passes.
- [x] Full repo test suite (205 files / 2561 tests) passes.
- [x] `npm run lint` and `npm run prettier:write` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)