### PR TITLE
feat(api): Added `loading` event to be triggered on app startup

### DIFF
--- a/docs/engine-api.md
+++ b/docs/engine-api.md
@@ -67,8 +67,11 @@ The browser API now re-exports a small set of shared types and constants so host
 
 ## Events
 
+The engine API emits events to subscribers via the `subscribe()` method. Each event has a name and a data payload, which can be of different types depending on the event.
+
 | Event      | Description                                      | Data Type                         |
 |------------|--------------------------------------------------|-----------------------------------|
+| loading    | Triggered when the source code data has started loading | string: `filePath` |
 | loaded     | Triggered when the source code data has finished loading | object: `{id: string, file: string, title: string, subtitle: string, version: string, running: boolean}`|
 | icon       | Triggered when the zip file is loaded and manifest links to a valid icon for the app | base64: A base64 string of the app icon, extracted from the zip file. |
 | registry   | Triggered when the app updates the registry | Map: the registry with all recent recent updates. |

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -386,6 +386,7 @@ export function execute(filePath: string, fileData: any, options: any = {}, deep
     if (brsWorker !== undefined) {
         resetWorker();
     }
+    notifyAll("loading", filePath);
     deviceDebug(`beacon,Loading ${filePath}...\r\n`);
     initSoundModule(sharedArray, options.muteSound);
     muteVideo(options.muteSound);


### PR DESCRIPTION
There was already two events during app launch `loaded` and `started`, but the Desktop app needed to know when the app was executed, before the source code is validated, so we added `loading` event.