### PR TITLE
fix(scenegraph): currFocusRow/currFocusColumn update before itemFocused fires

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -993,6 +993,32 @@ Regression: `test/extensions/scenegraph/ArrayGridFields.test.js` (asserts on a m
 values *and* order are pinned — including three no-pulse cases) and the channel-info/time-pan test in
 `test/extensions/scenegraph/TimeGrid.test.js`.
 
+### `currFocusRow`/`currFocusColumn` must be current BEFORE `itemFocused` fires
+
+Both fields are documented on the base `ArrayGrid` (`arraygrid.md`), not just `RowList`. Apps commonly read
+`currFocusRow`/`currFocusColumn` **synchronously from inside an `itemFocused` observer** — e.g. a header
+that collapses once the focused row leaves index 0 (found via a real app, Jellyfin-Roku's
+`VisualLibraryScene`). Since an engine-initiated, non-reentrant emission dispatches its observer
+synchronously (see the deferred-dispatch section above), whichever field is `super.setValue`'d *first* in
+source order is the one an observer on a *later* field sees as already-settled — and vice versa. Two bugs
+from getting this backwards, both fixed together:
+
+1. `ArrayGrid.setFocusedItem` never wrote `currFocusRow`/`currFocusColumn` at all for grid types
+   (MarkupGrid/PosterGrid) — they stayed pinned at the `0.0` default forever, since the base class never
+   derives row/column from `focusIndex`/`numColumns`.
+2. `RowList.setFocusedItem` emitted `itemFocused` before calling `setRowItemFocused` (which sets
+   `currFocusRow`/`currFocusColumn`), so a synchronous read inside an `itemFocused` observer got the row
+   from *before* this navigation — the app's collapse logic ran one navigation late, or never, depending on
+   how many rows existed.
+
+Fix: both `ArrayGrid.setFocusedItem` and `RowList.setFocusedItem` now `super.setValue` `currFocusRow`/
+`currFocusColumn` immediately before `itemFocused`, inside the same `enterInternalUpdate`/`exitInternalUpdate`
+bracket. `RowList.setRowItemFocused` still re-applies the same values afterward (a harmless same-value
+no-op) before settling `rowItemFocused` last — that ordering is unchanged.
+
+Regression: `test/extensions/scenegraph/ArrayGridFields.test.js`, describe block
+`"ArrayGrid currFocusRow/currFocusColumn reflect the new focus before itemFocused fires"`.
+
 ## Focus chain consistency (`focusedChild` ↔ live focus)
 
 `focusedChild` is a stored, observable field: `Node.setNodeFocus` walks the parent chain (`createPath`) at

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -330,6 +330,12 @@ export class ArrayGrid extends Group {
             this.updateItemFocus(this.focusIndex, true, nodeFocus);
             if (inFocusChain) {
                 super.setValue("itemUnfocused", new Int32(focusedIndex));
+                // currFocusRow/currFocusColumn must already reflect the new position before
+                // itemFocused fires: apps commonly read them synchronously from an itemFocused
+                // observer (see RowList.setFocusedItem for the same ordering requirement).
+                const numCols = Math.max(1, this.numCols || 1);
+                super.setValue("currFocusRow", new Float(Math.floor(newFocus / numCols)));
+                super.setValue("currFocusColumn", new Float(newFocus % numCols));
                 super.setValue("itemFocused", new Int32(index));
             } else {
                 // Unfocused: remember the target without notifying observers. setNodeFocus emits it on

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -250,6 +250,13 @@ export class RowList extends ArrayGrid {
             // Engine-initiated emission: reentrant observers defer (see Field.enterInternalUpdate).
             Field.enterInternalUpdate();
             try {
+                // currFocusRow/currFocusColumn must already reflect the new position before
+                // itemFocused fires: apps commonly read them synchronously from an itemFocused
+                // observer (e.g. collapsing a header when the focused row leaves index 0). The
+                // values are re-applied (as a same-value no-op) by setRowItemFocused below, which
+                // still settles rowItemFocused last — see its own ordering comment.
+                super.setValue("currFocusRow", new Float(rowIndex));
+                super.setValue("currFocusColumn", new Float(colIndex));
                 super.setValue("itemFocused", new Int32(rowIndex));
             } finally {
                 Field.exitInternalUpdate();

--- a/test/extensions/scenegraph/ArrayGridFields.test.js
+++ b/test/extensions/scenegraph/ArrayGridFields.test.js
@@ -232,6 +232,69 @@ describe("ArrayGrid scrollingStatus pulses on key navigation", () => {
     });
 });
 
+/**
+ * `currFocusRow`/`currFocusColumn` (documented on the base `ArrayGrid`, arraygrid.md) must already
+ * reflect the newly focused position by the time `itemFocused` fires. Apps commonly read them
+ * synchronously from inside an `itemFocused` observer — e.g. a header that collapses once the
+ * focused row leaves index 0 — and a stale (pre-navigation) value there makes the app react one
+ * navigation late, or never, depending on how many rows exist. Regression for two bugs found via a
+ * real app (Jellyfin-Roku's VisualLibraryScene): RowList emitted itemFocused BEFORE updating
+ * currFocusRow, and grid types (MarkupGrid/PosterGrid, via the base ArrayGrid.setFocusedItem) never
+ * updated currFocusRow/currFocusColumn at all.
+ */
+describe("ArrayGrid currFocusRow/currFocusColumn reflect the new focus before itemFocused fires", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+    test("RowList: an itemFocused observer reading currFocusRow synchronously sees the NEW row", () => {
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A", "B"], ["C", "D"], ["E"]]));
+        list.setNodeFocus(true);
+
+        const seenDuringItemFocused = [];
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            const name = event.fieldName ? event.fieldName.getValue() : "";
+            if (name === "itemFocused") {
+                seenDuringItemFocused.push(list.getValueJS("currFocusRow"));
+            }
+            originalPush(event);
+        };
+        list.addObserver(fakeInterpreter, "unscoped", new BrsString("itemFocused"), port);
+
+        expect(list.handleKey("down", true)).toBe(true);
+
+        expect(seenDuringItemFocused).toEqual([1]);
+    });
+
+    test("MarkupGrid: currFocusRow/currFocusColumn track focus as the grid navigates", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("numColumns", new Int32(2));
+        grid.setValue("content", buildContent([["A", "B", "C", "D"]]).getNodeChildren()[0]);
+        grid.setNodeFocus(true);
+
+        expect(grid.getValueJS("currFocusRow")).toBe(0);
+        expect(grid.getValueJS("currFocusColumn")).toBe(0);
+
+        expect(grid.handleKey("right", true)).toBe(true);
+        expect(grid.getValueJS("currFocusRow")).toBe(0);
+        expect(grid.getValueJS("currFocusColumn")).toBe(1);
+
+        expect(grid.handleKey("down", true)).toBe(true);
+        expect(grid.getValueJS("currFocusRow")).toBe(1);
+        expect(grid.getValueJS("currFocusColumn")).toBe(1);
+    });
+});
+
 describe("ArrayGrid numColumns/numRows string coercion", () => {
     beforeAll(() => {
         const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));


### PR DESCRIPTION
## Summary
- `RowList.setFocusedItem` emitted `itemFocused` before updating `currFocusRow`/`currFocusColumn`, so an app reading those fields synchronously inside its `itemFocused` observer got the row/column from before the current navigation (one step stale).
- The base `ArrayGrid.setFocusedItem` (used by `MarkupGrid`/`PosterGrid`) never wrote `currFocusRow`/`currFocusColumn` at all, leaving them pinned at their `0.0` default regardless of focus.
- Both fields are documented on the base `ArrayGrid` (`arraygrid.md`), and reading them from an `itemFocused` observer is a common app pattern (e.g. collapsing a header once focus leaves the first row) — engine-initiated field notifications dispatch synchronously, so field write order within a single focus move directly determines what an observer sees.
- Fix: both `setFocusedItem` implementations now update `currFocusRow`/`currFocusColumn` immediately before emitting `itemFocused`, inside the same `enterInternalUpdate`/`exitInternalUpdate` bracket.

## Test plan
- [x] Added regression tests in `test/extensions/scenegraph/ArrayGridFields.test.js` covering both the RowList ordering fix and the ArrayGrid/MarkupGrid tracking fix.
- [x] `npm run lint` and `npm run prettier:write` pass.
- [x] Full suite: `npm test` — 207 files / 2601 tests passing.
- [x] Documented the invariant in `.claude/docs/scenegraph-invariants.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)