### PR TITLE
fix(api): preserve rendezvous tracking state across resets in shared array

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -674,13 +674,17 @@ function resetWorker() {
  * Resets the shared array buffer to initial state (-1 values).
  */
 function resetArray() {
+    // Previous rendezvous tracking state is preserved across resets
+    const rendezvousTracking = Atomics.load(sharedArray, DataType.RDT);
+    // Reset all values to -1, which is the "no data" sentinel for the shared array.
     sharedArray.some((_, index: number) => {
         Atomics.store(sharedArray, index, -1);
         return index === DataBufferIndex - 1;
     });
-    // Rendezvous tracing is a host setting, not app state: restore it from the device info so it
-    // survives the worker reset that starts each app, rather than silently turning itself off.
+    // Rendezvous tracing is a host setting, not app state: it survives the worker
+    // reset that starts each app, rather than silently turning itself off.
     Atomics.store(sharedArray, DataType.RDZ, deviceData.logRendezvous ? 1 : 0);
+    Atomics.store(sharedArray, DataType.RDT, rendezvousTracking);
 }
 
 /**

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -744,12 +744,12 @@ export enum DataType {
     MUHS, // Memory Used Heap Size
     MHSL, // Memory Heap Size Limit
     MBWD, // Measured Bandwidth
-    RDZ, // Rendezvous Logging (0/1)
     CEC, // Consumer Electronics Control
     HDMI, // HDMI Status
     RHB, // Render Thread Heartbeat (statement counter, render thread writes only)
     RDN, // Rendezvous sequence Number (monotonic id shared by all threads for logRendezvous tracing)
     RDT, // Rendezvous Data Tracking (0/1), ECP `sgrendezvous` track/untrack state
+    RDZ, // Rendezvous Logging (0/1), enable/disable logRendezvous console trace
     // Key Buffer starts here: KeyBufferSize * KeyArraySpots
     RID, // Remote Id
     KEY, // Key Code


### PR DESCRIPTION
The rendezvous tracking was being silently disabled on every app switch. As this is a device state, we should preserve its state across app starts.