### PR TITLE
fix(docs): update limitations for Roku SceneGraph and network components

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -4,17 +4,14 @@ The **BrightScript Engine** implements the BrightScript language specification u
 
 ## In Scope (to be developed/fixed in future releases)
 
-* **Roku SceneGraph** SDK support is currently being implemented as an [extension](./extensions.md) published separately as the [brs-scenegraph](https://www.npmjs.com/package/brs-scenegraph) NPM package, with the following features implemented with some limitations:
-  * Load XML component files and create SceneGraph nodes tree.
-  * Basic support for `roSGNode` and `roSGScreen` components and rendering.
+* **Roku SceneGraph** framework support is implemented as an [extension](./extensions.md) published separately as the [brs-scenegraph](https://www.npmjs.com/package/brs-scenegraph) NPM package. All SceneGraph nodes documented by Roku are available, however because the engine is a simulator and not a hardware emulator, expect **rendering differences** from a real Roku device, please open a [GitHub issue](https://github.com/lvcabral/brs-engine/issues) if you find any problem or missing feature.  These are the current known limitations:
   * The `Task` node is implemented but its behavior is limited:
-    * For now only 10 concurrent task threads are supported per application, both in the browser and under Node.js/CLI
+    * For now only 30 concurrent task threads are supported per application
     * Only one `port` instance can be used on Task `init()` to observe fields
-    * Rendezvous is supported, but still not working properly for all edge cases.
+    * Rendezvous is implemented, but may not work properly for all edge cases.
     * `Task` nodes never spawn under the synchronous `executeFile()` execution model of the Node.js library — use `executeApp()` for Task support, see the [Node.js library guide](./using-node-library.md#running-apps-on-worker-threads-with-scenegraph-task-support).
-  * All **concrete** SceneGraph nodes documented by Roku are implemented. Because the engine is a simulator and not a hardware emulator, expect **rendering differences** from a real Roku device, and some nodes may not have full functionality yet — please open a [GitHub issue](https://github.com/lvcabral/brs-engine/issues) if you find any problem or missing feature.
-  * The support for focus change animation on grids, lists and panel nodes is not implemented yet.
-  * The remaining **abstract** base nodes are not implemented on their own and fall back to a plain `Group` (the Standard Dialog framework's `StdDlgAreaBase`, `StdDlgItemGroup` and `StdDlgGraphicItem`).
+  * The focus change native animation on grids, lists and panel nodes is not implemented yet.
+  * Some **abstract** base nodes are not implemented on their own and fall back to a plain `Group` (like the Standard Dialog framework's `StdDlgAreaBase`, `StdDlgItemGroup` and `StdDlgGraphicItem`).
   * **Component Libraries** are supported, both declared in XML (`<ComponentLibrary id="..." uri="..."/>`) and created at runtime via `CreateObject("roSGNode", "ComponentLibrary")` with the `uri` assigned in code. The component namespace is the library manifest's `sg_component_libs_provided` value (falling back to the node `id` when not declared), so its components are referenced as `LibraryName:ComponentName`. The `uri` may point to a local volume (`pkg:/`, `tmp:/`, `ext1:/`) or a remote `http(s)://` package (the configured CORS proxy is honored). Current limitations:
     * Libraries are fetched and compiled **synchronously** (the BrightScript event loop never yields, so an asynchronous load could not complete mid-execution). The node reports `loadStatus = "loading"` immediately and the `"ready"`/`"failed"` transition is emitted on the next render frame, so `observeField("loadStatus", ...)` callbacks are notified as on a real device — provided the app is pumping its screen message loop (`wait(...)`).
     * Inside a library, `pkg:/` still resolves to the host app's package (not the library's own); reference a library's bundled scripts with relative `uri` paths in its component XML.
@@ -43,15 +40,26 @@ The **BrightScript Engine** implements the BrightScript language specification u
   * Cookies are only partially supported, if `EnableCookies` is called and `EnableFreshConnection` is set to `false`, then Cookies from previous calls will be preserved.
   * The other Cookies related methods are just mocked and do nothing: `GetCookies`, `AddCookies`, `ClearCookies`.
   * The following methods are also only mocked but do nothing: `EnableResume`, `SetHttpVersion` and `SetMinimumTransferRate`.
-* The complete **Roku OS** file system is available and shared among threads (main, render and tasks), with all volumes: `pkg:`, `common:`, `tmp:`, `cachefs:` and `ext1:`. By default, the external volume (`ext1:`) and the writeable volumes (`tmp:` `cachefs:`) are limited to 32 MB each. The writable volumes `tmp:` and `cachefs:` are configurable, see [customization documentation](./customization.md); the `ext1:` limit is fixed.
+* The `roStreamSocket` (TCP) component performs real network I/O, on the Node.js/CLI package only.
+  * Supports listening, connecting, accepting connections, and sending/receiving stream data, including `roSocketEvent` delivery via `NotifyReadable()`/`Wait()`, backed by a small helper process per listener/connection.
+  * `Connect()` uses a blocking request with an 8-second timeout rather than modeling Roku's async-per-message-port connect semantics.
+  * `SetLinger`/`SetMaxSeg` (`ifSocketConnectionOption`) are accepted and stored but not enforced — Node's `net` module exposes no public `SO_LINGER`/`TCP_MAXSEG` hook.
+  * On the browser package `roStreamSocket` remains mocked, as browsers cannot open raw sockets.
+* The `roDataGramSocket` (UDP) component performs real network I/O, on the Node.js/CLI package only.
+  * Supports binding, broadcast, send and receive, including `roSocketEvent` delivery via `NotifyReadable()`/`Wait()`, backed by a small per-socket helper process.
+  * Real multicast group membership (`JoinGroup`/`DropGroup`) is not implemented on either platform.
+  * On the browser package `roDataGramSocket` remains mocked, as browsers cannot open raw sockets.
+* The complete **Roku OS** file system is available and shared among threads.
+  * Supports all volumes: `pkg:`, `common:`, `tmp:`, `cachefs:` and `ext1:`. 
+  * By default, the external volume (`ext1:`) and the writeable volumes (`tmp:` `cachefs:`) are limited to 32 MB each.
+  * The writable volumes `tmp:` and `cachefs:` limits are configurable, see [customization documentation](./customization.md); 
+  * The `ext1:` limit is fixed.
 * The `roInput` deep link events are supported, but the events related to Voice Commands are not available yet.
-* The `roStreamSocket` (TCP) component performs real network I/O — listening, connecting, accepting connections, and sending/receiving stream data, including `roSocketEvent` delivery via `NotifyReadable()`/`Wait()` — on the Node.js/CLI package only, backed by a small helper process per listener/connection (browsers cannot open raw sockets). `Connect()` uses a blocking request with an 8-second timeout rather than modeling Roku's async-per-message-port connect semantics. `SetLinger`/`SetMaxSeg` (`ifSocketConnectionOption`) are accepted and stored but not enforced — Node's `net` module exposes no public `SO_LINGER`/`TCP_MAXSEG` hook. On the browser package it remains mocked.
-* The `roDataGramSocket` (UDP) component performs real network I/O — binding, broadcast, send and receive, including `roSocketEvent` delivery via `NotifyReadable()`/`Wait()` — on the Node.js/CLI package only, backed by a small per-socket helper process (browsers cannot open raw sockets). On the browser package it remains mocked. Real multicast group membership (`JoinGroup`/`DropGroup`) is not implemented on either platform.
 * The component `roAppMemoryMonitor` will only return measured data in Node.JS and Chromium browsers. For browsers the memory heap info only accounts for the main thread, as WebWorkers do not have support for `performance.memory` API. The `roAppMemoryMonitorEvent` is not yet implemented.
 * The global functions `Eval()`, `GetLastRunCompileError()` and `GetLastRunRuntimeError()` are not available.
 * The string `mod` cannot be used as variable or function parameter name, because it conflicts with remainder operator `Mod` (Roku devices allows that).
 * Screensaver functionality is not yet implemented.
-* SDK 1.0 deprecated components are not supported, but will be implemented in the future as a legacy apps preservation initiative.
+* SDK 1.0 deprecated components are not supported, but may be implemented in the future as a new extension, allowing legacy apps to be executed.
 
 ## Mocked Components and Libraries
 


### PR DESCRIPTION
Updated the limitations documentation to reflect the current state properly