### PR TITLE
refactor(scenegraph): give ArrayGrid a focusRect hook so subclasses specialize geometry only

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -970,8 +970,29 @@ Three outsets meet on `subBoundingRect("item<r>_<c>")` and only two of them exis
 | outset | applied by | shows up in |
 | --- | --- | --- |
 | `rectMargins()` → `marginX`/`marginY` | `ArrayGrid.updateRect` | the **grid's own** reported rect (device-measured) |
-| `focusMargins(bmp)` → the 9-patch's declared content margins | `ArrayGrid.renderFocus` | the **drawn** focus frame — paint only, nothing reports it |
+| `focusMargins(bmp)` → the 9-patch's declared content margins | `ArrayGrid.focusFrameRect` | the **drawn** focus frame — paint only, nothing reports it |
 | *(none)* | — | an **item sub-rect** |
+
+**Override `focusFrameRect`, never `renderFocus`.** `renderFocus` is a template like
+`renderNode`/`renderNodeContent`: it owns which uri and blend field the focus state selects, the validity
+guard, the `hasNinePatch` write that `rectMargins()` reads, and the `drawImage` call —
+`focusFrameRect(itemRect, bmp, index)` owns only the geometry. `PosterGrid` used to override the whole
+method to specialize its rect math and silently dropped both the blend color (making
+`focusBitmapBlendColor` *and* `focusFootprintBlendColor` no-ops on that type) and the `hasNinePatch`
+write; a geometry-only hook makes that class of omission impossible. Two deliberate asymmetries in
+`PosterGrid`'s override, both pinned by `GridFocusFeedback.test.js`: its outset is device-measured
+constants (`marginY + focusPadding*`) so it is **not** gated on `bmp.ninePatch` the way the base is —
+there are no markers to read — and it takes only `posterRect`'s x/width, so the frame's height still spans
+the caption band. The `index` parameter is what lets it find that cell's laid-out poster; it replaced a
+`focusLayoutOverride` field that the call sites set and cleared around `renderFocus` to smuggle the layout
+in. `-1` means "the caller has no index" (`TimeGrid`, and the row-based grids, whose position is
+(row, col) rather than a flat content index).
+
+The base's non-9-patch branch returns `itemRect` **itself, not a copy**: `Group.drawImage` writes
+`rect.width`/`rect.height` for a plain bitmap and `renderItemComponent` then positions and clips the item
+against the same object, so the scaled size the draw computes is what the item is laid out against. An
+override returning a fresh object severs that link — which is what every override wants, but do it
+knowingly.
 
 The calibrated invariant is **`subBoundingRect("item<r>_<c>")` == the item component's own rect** — the
 bare poster, in all three coordinate spaces, focused cell included. `PosterGridItem` corroborates it

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -18,6 +18,7 @@ import { Group } from "./Group";
 import { Node } from "./Node";
 import { Field } from "./Field";
 import { createNode } from "../factory/NodeFactory";
+import { normalizeBlendColor } from "../SGUtil";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
 import { ContentNode } from "./ContentNode";
@@ -654,12 +655,12 @@ export class ArrayGrid extends Group {
         const drawFocus = this.getValueJS("drawFocusFeedback");
         const drawFocusOnTop = this.getValueJS("drawFocusFeedbackOnTop");
         if (focused && drawFocus && !drawFocusOnTop) {
-            this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
+            this.renderFocus(itemRect, opacity, nodeFocus, draw2D, index);
         }
         const itemOrigin = [itemRect.x, itemRect.y];
         this.renderItemClipped(interpreter, this.itemComps[index], itemOrigin, itemRect, rotation, opacity, draw2D);
         if (focused && drawFocus && drawFocusOnTop) {
-            this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
+            this.renderFocus(itemRect, opacity, nodeFocus, draw2D, index);
         }
     }
 
@@ -695,7 +696,17 @@ export class ArrayGrid extends Group {
         }
     }
 
-    protected renderFocus(itemRect: Rect, opacity: number, nodeFocus: boolean, draw2D?: IfDraw2D) {
+    /**
+     * Draws the focus frame (or, when the grid itself is unfocused, the footprint) around an item.
+     *
+     * TEMPLATE METHOD — override `focusFrameRect`, never this. Everything here is shared contract: which
+     * uri and blend field the focus state selects, the validity guard, the `hasNinePatch` write that
+     * `rectMargins()` reads, and the `drawImage` call. `PosterGrid` used to override this whole method to
+     * specialize only its geometry, and in doing so silently dropped the blend color (both fields became
+     * no-ops on that type) and the `hasNinePatch` write. A geometry-only hook makes that class of
+     * omission impossible.
+     */
+    protected renderFocus(itemRect: Rect, opacity: number, nodeFocus: boolean, draw2D?: IfDraw2D, index = -1) {
         const bmpUri = nodeFocus ? "focusBitmapUri" : "focusFootprintBitmapUri";
         const blendField = nodeFocus ? "focusBitmapBlendColor" : "focusFootprintBlendColor";
         const bmp = this.getBitmap(bmpUri);
@@ -703,17 +714,35 @@ export class ArrayGrid extends Group {
             return;
         }
         this.hasNinePatch = bmp.ninePatch;
+        const blendColor = normalizeBlendColor(this.getValueJS(blendField));
+        this.drawImage(bmp, this.focusFrameRect(itemRect, bmp, index), 0, opacity, draw2D, blendColor);
+    }
+
+    /**
+     * The rect the focus frame is DRAWN in, given the item's cell rect and the resolved frame bitmap.
+     * Override this to specialize a grid's focus geometry.
+     *
+     * `index` is the content index of the focused item, or -1 when the caller has none: the
+     * `renderItemComponent` call sites know it, `LabelList.renderFocused` and `TimeGrid` do not.
+     * `PosterGrid` needs it to find that cell's laid-out poster rect.
+     *
+     * ALIASING: the non-9-patch branch returns `itemRect` ITSELF, not a copy. `Group.drawImage` writes
+     * `rect.width`/`rect.height` for a plain bitmap, and `renderItemComponent` then positions and clips
+     * the item against the same object — so the scaled size the draw computes is what the item is laid
+     * out against. Pre-existing and load-bearing; an override returning a fresh object severs that link,
+     * which is what every override wants, but do it deliberately.
+     */
+    protected focusFrameRect(itemRect: Rect, bmp: RoBitmap, index: number): Rect {
+        if (!bmp.ninePatch) {
+            return itemRect;
+        }
         const { left, right, top, bottom } = this.focusMargins(bmp);
-        let focusRect = bmp.ninePatch
-            ? {
-                  x: itemRect.x - left,
-                  y: itemRect.y - top,
-                  width: itemRect.width + left + right,
-                  height: itemRect.height + top + bottom,
-              }
-            : itemRect;
-        const blendColor = this.getValueJS(blendField) as number;
-        this.drawImage(bmp, focusRect, 0, opacity, draw2D, blendColor);
+        return {
+            x: itemRect.x - left,
+            y: itemRect.y - top,
+            width: itemRect.width + left + right,
+            height: itemRect.height + top + bottom,
+        };
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/LabelList.ts
+++ b/src/extensions/scenegraph/nodes/LabelList.ts
@@ -208,14 +208,14 @@ export class LabelList extends ArrayGrid {
         const drawFocus = this.getValueJS("drawFocusFeedback") as boolean;
         const drawFocusOnTop = this.getValueJS("drawFocusFeedbackOnTop") as boolean;
         if (drawFocus && !drawFocusOnTop) {
-            this.renderFocus(rect, opacity, nodeFocus, draw2D);
+            this.renderFocus(rect, opacity, nodeFocus, draw2D, index);
         }
         if (iconBmp) {
             this.renderIcon(iconBmp, rect, opacity, draw2D, iconColor ? color : undefined);
         }
         this.drawText(text, font, color, opacity, textRect, align, "center", 0, draw2D, "...", index);
         if (drawFocus && drawFocusOnTop) {
-            this.renderFocus(rect, opacity, nodeFocus, draw2D);
+            this.renderFocus(rect, opacity, nodeFocus, draw2D, index);
         }
         this.hasNinePatch &&= drawFocus;
     }

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -8,6 +8,7 @@ import {
     Int32,
     IfDraw2D,
     Rect,
+    RoBitmap,
     RoFont,
     isBrsString,
 } from "brs-engine";
@@ -111,7 +112,6 @@ export class PosterGrid extends ArrayGrid {
     private readonly focusPaddingTop: number;
     private readonly focusPaddingBottom: number;
     private readonly defaultCaptionBackgroundUri: string;
-    private focusLayoutOverride?: PosterItemLayout;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.PosterGrid) {
         super([], name);
@@ -600,45 +600,38 @@ export class PosterGrid extends ArrayGrid {
         const drawFocus = this.getValueJS("drawFocusFeedback");
         const drawFocusOnTop = this.getValueJS("drawFocusFeedbackOnTop");
         if (focused && drawFocus && !drawFocusOnTop) {
-            this.focusLayoutOverride = layout;
-            this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
-            this.focusLayoutOverride = undefined;
+            this.renderFocus(itemRect, opacity, nodeFocus, draw2D, index);
         }
         const itemOrigin = [itemRect.x, itemRect.y];
         this.renderItemClipped(interpreter, itemComp, itemOrigin, itemRect, rotation, opacity, draw2D);
         if (focused && drawFocus && drawFocusOnTop) {
-            this.focusLayoutOverride = layout;
-            this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
-            this.focusLayoutOverride = undefined;
+            this.renderFocus(itemRect, opacity, nodeFocus, draw2D, index);
         }
     }
 
-    protected renderFocus(itemRect: Rect, opacity: number, nodeFocus: boolean, draw2D?: IfDraw2D) {
-        const bmpUri = nodeFocus ? "focusBitmapUri" : "focusFootprintBitmapUri";
-        const blendField = nodeFocus ? "focusBitmapBlendColor" : "focusFootprintBlendColor";
-        const bmp = this.getBitmap(bmpUri);
-        if (!bmp?.isValid()) {
-            return;
-        }
-        const layout = this.focusLayoutOverride;
-        const posterRect = layout?.posterRect;
-        const baseX = posterRect ? itemRect.x + posterRect.x : itemRect.x;
-        const baseWidth = posterRect?.width ?? itemRect.width;
-        const baseY = itemRect.y;
-        const baseHeight = itemRect.height;
+    /**
+     * A PosterGrid's focus frame tracks the POSTER, not the whole cell: a cell reserves a caption zone
+     * below (or above) the poster, and a frame around the whole cell would enclose the captions too.
+     * `layoutByIndex` holds that per-cell geometry keyed by content index, which is why the hook needs
+     * the index — it replaces a `focusLayoutOverride` field that the two call sites set and cleared
+     * around `renderFocus` purely to smuggle the layout in.
+     *
+     * Deliberately NOT gated on `bmp.ninePatch`, unlike the base: this outset is
+     * `marginY + focusPadding*`, device-measured constants, not the 9-patch's own content margins, so
+     * there is nothing marker-derived to gate on. Note it uses only `posterRect`'s x/width — the frame's
+     * top stays at the cell top, so with `captionVertAlignment = "above"` it spans the caption zone too.
+     */
+    protected focusFrameRect(itemRect: Rect, _bmp: RoBitmap, index: number): Rect {
+        const posterRect = this.layoutByIndex.get(index)?.posterRect;
         const extraTop = this.marginY + this.focusPaddingTop;
         const extraBottom = this.marginY + this.focusPaddingBottom;
         const extraHorizontal = this.focusPaddingX;
-        const focusRect: Rect = {
-            x: baseX - extraHorizontal,
-            y: baseY - extraTop,
-            width: baseWidth + extraHorizontal * 2,
-            height: baseHeight + extraTop + extraBottom,
+        return {
+            x: (posterRect ? itemRect.x + posterRect.x : itemRect.x) - extraHorizontal,
+            y: itemRect.y - extraTop,
+            width: (posterRect?.width ?? itemRect.width) + extraHorizontal * 2,
+            height: itemRect.height + extraTop + extraBottom,
         };
-        // Only the rect math is specialized here; the blend color must still be honored, as in
-        // ArrayGrid.renderFocus — dropping it made both blend-color fields silent no-ops on this type.
-        const blendColor = this.getValueJS(blendField) as number;
-        this.drawImage(bmp, focusRect, 0, opacity, draw2D, blendColor);
     }
 
     protected createItemComponent(_interpreter: Interpreter, itemRect: Rect, content: ContentNode) {

--- a/test/extensions/scenegraph/GridFocusFeedback.test.js
+++ b/test/extensions/scenegraph/GridFocusFeedback.test.js
@@ -4,13 +4,19 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, Int32 } = core;
+const { BrsDevice, BrsString, Float, Int32, Interpreter, RoArray } = core;
 
 describe("ArrayGrid focus feedback rendering", () => {
+    let interpreter;
+
     beforeAll(() => {
         // The default focus bitmap (common:/images/focus_grid.9.png) lives in the common: volume.
         const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
         BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
     });
 
     afterEach(() => {
@@ -41,13 +47,14 @@ describe("ArrayGrid focus feedback rendering", () => {
         expect(calls[0].rect.height).toBe(338);
     });
 
-    // PosterGrid overrides renderFocus for its own rect math (the frame tracks the poster, not the whole
-    // item) and once dropped the blend color entirely, making BOTH blend fields silent no-ops on this
-    // type — the override re-derives what the base already resolves, so it can drift again.
+    // PosterGrid specializes its focus GEOMETRY (the frame tracks the poster, not the whole cell). It used
+    // to do that by overriding renderFocus wholesale, which dropped the blend color — making both blend
+    // fields silent no-ops on this type — and the base's hasNinePatch write. It now overrides only
+    // focusFrameRect, so the shared scaffolding cannot be dropped again.
     test.each([
         ["focused", true, "focusBitmapBlendColor"],
         ["unfocused", false, "focusFootprintBlendColor"],
-    ])("PosterGrid honors the %s blend color in its own renderFocus", (_label, nodeFocus, blendField) => {
+    ])("PosterGrid honors the %s blend color through the shared renderFocus", (_label, nodeFocus, blendField) => {
         const grid = SGNodeFactory.createNode("PosterGrid");
         const purple = 0x7b2ff7ff | 0;
         grid.setValue(blendField, new Int32(purple));
@@ -61,5 +68,75 @@ describe("ArrayGrid focus feedback rendering", () => {
 
         expect(calls).toHaveLength(1);
         expect(calls[0].rgba).toBe(purple);
+    });
+
+    test("PosterGrid records hasNinePatch from the drawn frame, like every other grid", () => {
+        // The old override omitted this write. Harmless on PosterGrid today only because it also overrides
+        // rectMargins(), the sole reader — a coupling no subclass should have to know about.
+        const grid = SGNodeFactory.createNode("PosterGrid");
+        grid.hasNinePatch = false;
+
+        grid.renderFocus({ x: 0, y: 0, width: 300, height: 300 }, 1, true, { drawNinePatch: () => {} });
+
+        expect(grid.hasNinePatch).toBe(true);
+    });
+
+    test("PosterGrid outsets its focus frame by its own constants, not the 9-patch content margins", () => {
+        // The outset is device-measured (marginY + focusPadding*), NOT the 19px content margins the base
+        // reads off the 9-patch. This pins that PosterGrid's geometry stays ungated on bmp.ninePatch and is
+        // not "unified" with the base's focusMargins path — the two are deliberately different.
+        const grid = SGNodeFactory.createNode("PosterGrid");
+        const calls = [];
+        const draw2D = { drawNinePatch: (bmp, rect) => calls.push({ ...rect }) };
+        const itemRect = { x: 100, y: 100, width: 300, height: 300 };
+
+        grid.renderFocus(itemRect, 1, true, draw2D);
+
+        expect(calls).toHaveLength(1);
+        // With no laid-out poster for this index the frame falls back to the whole cell, so the outsets
+        // themselves are what is observable here.
+        expect(itemRect.y - calls[0].y).toBe(grid.marginY + grid.focusPaddingTop);
+        expect(itemRect.x - calls[0].x).toBe(grid.focusPaddingX);
+        expect(calls[0].width - itemRect.width).toBe(grid.focusPaddingX * 2);
+        // The base would have used these instead; they must differ, or the assertion above is vacuous.
+        expect(grid.focusMargins(grid.getBitmap("focusBitmapUri")).top).not.toBe(grid.marginY + grid.focusPaddingTop);
+    });
+
+    test("PosterGrid's focus frame width tracks the laid-out poster, not the cell", () => {
+        // The frame's x/width come from that cell's laid-out posterRect — the behavior the deleted
+        // focusLayoutOverride field existed to feed, and which no rect assertion covered before. Its
+        // HEIGHT deliberately still spans the cell (captions included); only x/width are poster-derived.
+        const grid = SGNodeFactory.createNode("PosterGrid");
+        grid.setValue("basePosterSize", new RoArray([new Float(120), new Float(120)]));
+        grid.setValue("caption1NumLines", new Int32(1));
+        grid.setValue("numColumns", new Int32(1));
+        const content = SGNodeFactory.createNode("ContentNode");
+        for (const title of ["A", "B"]) {
+            const item = SGNodeFactory.createNode("ContentNode");
+            item.setValue("title", new BrsString(title));
+            content.appendChildToParent(item);
+        }
+        grid.setValue("content", content);
+
+        const frames = [];
+        const draw2D = {
+            drawNinePatch: (bmp, rect) => frames.push({ ...rect }),
+            doDrawRotatedRect: () => {},
+            doDrawRotatedText: () => {},
+            doDrawScaledObject: () => {},
+            doDrawRotatedBitmap: () => {},
+            doDrawCroppedBitmap: () => {},
+            pushClip: () => {},
+            popClip: () => {},
+        };
+        grid.paintNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(frames.length).toBeGreaterThan(0);
+        // Poster width (120) plus the horizontal outset on each side — NOT the cell width.
+        expect(frames[0].width).toBe(120 + grid.focusPaddingX * 2);
+        expect(frames[0].x).toBe(-grid.focusPaddingX);
+        // The caption band is inside the frame's height, so it is taller than the poster: that asymmetry
+        // is deliberate, and asserting it here stops a refactor from "fixing" it silently.
+        expect(frames[0].height).toBeGreaterThan(120);
     });
 });


### PR DESCRIPTION
Stacked on #1173 (which is stacked on #1172). Retarget as each lands.

Second of three follow-ups from the review of #1172. Pure refactor plus the test coverage that was missing.

## Problem

`PosterGrid` overrode `ArrayGrid.renderFocus` wholesale in order to specialize only its **rect math**, and in doing so re-derived four things the base already does — the uri pick, the validity guard, the blend-color pick, and the `drawImage` call — while silently dropping two others:

- **the blend color**, which made `focusBitmapBlendColor` *and* `focusFootprintBlendColor` no-ops on that type. #1172 had to restore it.
- **the `hasNinePatch` write** that `rectMargins()` reads. Still missing until this PR.

The override's own comment said "only the rect math is specialized here" — which is precisely the signal that the split was in the wrong place. Fixing the copy leaves the next field to be dropped the same way.

## Fix

`renderFocus` becomes a template method, like `renderNode`/`renderNodeContent`. It owns the shared contract; a new `focusFrameRect(itemRect, bmp, index)` owns only the geometry, so a subclass **cannot** drop the scaffolding again.

Threading the item index through the hook also deletes `PosterGrid.focusLayoutOverride` — a field the two call sites set and cleared around `renderFocus` purely to smuggle the per-cell layout in, i.e. a hidden argument channel that leaked if `renderFocus` threw. `-1` means "the caller has no index": `TimeGrid`, and the row-based grids whose position is (row, col) rather than a flat content index.

### Three decisions made deliberately, not incidentally

- **PosterGrid's outset stays ungated on `bmp.ninePatch`.** The base gates because `focusMargins` reads the 9-patch's markers; PosterGrid's outset is `marginY + focusPadding*` — device-measured constants — so there is nothing marker-derived to gate on. Unifying them would be wrong; a test now pins the difference so nobody "simplifies" it.
- **PosterGrid's frame height still spans the caption band.** It uses only `posterRect`'s x/width. Undocumented and easy to lose in a refactor, so it is asserted.
- **The base's non-9-patch branch keeps returning `itemRect` itself, not a copy.** `Group.drawImage` writes `rect.width`/`height` for a plain bitmap and `renderItemComponent` then positions and clips the item against the same object, so the scaled size the draw computes is what the item is laid out against. Documented in the hook's docstring, since it is invisible at the call site.

Restoring the `hasNinePatch` write on `PosterGrid` is observably inert: `rectMargins()` is its only reader, and `PosterGrid` overrides that with a resolution-derived constant. Worth stating because it is the first thing a reviewer will check.

## Tests

**PosterGrid's focus rect had no rect assertion anywhere**, so adding that coverage is the point of this PR rather than an afterthought:

- frame width tracks the laid-out poster (`120 + 2×focusPaddingX`, not the cell width) and x is offset by the horizontal padding
- the outset equals its own constants and is asserted to **differ** from `focusMargins(bmp).top`, so the ungated decision can't be silently unified
- the caption band is inside the frame height — the deliberate asymmetry
- `hasNinePatch` is recorded after a `renderFocus`

The base path's existing pins pass **unmodified**, which is the real proof the extraction preserved behavior: RowList's exact 81/81/338/338, LabelList's margin-relative rect through its no-arg `focusMargins` override, and the real-render `RowListItemSubRect` suite across {HD,FHD} × {RowList,ZoomRowList}.

Full suite green: 209 files, 2656 passed.

## Not done

**`hasNinePatch` is not stabilized.** It is genuinely unstable — re-derived per frame from whichever bitmap was drawn last, which is why `MarkupGrid`/`MarkupList` override `rectMargins()` to zero. But it leaks into reported rects on four node types and needs device measurement, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)