### PR TITLE
fix(scenegraph): normalize key actions/icons and add keySelected() handler for Dynamic Keyboards

### DIFF
--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -577,7 +577,7 @@ export class DynamicKeyGrid extends Group {
         const mode = this.mode;
         const upper = mode.endsWith("Upper") || mode.endsWith("Shift");
         const base = mode.startsWith("Symbols") ? "Symbols" : mode.startsWith("Accents") ? "Accents" : "ABC123";
-        switch (strOut) {
+        switch (strOut.toLowerCase()) {
             case "shift":
                 return "shift";
             case "space":

--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -113,7 +113,7 @@ export class DynamicKeyboardBase extends Group {
 
     /** Applies a selected key (its strOut or label) to the text and keyboard mode. */
     protected applyKey(out: string) {
-        switch (out) {
+        switch (out.toLowerCase()) {
             case "clear":
                 this.textEditBox.setValue("text", new BrsString(""));
                 this.textEditBox.moveCursor(0);
@@ -132,7 +132,7 @@ export class DynamicKeyboardBase extends Group {
                 return;
             case "shift":
             case "capslock":
-            case "UpperLower":
+            case "upperlower":
                 this.toggleCase();
                 return;
             case "abc123":

--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -132,7 +132,6 @@ export class DynamicKeyboardBase extends Group {
                 return;
             case "shift":
             case "capslock":
-            case "upperlower":
                 this.toggleCase();
                 return;
             case "abc123":

--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -40,7 +40,7 @@ export class DynamicKeyboardBase extends Group {
 
         this.textEditBox = new VoiceTextEditBox();
         this.keyGrid = new DynamicKeyGrid();
-        this.keyGrid.onKeySelected = (out) => this.applyKey(out);
+        this.keyGrid.onKeySelected = (out) => this.dispatchKeySelected(out);
 
         this.setValueSilent("textEditBox", this.textEditBox);
         this.setValueSilent("keyGrid", this.keyGrid);
@@ -110,6 +110,22 @@ export class DynamicKeyboardBase extends Group {
     // -------------------------------------------------------------------------
     // Key selection → text editing / mode switching
     // -------------------------------------------------------------------------
+
+    /**
+     * Gives an extending component's `keySelected(key as string) as boolean` interface function
+     * (per the DynamicCustomKeyboard spec) first chance to handle a key selection. Returning true
+     * means "handled" and skips the default handler; false, or the function not being declared,
+     * falls through to applyKey.
+     */
+    private dispatchKeySelected(out: string) {
+        if (this.funcNames.has("keyselected") && sgRoot.interpreter) {
+            const handled = this.callFunction(sgRoot.interpreter, new BrsString("keySelected"), new BrsString(out));
+            if (handled instanceof BrsBoolean && handled.toBoolean()) {
+                return;
+            }
+        }
+        this.applyKey(out);
+    }
 
     /** Applies a selected key (its strOut or label) to the text and keyboard mode. */
     protected applyKey(out: string) {

--- a/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
+++ b/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
@@ -246,7 +246,7 @@ export interface SpecialKeyIcon {
  * clear/space/delete icons ship in `common.zip`; everything else is a glyph.
  */
 export function resolveKeyIcon(strOut: string): SpecialKeyIcon | undefined {
-    switch (strOut) {
+    switch (strOut.toLowerCase()) {
         case "clear":
             return { iconName: "clear", glyph: "clear" };
         case "backspace":

--- a/test/extensions/scenegraph/DynamicKeyboard.test.js
+++ b/test/extensions/scenegraph/DynamicKeyboard.test.js
@@ -197,6 +197,65 @@ describe("Dynamic voice keyboards", () => {
         });
     });
 
+    describe("keySelected custom handler", () => {
+        afterEach(() => {
+            sgRoot._interpreter = undefined;
+        });
+
+        test("a declared keySelected() returning true skips the default handler", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.funcNames.add("keyselected");
+            sgRoot._interpreter = fakeInterpreter;
+            const calls = [];
+            kbd.callFunction = (interpreter, name, key) => {
+                calls.push([interpreter, name.getValue(), key.getValue()]);
+                return core.BrsBoolean.True;
+            };
+            kbd.keyGrid.setValue("jumpToKey", coords(1, 0, 0)); // "a"
+            kbd.handleKey("OK", true);
+            expect(calls).toEqual([[fakeInterpreter, "keySelected", "a"]]);
+            expect(textOf(kbd)).toBe(""); // default insert was skipped
+        });
+
+        test("a declared keySelected() returning false falls through to the default handler", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.funcNames.add("keyselected");
+            sgRoot._interpreter = fakeInterpreter;
+            kbd.callFunction = () => core.BrsBoolean.False;
+            kbd.keyGrid.setValue("jumpToKey", coords(1, 0, 0)); // "a"
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe("a");
+        });
+
+        test("no keySelected() declared never calls callFunction and applies the default handler", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot._interpreter = fakeInterpreter;
+            let called = false;
+            kbd.callFunction = () => {
+                called = true;
+                return core.BrsBoolean.True;
+            };
+            kbd.keyGrid.setValue("jumpToKey", coords(1, 0, 0)); // "a"
+            kbd.handleKey("OK", true);
+            expect(called).toBe(false);
+            expect(textOf(kbd)).toBe("a");
+        });
+
+        test("keySelected() declared but no interpreter set falls back to the default handler", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.funcNames.add("keyselected");
+            let called = false;
+            kbd.callFunction = () => {
+                called = true;
+                return core.BrsBoolean.True;
+            };
+            kbd.keyGrid.setValue("jumpToKey", coords(1, 0, 0)); // "a"
+            kbd.handleKey("OK", true);
+            expect(called).toBe(false);
+            expect(textOf(kbd)).toBe("a");
+        });
+    });
+
     describe("DynamicPinPad", () => {
         test("key grid matches the legacy keyboard_pinpad size (HD)", () => {
             const pad = SGNodeFactory.createNode("DynamicPinPad");


### PR DESCRIPTION
In Roku, the Dynamic Keyboard key definition attribute `strOut` is case insensitive to show icon and perform actions.

Also implements the `keySelected()` custom key-selection handler documented in the Dynamic Keyboard spec: a component extending a Dynamic keyboard node can declare `function keySelected(key as string) as boolean` in its `<interface>` to intercept a key selection before the built-in default handler runs. Returning `true` skips the default handler; returning `false`, or not declaring the function, falls through to the existing default behavior unchanged.