### PR TITLE
Drop a backwards focus steal raised via a container redirect

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -658,7 +658,9 @@ capture the **native JS stack** mid-recursion (a temporary depth tripwire dumpin
    > registered *after* the `setFocus` call, so a field (not a callback) is recorded and re-notified from
    > the extension `tick` hook after init unwinds (`deliverPendingInitFocus`, render-thread only). The
    > split is intentional (callback-level reentrant-unwind vs. field-level message-loop delivery) — do
-   > **not** naively merge them. `notifyObservers` **consumes** a field from `pendingInitFocusFields` as
+   > **not** naively merge them. A `deferredQueue` entry also carries the `focusedChild` notification it
+   > was raised under (`focusNotifyOwner`), reinstated around the deferred dispatch so a nested `setFocus`
+   > is still classifiable as a focus steal — see the focus-chain section below. `notifyObservers` **consumes** a field from `pendingInitFocusFields` as
    > it dispatches so an inline re-focus of a still-pending ancestor doesn't double-fire; and `invoke`
    > stashes/zeroes both `internalUpdateDepth` and `focusEmissionDepth` so a handler's own writes are
    > treated as app-initiated. Any change to dispatch semantics must be re-checked against *both* paths
@@ -1214,6 +1216,34 @@ because an app that re-grabs focus from its own `focusedChild` observer (sgRoute
    just *gained* focus hands it to an inner widget. The mirror case, a node re-grabbing focus as it
    *loses* it, leaves the chain and the remote with the node the in-flight transaction focused.
 
+   **The owner alone is not enough — the TARGET is classified too.** A container that observes its own
+   `focusedChild` and redirects focus into its own child *stays* in the chain, so an owner-only test reads
+   a subsequent re-grab to an unrelated sibling as legal forward focus and strands the app on the node it
+   was navigating away from (device-measured: `list-refocus-settle-probe` R7). Four rules, and the
+   **order** matters:
+   - The owner must still be in the focus chain (the classic backwards steal).
+   - `target === focused` is idempotent and honored — but tested **after** the owner walk, never before.
+     Ahead of it, a focus-*loss* observer re-asserting the incoming node gets honored, re-running the
+     whole transaction and double-firing every observer (`focusedChild` is `alwaysNotify`, and an
+     `ArrayGrid` re-publishes its `itemFocused` settle, re-triggering app side effects like starting
+     preview playback).
+   - The target-subtree test applies **only when the owner is a proper ancestor** of the focused node. When
+     the owner *is* the focused node, the transaction staged `focusedChild` on the leaf itself, so the
+     redirect is the ordinary "I got focus but nothing to show, pass it on" pattern — which legitimately
+     targets a sibling or the parent.
+   - A target that is **not in the owner's tree** is never a steal, or the subtree walk drops it: a node
+     still unparented (a component focusing itself from `init()`, which runs *before* `appendChild`) and
+     the scene's `dialog` (parented to the Scene via `setNodeParent`, never into the owner).
+
+   **The classification must survive the deferral, not defeat it.** A grid's focus-gain settle is an
+   engine emission, so raised inside another observer it defers — by which point the transaction has left
+   the stack and the steal is unclassifiable. Do **not** fix that by dispatching the settle synchronously:
+   the settle is also what carries an app's reentrant multi-list load, so inline dispatch re-creates the
+   `deferred-observer-app` crash (an earlier list's `content` still `invalid` when a later list's handler
+   runs), and the two shapes are indistinguishable — both are "a container's `focusedChild` observer calls
+   `setFocus` on a list". Instead the deferred entry records the notification it was raised under and
+   `Node.runWithFocusNotifyOwner` reinstates it around the dispatch, leaving *when* observers run alone.
+
    Scoped to transactions where a node is **taking** focus (`notifyStagedFocus`'s `gaining` flag). The
    unfocus paths notify without classifying: with no competing target there is nothing to defend, and
    swallowing an unfocus observer's restore would leave the app with **no focused node at all**. The
@@ -1232,5 +1262,7 @@ because an app that re-grabs focus from its own `focusedChild` observer (sgRoute
    true` until the next focus transaction, so two nodes report focus at once. Reproducing that would make
    both render focused. We report `hasFocus()` only for the live focus.
 
-   Regression: `focus-steal-app` in `test/cli/`, which must stay green alongside
-   `dialog-buttongroup-focus-app` and `init-focus-observer-app`.
+   Regression: `focus-steal-app` and `container-redirect-focus-app` in `test/cli/` (the latter drives all
+   four rules plus the deferral through a real app; the `Focus.test.js` unit tests use port observers,
+   which never defer), which must stay green alongside `dialog-buttongroup-focus-app`,
+   `deferred-observer-app` and `init-focus-observer-app`.

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -1219,21 +1219,20 @@ because an app that re-grabs focus from its own `focusedChild` observer (sgRoute
    **The owner alone is not enough — the TARGET is classified too.** A container that observes its own
    `focusedChild` and redirects focus into its own child *stays* in the chain, so an owner-only test reads
    a subsequent re-grab to an unrelated sibling as legal forward focus and strands the app on the node it
-   was navigating away from (device-measured: `list-refocus-settle-probe` R7). Four rules, and the
-   **order** matters:
-   - The owner must still be in the focus chain (the classic backwards steal).
-   - `target === focused` is idempotent and honored — but tested **after** the owner walk, never before.
-     Ahead of it, a focus-*loss* observer re-asserting the incoming node gets honored, re-running the
-     whole transaction and double-firing every observer (`focusedChild` is `alwaysNotify`, and an
-     `ArrayGrid` re-publishes its `itemFocused` settle, re-triggering app side effects like starting
-     preview playback).
+   was navigating away from (device-measured: `list-refocus-settle-probe` R7). Three rules, sharing one
+   bounded ancestor walk (`Node.isAncestorOrSelf`), and the **order** matters:
+   - The owner must still be in the focus chain (the classic backwards steal). `target === focused`
+     (probe2 N4, re-asserting the node that just took focus) is idempotent and falls out of the next rule
+     for free once this one confirms the owner is a proper ancestor — it is not a separate check.
    - The target-subtree test applies **only when the owner is a proper ancestor** of the focused node. When
      the owner *is* the focused node, the transaction staged `focusedChild` on the leaf itself, so the
      redirect is the ordinary "I got focus but nothing to show, pass it on" pattern — which legitimately
      targets a sibling or the parent.
    - A target that is **not in the owner's tree** is never a steal, or the subtree walk drops it: a node
      still unparented (a component focusing itself from `init()`, which runs *before* `appendChild`) and
-     the scene's `dialog` (parented to the Scene via `setNodeParent`, never into the owner).
+     the scene's `dialog` (parented to the Scene via `setNodeParent`, never into the owner). Checked last —
+     it costs an unbounded walk to the scene root, so it only runs once the cheap subtree walk has already
+     failed to place `target` under `owner`.
 
    **The classification must survive the deferral, not defeat it.** A grid's focus-gain settle is an
    engine emission, so raised inside another observer it defers — by which point the transaction has left

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -257,7 +257,34 @@ export class ArrayGrid extends Group {
                 }
             }
             if (focusIndex >= 0) {
-                this.setFocusedItem(focusIndex);
+                // Device-measured (`test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5): a
+                // focus-gain re-publishes the settle and its observers run BETWEEN the probe's
+                // `before` and `after` records — i.e. before `setFocus` returns.
+                //
+                // That timing is load-bearing, not cosmetic: an app that re-grabs focus from the
+                // resulting `rowItemFocused` observer (an overlay re-showing itself) must be
+                // classified by `Node.isFocusRequestDropped` as a backwards steal and dropped. That
+                // rule keys off `Node.focusNotifyOwners`, which is loaded only while the focus
+                // transaction is on the stack — so a deferred settle escapes it, the steal wins the
+                // live focus, and the app is stranded on the node it was navigating away from.
+                //
+                // Scoped to exactly that case: inline ONLY when a `focusedChild` notification is
+                // dispatching. A plain `setFocus` from app code has no transaction to defend, and
+                // forcing its settle inline there re-creates the reentrancy the deferral exists to
+                // prevent — an observer that assigns content to several lists and moves focus between
+                // the assignments would have a later list's `itemFocused` handler run while an
+                // earlier `content` is still `invalid` (deferred-observer-app).
+                const syncSettle = Node.inFocusNotification();
+                if (syncSettle) {
+                    Field.enterSyncFocusSettle();
+                }
+                try {
+                    this.setFocusedItem(focusIndex);
+                } finally {
+                    if (syncSettle) {
+                        Field.exitSyncFocusSettle();
+                    }
+                }
             }
         }
         return focus;

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -257,11 +257,6 @@ export class ArrayGrid extends Group {
                 }
             }
             if (focusIndex >= 0) {
-                // The focus-gain settle (`itemFocused`/`rowItemFocused`) defers like every other grid
-                // emission when it is raised inside another observer. An app that re-grabs focus from
-                // the resulting handler is still classified as a backwards steal, because the deferred
-                // entry carries the notification it was raised under — see
-                // `Node.runWithFocusNotifyOwner`, which is what makes keeping the deferral safe here.
                 this.setFocusedItem(focusIndex);
             }
         }

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -257,34 +257,12 @@ export class ArrayGrid extends Group {
                 }
             }
             if (focusIndex >= 0) {
-                // Device-measured (`test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5): a
-                // focus-gain re-publishes the settle and its observers run BETWEEN the probe's
-                // `before` and `after` records — i.e. before `setFocus` returns.
-                //
-                // That timing is load-bearing, not cosmetic: an app that re-grabs focus from the
-                // resulting `rowItemFocused` observer (an overlay re-showing itself) must be
-                // classified by `Node.isFocusRequestDropped` as a backwards steal and dropped. That
-                // rule keys off `Node.focusNotifyOwners`, which is loaded only while the focus
-                // transaction is on the stack — so a deferred settle escapes it, the steal wins the
-                // live focus, and the app is stranded on the node it was navigating away from.
-                //
-                // Scoped to exactly that case: inline ONLY when a `focusedChild` notification is
-                // dispatching. A plain `setFocus` from app code has no transaction to defend, and
-                // forcing its settle inline there re-creates the reentrancy the deferral exists to
-                // prevent — an observer that assigns content to several lists and moves focus between
-                // the assignments would have a later list's `itemFocused` handler run while an
-                // earlier `content` is still `invalid` (deferred-observer-app).
-                const syncSettle = Node.inFocusNotification();
-                if (syncSettle) {
-                    Field.enterSyncFocusSettle();
-                }
-                try {
-                    this.setFocusedItem(focusIndex);
-                } finally {
-                    if (syncSettle) {
-                        Field.exitSyncFocusSettle();
-                    }
-                }
+                // The focus-gain settle (`itemFocused`/`rowItemFocused`) defers like every other grid
+                // emission when it is raised inside another observer. An app that re-grabs focus from
+                // the resulting handler is still classified as a backwards steal, because the deferred
+                // entry carries the notification it was raised under — see
+                // `Node.runWithFocusNotifyOwner`, which is what makes keeping the deferral safe here.
+                this.setFocusedItem(focusIndex);
             }
         }
         return focus;

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -75,12 +75,6 @@ export class Field {
      */
     private static internalUpdateDepth = 0;
     /**
-     * >0 while a focus-GAIN settle is being published, which a device dispatches synchronously even
-     * though every other grid emission defers. Overrides the deferral in `executeCallbacks`; see
-     * `enterSyncFocusSettle` for why the timing is load-bearing.
-     */
-    private static syncFocusSettleDepth = 0;
-    /**
      * >0 while a component's `init()` is running (the `init` hierarchy walk in `initializeNode`).
      * Focus emissions raised during `init` must defer until the OUTERMOST init unwinds — on Roku a
      * `setFocus(true)` in `init()` dispatches its `focusedChild` observers from the message loop
@@ -105,8 +99,19 @@ export class Field {
      * each other (a manual field-alias ping-pong) loop forever.
      */
     private static draining = false;
-    /** Deferred reentrant observer invocations, drained at the outermost unwind. */
-    private static readonly deferredQueue: { field: Field; callback: BrsCallback; event: RoSGNodeEvent }[] = [];
+    /**
+     * Deferred reentrant observer invocations, drained at the outermost unwind.
+     *
+     * `focusNotifyOwner` is the `focusedChild` notification that was dispatching when the emission
+     * was queued, reinstated around the deferred call so a `setFocus` raised from the callback is
+     * still classifiable as a backwards steal — see `Node.runWithFocusNotifyOwner`.
+     */
+    private static readonly deferredQueue: {
+        field: Field;
+        callback: BrsCallback;
+        event: RoSGNodeEvent;
+        focusNotifyOwner?: Node;
+    }[] = [];
     /**
      * Fields whose focus-chain notification was raised during a component's init() and deferred.
      * The observer that reacts is often registered LATER in the same init (after the setFocus call),
@@ -135,24 +140,6 @@ export class Field {
     /** Marks exit from an engine-initiated field emission. */
     static exitInternalUpdate() {
         Field.internalUpdateDepth--;
-    }
-
-    /**
-     * Marks a focus-gain settle that must dispatch SYNCHRONOUSLY rather than defer.
-     *
-     * Device-measured (`test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5): when a grid gains
-     * focus it re-publishes its focus fields and those observers run before `setFocus` returns. Every
-     * other engine-initiated grid emission defers (see `internalUpdateDepth`), and applying that here
-     * broke the focus-steal drop rule, which can only classify a nested `setFocus` while the focus
-     * transaction is still on the stack (`Node.focusNotifyOwners`).
-     */
-    static enterSyncFocusSettle() {
-        Field.syncFocusSettleDepth++;
-    }
-
-    /** Marks exit from a synchronous focus-gain settle. */
-    static exitSyncFocusSettle() {
-        Field.syncFocusSettleDepth--;
     }
 
     /** Marks entry into a component's `init()` (the init hierarchy walk). */
@@ -221,7 +208,6 @@ export class Field {
         Field.observerDepth = 0;
         Field.parentCascadeDepth = 0;
         Field.internalUpdateDepth = 0;
-        Field.syncFocusSettleDepth = 0;
         Field.initDepth = 0;
         Field.focusEmissionDepth = 0;
         Field.draining = false;
@@ -774,12 +760,17 @@ export class Field {
             Field.internalUpdateDepth > 0 &&
             Field.observerDepth > 0 &&
             !Field.draining &&
-            Field.parentCascadeDepth === 0 &&
-            // A focus-gain settle dispatches inline: a device runs these observers before setFocus
-            // returns, and the focus-steal drop rule depends on that (see enterSyncFocusSettle).
-            Field.syncFocusSettleDepth === 0
+            Field.parentCascadeDepth === 0
         ) {
-            Field.deferredQueue.push({ field: this, callback, event });
+            // Carry the in-flight focus notification with the entry: it will have left the stack by
+            // the time this drains, and without it a `setFocus` raised from the callback can no
+            // longer be classified as a backwards steal (see Node.runWithFocusNotifyOwner).
+            Field.deferredQueue.push({
+                field: this,
+                callback,
+                event,
+                focusNotifyOwner: Node.currentFocusNotifyOwner(),
+            });
             return;
         }
 
@@ -845,7 +836,11 @@ export class Field {
                 field.notifying = true;
                 Field.observerDepth++;
                 try {
-                    field.invoke(deferred.callback, deferred.event);
+                    // Reinstate the focus notification this emission was raised under, so a nested
+                    // setFocus stays classifiable even though the transaction has left the stack.
+                    Node.runWithFocusNotifyOwner(deferred.focusNotifyOwner, () =>
+                        field.invoke(deferred.callback, deferred.event)
+                    );
                 } finally {
                     Field.observerDepth--;
                     field.notifying = wasNotifying;
@@ -868,20 +863,13 @@ export class Field {
         // re-enters them on its own.
         const stashedInternalDepth = Field.internalUpdateDepth;
         const stashedFocusDepth = Field.focusEmissionDepth;
-        // Stashed for the same reason: the sync-dispatch exemption applies to the focus-gain settle
-        // itself, not to whatever the handler goes on to trigger. A grid emission raised from inside
-        // this callback must defer as usual, or a reentrant cascade dispatches inline and loses the
-        // handler-boundary ordering the deferral exists to preserve.
-        const stashedSyncSettle = Field.syncFocusSettleDepth;
         Field.internalUpdateDepth = 0;
         Field.focusEmissionDepth = 0;
-        Field.syncFocusSettleDepth = 0;
         try {
             this.invokeCallable(callback, event);
         } finally {
             Field.internalUpdateDepth = stashedInternalDepth;
             Field.focusEmissionDepth = stashedFocusDepth;
-            Field.syncFocusSettleDepth = stashedSyncSettle;
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -75,6 +75,12 @@ export class Field {
      */
     private static internalUpdateDepth = 0;
     /**
+     * >0 while a focus-GAIN settle is being published, which a device dispatches synchronously even
+     * though every other grid emission defers. Overrides the deferral in `executeCallbacks`; see
+     * `enterSyncFocusSettle` for why the timing is load-bearing.
+     */
+    private static syncFocusSettleDepth = 0;
+    /**
      * >0 while a component's `init()` is running (the `init` hierarchy walk in `initializeNode`).
      * Focus emissions raised during `init` must defer until the OUTERMOST init unwinds — on Roku a
      * `setFocus(true)` in `init()` dispatches its `focusedChild` observers from the message loop
@@ -129,6 +135,24 @@ export class Field {
     /** Marks exit from an engine-initiated field emission. */
     static exitInternalUpdate() {
         Field.internalUpdateDepth--;
+    }
+
+    /**
+     * Marks a focus-gain settle that must dispatch SYNCHRONOUSLY rather than defer.
+     *
+     * Device-measured (`test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5): when a grid gains
+     * focus it re-publishes its focus fields and those observers run before `setFocus` returns. Every
+     * other engine-initiated grid emission defers (see `internalUpdateDepth`), and applying that here
+     * broke the focus-steal drop rule, which can only classify a nested `setFocus` while the focus
+     * transaction is still on the stack (`Node.focusNotifyOwners`).
+     */
+    static enterSyncFocusSettle() {
+        Field.syncFocusSettleDepth++;
+    }
+
+    /** Marks exit from a synchronous focus-gain settle. */
+    static exitSyncFocusSettle() {
+        Field.syncFocusSettleDepth--;
     }
 
     /** Marks entry into a component's `init()` (the init hierarchy walk). */
@@ -197,6 +221,7 @@ export class Field {
         Field.observerDepth = 0;
         Field.parentCascadeDepth = 0;
         Field.internalUpdateDepth = 0;
+        Field.syncFocusSettleDepth = 0;
         Field.initDepth = 0;
         Field.focusEmissionDepth = 0;
         Field.draining = false;
@@ -749,7 +774,10 @@ export class Field {
             Field.internalUpdateDepth > 0 &&
             Field.observerDepth > 0 &&
             !Field.draining &&
-            Field.parentCascadeDepth === 0
+            Field.parentCascadeDepth === 0 &&
+            // A focus-gain settle dispatches inline: a device runs these observers before setFocus
+            // returns, and the focus-steal drop rule depends on that (see enterSyncFocusSettle).
+            Field.syncFocusSettleDepth === 0
         ) {
             Field.deferredQueue.push({ field: this, callback, event });
             return;
@@ -840,13 +868,20 @@ export class Field {
         // re-enters them on its own.
         const stashedInternalDepth = Field.internalUpdateDepth;
         const stashedFocusDepth = Field.focusEmissionDepth;
+        // Stashed for the same reason: the sync-dispatch exemption applies to the focus-gain settle
+        // itself, not to whatever the handler goes on to trigger. A grid emission raised from inside
+        // this callback must defer as usual, or a reentrant cascade dispatches inline and loses the
+        // handler-boundary ordering the deferral exists to preserve.
+        const stashedSyncSettle = Field.syncFocusSettleDepth;
         Field.internalUpdateDepth = 0;
         Field.focusEmissionDepth = 0;
+        Field.syncFocusSettleDepth = 0;
         try {
             this.invokeCallable(callback, event);
         } finally {
             Field.internalUpdateDepth = stashedInternalDepth;
             Field.focusEmissionDepth = stashedFocusDepth;
+            Field.syncFocusSettleDepth = stashedSyncSettle;
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1528,10 +1528,6 @@ export class Node extends RoSGNode implements BrsValue {
         //      slip through: the owner IS still in the chain (focus went to its own child), so
         //      condition 1 alone reads that steal as a legal forward focus and strands the app on the
         //      node it was navigating away from.
-        if (target === focused) {
-            // Re-asserting the node that just took focus is idempotent, never a steal (probe2 N4).
-            return false;
-        }
         // Cheap upward walks, the same shape restoreFocusChainOnAttach uses — an O(subtree) descent
         // would run on every nested focus request.
         let ownerInChain: BrsType = focused;
@@ -1540,6 +1536,15 @@ export class Node extends RoSGNode implements BrsValue {
         }
         if (ownerInChain !== owner) {
             return true;
+        }
+        // Tested only AFTER the owner-in-chain check, never before it: a focus-LOSS observer that
+        // re-asserts the node currently TAKING focus must still be dropped. Honoring it re-runs the
+        // whole focus transaction — `focusedChild` is alwaysNotify and `ArrayGrid.setNodeFocus`
+        // re-publishes its settle — so every observer fires a second time, and an app with a side
+        // effect on `itemFocused` (starting preview playback) gets a spurious repeat.
+        if (target === focused) {
+            // Re-asserting the node that just took focus is idempotent, never a steal (probe2 N4).
+            return false;
         }
         // The target test applies ONLY when the owner is a PROPER ANCESTOR of the focused node, i.e. the
         // container shape: the owner handed focus down into its own subtree, and something reached from

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1502,7 +1502,10 @@ export class Node extends RoSGNode implements BrsValue {
      * behave on a device and not here: the engine used to let the re-grab win the live focus while
      * the outer transaction still wrote its own chain, leaving `sgRoot.focused` and `focusedChild`
      * pointing at different nodes.
-     * @returns True when the in-flight notification is a focus loss, so the request is ignored.
+     * @param target Node the nested `setFocus(true)` is trying to focus.
+     * @returns True when the request is a backwards steal — the notifying owner has left the focus
+     *   chain, or it redirected focus into its own subtree and `target` sits outside it — so the
+     *   request is ignored.
      */
     private static isFocusRequestDropped(target: Node): boolean {
         const owner = Node.focusNotifyOwners.at(-1);
@@ -1559,11 +1562,47 @@ export class Node extends RoSGNode implements BrsValue {
         if (owner === focused) {
             return false;
         }
+        // A target that is not part of the owner's tree at all is not a steal — the subtree walk below
+        // could never reach the owner, so without this every such request would be dropped, silently
+        // swallowing two ordinary shapes:
+        //   - a component created inside the notification whose `init()` calls `m.top.setFocus(true)`.
+        //     `init` runs BEFORE `appendChild`, so the node is still parentless at that moment; the
+        //     ancestry is repaired by `restoreFocusChainOnAttach`, which only runs if focus moved.
+        //   - `m.top.dialog = d` followed by `d.setFocus(true)`. A dialog is the scene's modal
+        //     overlay, parented via `setNodeParent` straight to the Scene, so it is never inside the
+        //     owner's subtree — and focusing it is the whole point of showing it.
+        // Neither is pulling focus back out of the committed chain, which is the steal being dropped.
+        if (!(target.parent instanceof Node) || Node.isSceneDialog(target)) {
+            return false;
+        }
         let targetUnderOwner: BrsType = target;
         while (targetUnderOwner instanceof Node && targetUnderOwner !== owner) {
             targetUnderOwner = targetUnderOwner.parent;
         }
         return targetUnderOwner !== owner;
+    }
+
+    /**
+     * Whether `node` is the dialog the scene is currently showing (or sits inside it).
+     *
+     * `Scene.dialog` tracks the live modal directly, so this needs no `Dialog`/`StandardDialog`
+     * import — which would be a cycle, since both extend `Group`.
+     * @param node Node to test.
+     * @returns True when the node is the current scene dialog or one of its descendants.
+     */
+    private static isSceneDialog(node: Node): boolean {
+        const dialog = sgRoot.scene?.dialog;
+        if (!dialog) {
+            return false;
+        }
+        let ancestor: BrsType = node;
+        while (ancestor instanceof Node) {
+            if (ancestor === dialog) {
+                return true;
+            }
+            ancestor = ancestor.parent;
+        }
+        return false;
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1541,6 +1541,19 @@ export class Node extends RoSGNode implements BrsValue {
         if (ownerInChain !== owner) {
             return true;
         }
+        // The target test applies ONLY when the owner is a PROPER ANCESTOR of the focused node, i.e. the
+        // container shape: the owner handed focus down into its own subtree, and something reached from
+        // that notification is now trying to pull focus back out. That is the steal to drop.
+        //
+        // When the owner IS the focused node the transaction staged `focusedChild` on the leaf itself
+        // (see setNodeFocus's final stageFocusedChild), so the node observing its own focus gain is
+        // simply deciding where focus should go next — the "I got focus but have nothing to show, pass it
+        // on" pattern, which legitimately targets a sibling or its own parent. Applying the subtree test
+        // there dropped both, a regression against pre-change behavior that `focus-probe2` never covered
+        // (N1/N2 only measured forward focus INTO a container's subtree).
+        if (owner === focused) {
+            return false;
+        }
         let targetUnderOwner: BrsType = target;
         while (targetUnderOwner instanceof Node && targetUnderOwner !== owner) {
             targetUnderOwner = targetUnderOwner.parent;

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -95,28 +95,18 @@ export class Node extends RoSGNode implements BrsValue {
 
     /**
      * The `focusedChild` notification dispatching right now, if any — the context a nested
-     * `setFocus` is classified against by `isFocusRequestDropped`.
-     *
-     * Captured by `Field.executeCallbacks` when it DEFERS an emission raised inside a focus
-     * transaction, so the classification survives the wait; see `runWithFocusNotifyOwner`.
+     * `setFocus` is classified against by `isFocusRequestDropped`. Captured by
+     * `Field.executeCallbacks` when it defers an emission raised inside a focus transaction, so the
+     * classification survives the wait; see `runWithFocusNotifyOwner`.
      */
     static currentFocusNotifyOwner(): Node | undefined {
         return Node.focusNotifyOwners.at(-1);
     }
 
     /**
-     * Runs `body` with `owner` reinstated as the in-flight `focusedChild` notification.
-     *
-     * A grid's focus-gain settle (`itemFocused`/`rowItemFocused`) is an engine emission, so when it is
-     * raised inside another observer it defers to the end of that handler (see `executeCallbacks`) —
-     * but by then the focus transaction has left the stack, and a `setFocus` raised from the settle's
-     * observer could no longer be told apart from an ordinary app-initiated one. That is how a
-     * backwards steal used to win the live focus: an app re-grabbing focus from its `rowItemFocused`
-     * handler (an overlay re-showing itself) stranded the user on the node being navigated away from.
-     *
-     * Restoring the captured owner around the deferred dispatch keeps the drop rule applicable
-     * without changing WHEN the observer runs — deferral is what stops a later list's handler from
-     * running while an earlier `content` is still `invalid` (`deferred-observer-app`).
+     * Runs `body` with `owner` reinstated as the in-flight `focusedChild` notification, so a
+     * `setFocus` raised from a deferred grid focus-settle observer (`itemFocused`/`rowItemFocused`)
+     * is still classified against the notification it was originally raised under.
      * @param owner Notification owner captured at defer time, or undefined if there was none.
      * @param body Deferred dispatch to run.
      */
@@ -1369,10 +1359,9 @@ export class Node extends RoSGNode implements BrsValue {
      */
     setNodeFocus(focusOn: boolean): boolean {
         if (focusOn && Node.isFocusRequestDropped(this)) {
-            // Device-measured: Roku ignores a focus request raised from a focus-LOSS notification
-            // (see notifyStagedFocus). Report the request as not applied, so a subclass override
-            // gated on `super.setNodeFocus(...)` skips its focus bookkeeping too (an ArrayGrid must
-            // not move `itemFocused` for a grid that never took focus).
+            // Report the request as not applied, so a subclass override gated on
+            // `super.setNodeFocus(...)` skips its own focus bookkeeping too (an ArrayGrid must not
+            // move `itemFocused` for a grid that never took focus).
             return false;
         }
         if (focusOn) {
@@ -1495,16 +1484,7 @@ export class Node extends RoSGNode implements BrsValue {
         Field.enterFocusEmission();
         try {
             for (const entry of staged) {
-                if (gaining) {
-                    Node.focusNotifyOwners.push(entry.node);
-                }
-                try {
-                    entry.field.notifyObservers();
-                } finally {
-                    if (gaining) {
-                        Node.focusNotifyOwners.pop();
-                    }
-                }
+                Node.runWithFocusNotifyOwner(gaining ? entry.node : undefined, () => entry.field.notifyObservers());
             }
         } finally {
             Field.exitFocusEmission();
@@ -1519,20 +1499,13 @@ export class Node extends RoSGNode implements BrsValue {
     /**
      * Whether a `setFocus(true)` issued right now must be ignored.
      *
-     * Device-measured: a Roku honors a focus request raised from a `focusedChild` observer only when
-     * the observed node is still in the focus chain — the "forward focus" pattern where a container
-     * that just GAINED focus hands it to an inner widget. A request raised from the mirror-image
-     * notification, by a node that just LOST focus, is dropped: the chain and the remote stay with
-     * the node the in-flight transaction focused.
-     *
-     * That asymmetry is what makes an app which re-grabs focus from its own focus-loss observer
-     * behave on a device and not here: the engine used to let the re-grab win the live focus while
-     * the outer transaction still wrote its own chain, leaving `sgRoot.focused` and `focusedChild`
-     * pointing at different nodes.
+     * A Roku honors a focus request raised from a `focusedChild` observer only when the observed node
+     * is still in the focus chain (forward focus — a container that just gained focus hands it to an
+     * inner widget) AND the target stays inside that owner's subtree. A request from a node that just
+     * lost focus, or one that reaches for a target outside the subtree the owner just focused, is a
+     * backwards steal and is dropped.
      * @param target Node the nested `setFocus(true)` is trying to focus.
-     * @returns True when the request is a backwards steal — the notifying owner has left the focus
-     *   chain, or it redirected focus into its own subtree and `target` sits outside it — so the
-     *   request is ignored.
+     * @returns True when the request must be ignored.
      */
     private static isFocusRequestDropped(target: Node): boolean {
         const owner = Node.focusNotifyOwners.at(-1);
@@ -1540,96 +1513,49 @@ export class Node extends RoSGNode implements BrsValue {
         if (!owner || !(focused instanceof Node)) {
             return false;
         }
-        // Classify by BOTH the notifying owner and the TARGET.
-        //
-        // The rule `focus-probe2` established is (a): a nested request is dropped only when it targets
-        // a node OUTSIDE the subtree the in-flight transaction just focused, while redirecting focus
-        // WITHIN that subtree is allowed. "Within" means inside the notifying owner — forward focus
-        // routinely targets a SIBLING of the focused leaf (a container handing focus from its first
-        // child to another, which is how a dialog highlights its buttons), so testing only whether the
-        // target sits at-or-below the live focus is too strict and breaks that pattern.
-        //
-        // Two conditions, and both matter:
-        //   1. The owner must still be in the focus chain. A request from a node that just LOST focus
-        //      is the classic backwards steal (probe2 N3).
-        //   2. The target must be inside the owner's subtree. Otherwise a container that observes its
-        //      own `focusedChild`, redirects focus to its inner list, and then has the list's
-        //      focus-gain settle run an app observer that re-grabs focus to an unrelated sibling would
-        //      slip through: the owner IS still in the chain (focus went to its own child), so
-        //      condition 1 alone reads that steal as a legal forward focus and strands the app on the
-        //      node it was navigating away from.
-        // Cheap upward walks, the same shape restoreFocusChainOnAttach uses — an O(subtree) descent
-        // would run on every nested focus request.
-        let ownerInChain: BrsType = focused;
-        while (ownerInChain instanceof Node && ownerInChain !== owner) {
-            ownerInChain = ownerInChain.parent;
-        }
-        if (ownerInChain !== owner) {
+        // Owner must still be in the focus chain.
+        if (!Node.isAncestorOrSelf(owner, focused)) {
             return true;
         }
-        // Tested only AFTER the owner-in-chain check, never before it: a focus-LOSS observer that
-        // re-asserts the node currently TAKING focus must still be dropped. Honoring it re-runs the
-        // whole focus transaction — `focusedChild` is alwaysNotify and `ArrayGrid.setNodeFocus`
-        // re-publishes its settle — so every observer fires a second time, and an app with a side
-        // effect on `itemFocused` (starting preview playback) gets a spurious repeat.
-        if (target === focused) {
-            // Re-asserting the node that just took focus is idempotent, never a steal (probe2 N4).
+        // Legitimate forward focus: the owner focused itself (nothing to redirect out of), or the
+        // target is inside the subtree the owner just focused.
+        if (owner === focused || Node.isAncestorOrSelf(owner, target)) {
             return false;
         }
-        // The target test applies ONLY when the owner is a PROPER ANCESTOR of the focused node, i.e. the
-        // container shape: the owner handed focus down into its own subtree, and something reached from
-        // that notification is now trying to pull focus back out. That is the steal to drop.
-        //
-        // When the owner IS the focused node the transaction staged `focusedChild` on the leaf itself
-        // (see setNodeFocus's final stageFocusedChild), so the node observing its own focus gain is
-        // simply deciding where focus should go next — the "I got focus but have nothing to show, pass it
-        // on" pattern, which legitimately targets a sibling or its own parent. Applying the subtree test
-        // there dropped both, a regression against pre-change behavior that `focus-probe2` never covered
-        // (N1/N2 only measured forward focus INTO a container's subtree).
-        if (owner === focused) {
-            return false;
-        }
-        // A target that is not part of the owner's tree at all is not a steal — the subtree walk below
-        // could never reach the owner, so without this every such request would be dropped, silently
-        // swallowing two ordinary shapes:
-        //   - a component created inside the notification whose `init()` calls `m.top.setFocus(true)`.
-        //     `init` runs BEFORE `appendChild`, so the node is still parentless at that moment; the
-        //     ancestry is repaired by `restoreFocusChainOnAttach`, which only runs if focus moved.
-        //   - `m.top.dialog = d` followed by `d.setFocus(true)`. A dialog is the scene's modal
-        //     overlay, parented via `setNodeParent` straight to the Scene, so it is never inside the
-        //     owner's subtree — and focusing it is the whole point of showing it.
-        // Neither is pulling focus back out of the committed chain, which is the steal being dropped.
+        // A target outside the owner's tree entirely is not a steal either — a node still unparented
+        // (mid-`init()`, before `appendChild`), or the scene's modal `dialog` (parented straight to
+        // the Scene, never into the owner).
         if (!(target.parent instanceof Node) || Node.isSceneDialog(target)) {
             return false;
         }
-        let targetUnderOwner: BrsType = target;
-        while (targetUnderOwner instanceof Node && targetUnderOwner !== owner) {
-            targetUnderOwner = targetUnderOwner.parent;
-        }
-        return targetUnderOwner !== owner;
+        return true;
     }
 
     /**
-     * Whether `node` is the dialog the scene is currently showing (or sits inside it).
-     *
-     * `Scene.dialog` tracks the live modal directly, so this needs no `Dialog`/`StandardDialog`
-     * import — which would be a cycle, since both extend `Group`.
+     * Whether the upward walk from `node` reaches `ancestor` (`node` itself counts).
+     * @param ancestor Node to test membership against.
+     * @param node Node (or non-Node value) to walk up from.
+     * @returns True when `node` is `ancestor` or nested somewhere below it.
+     */
+    private static isAncestorOrSelf(ancestor: Node, node: BrsType): boolean {
+        let current = node;
+        while (current instanceof Node) {
+            if (current === ancestor) {
+                return true;
+            }
+            current = current.parent;
+        }
+        return false;
+    }
+
+    /**
+     * Whether `node` is the dialog the scene is currently showing, or sits inside it.
      * @param node Node to test.
      * @returns True when the node is the current scene dialog or one of its descendants.
      */
     private static isSceneDialog(node: Node): boolean {
         const dialog = sgRoot.scene?.dialog;
-        if (!dialog) {
-            return false;
-        }
-        let ancestor: BrsType = node;
-        while (ancestor instanceof Node) {
-            if (ancestor === dialog) {
-                return true;
-            }
-            ancestor = ancestor.parent;
-        }
-        return false;
+        return dialog instanceof Node && Node.isAncestorOrSelf(dialog, node);
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -92,6 +92,18 @@ export class Node extends RoSGNode implements BrsValue {
      * focus onward) from a focus-loss one (whose focus requests a Roku ignores).
      */
     private static readonly focusNotifyOwners: Node[] = [];
+
+    /**
+     * Whether a `focusedChild` notification is dispatching right now, i.e. a focus transaction is on
+     * the stack and a nested `setFocus` raised from here can still be classified by
+     * `isFocusRequestDropped`.
+     *
+     * Read by `ArrayGrid.setNodeFocus` to decide whether its focus-gain settle must dispatch inline:
+     * only then does the timing matter, because only then is there a transaction to defend.
+     */
+    static inFocusNotification(): boolean {
+        return Node.focusNotifyOwners.length > 0;
+    }
     /**
      * Set while a focus transaction stages its `focusedChild` writes: `setValue` applies the value
      * but routes the notification here instead of dispatching it — see `stageFocusedChild`.
@@ -1329,7 +1341,7 @@ export class Node extends RoSGNode implements BrsValue {
      * @returns Whether the node is focusable.
      */
     setNodeFocus(focusOn: boolean): boolean {
-        if (focusOn && Node.isFocusRequestDropped()) {
+        if (focusOn && Node.isFocusRequestDropped(this)) {
             // Device-measured: Roku ignores a focus request raised from a focus-LOSS notification
             // (see notifyStagedFocus). Report the request as not applied, so a subclass override
             // gated on `super.setNodeFocus(...)` skips its focus bookkeeping too (an ArrayGrid must
@@ -1492,20 +1504,48 @@ export class Node extends RoSGNode implements BrsValue {
      * pointing at different nodes.
      * @returns True when the in-flight notification is a focus loss, so the request is ignored.
      */
-    private static isFocusRequestDropped(): boolean {
+    private static isFocusRequestDropped(target: Node): boolean {
         const owner = Node.focusNotifyOwners.at(-1);
         const focused = sgRoot.focused;
         if (!owner || !(focused instanceof Node)) {
             return false;
         }
-        // Is the owner still in the focus chain? Cheap upward walk from the focused node, the same
-        // shape restoreFocusChainOnAttach uses — an O(subtree) descent would be walked on every
-        // focus request made from inside a notification.
-        let ancestor: BrsType = focused;
-        while (ancestor instanceof Node && ancestor !== owner) {
-            ancestor = ancestor.parent;
+        // Classify by BOTH the notifying owner and the TARGET.
+        //
+        // The rule `focus-probe2` established is (a): a nested request is dropped only when it targets
+        // a node OUTSIDE the subtree the in-flight transaction just focused, while redirecting focus
+        // WITHIN that subtree is allowed. "Within" means inside the notifying owner — forward focus
+        // routinely targets a SIBLING of the focused leaf (a container handing focus from its first
+        // child to another, which is how a dialog highlights its buttons), so testing only whether the
+        // target sits at-or-below the live focus is too strict and breaks that pattern.
+        //
+        // Two conditions, and both matter:
+        //   1. The owner must still be in the focus chain. A request from a node that just LOST focus
+        //      is the classic backwards steal (probe2 N3).
+        //   2. The target must be inside the owner's subtree. Otherwise a container that observes its
+        //      own `focusedChild`, redirects focus to its inner list, and then has the list's
+        //      focus-gain settle run an app observer that re-grabs focus to an unrelated sibling would
+        //      slip through: the owner IS still in the chain (focus went to its own child), so
+        //      condition 1 alone reads that steal as a legal forward focus and strands the app on the
+        //      node it was navigating away from.
+        if (target === focused) {
+            // Re-asserting the node that just took focus is idempotent, never a steal (probe2 N4).
+            return false;
         }
-        return ancestor !== owner;
+        // Cheap upward walks, the same shape restoreFocusChainOnAttach uses — an O(subtree) descent
+        // would run on every nested focus request.
+        let ownerInChain: BrsType = focused;
+        while (ownerInChain instanceof Node && ownerInChain !== owner) {
+            ownerInChain = ownerInChain.parent;
+        }
+        if (ownerInChain !== owner) {
+            return true;
+        }
+        let targetUnderOwner: BrsType = target;
+        while (targetUnderOwner instanceof Node && targetUnderOwner !== owner) {
+            targetUnderOwner = targetUnderOwner.parent;
+        }
+        return targetUnderOwner !== owner;
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -94,15 +94,42 @@ export class Node extends RoSGNode implements BrsValue {
     private static readonly focusNotifyOwners: Node[] = [];
 
     /**
-     * Whether a `focusedChild` notification is dispatching right now, i.e. a focus transaction is on
-     * the stack and a nested `setFocus` raised from here can still be classified by
-     * `isFocusRequestDropped`.
+     * The `focusedChild` notification dispatching right now, if any — the context a nested
+     * `setFocus` is classified against by `isFocusRequestDropped`.
      *
-     * Read by `ArrayGrid.setNodeFocus` to decide whether its focus-gain settle must dispatch inline:
-     * only then does the timing matter, because only then is there a transaction to defend.
+     * Captured by `Field.executeCallbacks` when it DEFERS an emission raised inside a focus
+     * transaction, so the classification survives the wait; see `runWithFocusNotifyOwner`.
      */
-    static inFocusNotification(): boolean {
-        return Node.focusNotifyOwners.length > 0;
+    static currentFocusNotifyOwner(): Node | undefined {
+        return Node.focusNotifyOwners.at(-1);
+    }
+
+    /**
+     * Runs `body` with `owner` reinstated as the in-flight `focusedChild` notification.
+     *
+     * A grid's focus-gain settle (`itemFocused`/`rowItemFocused`) is an engine emission, so when it is
+     * raised inside another observer it defers to the end of that handler (see `executeCallbacks`) —
+     * but by then the focus transaction has left the stack, and a `setFocus` raised from the settle's
+     * observer could no longer be told apart from an ordinary app-initiated one. That is how a
+     * backwards steal used to win the live focus: an app re-grabbing focus from its `rowItemFocused`
+     * handler (an overlay re-showing itself) stranded the user on the node being navigated away from.
+     *
+     * Restoring the captured owner around the deferred dispatch keeps the drop rule applicable
+     * without changing WHEN the observer runs — deferral is what stops a later list's handler from
+     * running while an earlier `content` is still `invalid` (`deferred-observer-app`).
+     * @param owner Notification owner captured at defer time, or undefined if there was none.
+     * @param body Deferred dispatch to run.
+     */
+    static runWithFocusNotifyOwner<T>(owner: Node | undefined, body: () => T): T {
+        if (!owner) {
+            return body();
+        }
+        Node.focusNotifyOwners.push(owner);
+        try {
+            return body();
+        } finally {
+            Node.focusNotifyOwners.pop();
+        }
     }
     /**
      * Set while a focus transaction stages its `focusedChild` writes: `setValue` applies the value

--- a/test/cli/cli-scenegraph.test.js
+++ b/test/cli/cli-scenegraph.test.js
@@ -1197,6 +1197,56 @@ describe.concurrent("cli scenegraph", () => {
         ]);
     }, 30000);
 
+    it("Classifies a focus request raised from a container's redirect settle", async () => {
+        let command = ["node", brsCliPath, "-r container-redirect-focus-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // The container-redirect shape from `test/simulator/probes/list-refocus-settle-probe` (R7): a
+        // container observes its own focusedChild, redirects focus down to an inner list, and the
+        // list's focus-gain settle runs an app observer. What that observer may do is the whole test:
+        //   1. re-grabbing focus OUTSIDE the container is a backwards steal and is dropped, so the
+        //      list keeps focus (honoring it stranded the app on the node it was leaving).
+        //   2. focusing a component that focuses itself from init(), or the scene's dialog, is NOT a
+        //      steal - neither is parented inside the container when the request is raised, so a
+        //      target-subtree test alone would silently swallow both.
+        //   3. a focus-LOSS observer re-asserting the node that is TAKING focus is still dropped, so
+        //      the transaction is not re-run and itemFocused fires exactly once (a second fire
+        //      re-triggers app side effects like starting preview playback).
+        //   4. the settle still DEFERS. This is `deferred-observer-app`'s crash shape re-triggered
+        //      from a focusedChild notification: each list's settle observer reads a third list whose
+        //      content is assigned last, so dispatching them inline crashes on dot-of-invalid.
+        // (4) is why the classification travels with the queued entry
+        // (Node.runWithFocusNotifyOwner) instead of the settle being forced to dispatch synchronously
+        // - buying (1) that way re-creates the very reentrancy the deferral exists to prevent.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Container Redirect Focus Repro ===",
+            "-- scenario 1",
+            "   after setFocus: listInChain=true overlayFocus=false",
+            "   onItemFocused index= 0 fireCount= 1",
+            "   steal: listInChain=true overlayFocus=false",
+            "-- scenario 2",
+            "   after setFocus: listInChain=true overlayFocus=false",
+            "   onItemFocused index= 0 fireCount= 1",
+            "   selfFocusingPage hasFocus=true",
+            "   dialog inFocusChain=true",
+            "-- scenario 3",
+            "   onItemFocused index= 0 fireCount= 1",
+            "-- scenario 4",
+            "   loader: start",
+            "   loader: done",
+            "   loader: observer sees loaderC count= 31",
+            "   loader: observer sees loaderC count= 31",
+            "   loader: observer sees loaderC count= 31",
+            "   loader: observer sees loaderC count= 31",
+            "=== Container Redirect Focus Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     it("ButtonGroup leaves custom (non-Button) children unmanaged", async () => {
         let command = ["node", brsCliPath, "-r buttongroup-custom-children-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/container-redirect-focus-app/components/MainScene.xml
+++ b/test/cli/resources/container-redirect-focus-app/components/MainScene.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Pins the focus-steal classification for the container-redirect shape, measured on device in
+    `test/simulator/probes/list-refocus-settle-probe` (R7).
+
+    A container observes its own `focusedChild` and redirects focus down to an inner list. The list's
+    focus-gain settle (`itemFocused`) then runs an app observer. What that observer is allowed to do
+    is the whole point:
+
+      1. re-grabbing focus to a node OUTSIDE the container -> a backwards steal, DROPPED. Honoring it
+         strands the app on the node it was navigating away from (the reported symptom: an overlay
+         stays up and keeps taking the remote).
+      2. focusing a component whose `init()` focuses itself, or the scene's `dialog` -> NOT steals.
+         Neither is parented inside the container when the request is raised, so a target-subtree test
+         alone would silently swallow both.
+      3. a focus-LOSS observer re-asserting the node that is TAKING focus -> still dropped, so the
+         focus transaction is not re-run and `itemFocused` fires exactly once.
+
+    All three run from a real focus transaction (a top-level field write), and the settle that carries
+    them is DEFERRED - which is what makes this a regression test for the classification surviving the
+    deferral rather than the settle being forced to dispatch inline. Forcing it inline instead
+    re-creates the reentrancy crash `deferred-observer-app` pins.
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="runScenario" type="integer" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.focusedCount = 0
+
+        ' A sibling of the container, standing in for the app's overlay.
+        m.overlay = createObject("roSGNode", "Group")
+        m.overlay.focusable = true
+        m.top.appendChild(m.overlay)
+
+        m.container = createObject("roSGNode", "Group")
+        m.container.focusable = true
+        m.list = createObject("roSGNode", "LabelList")
+        m.container.appendChild(m.list)
+        m.top.appendChild(m.container)
+
+        m.list.content = buildContent(4)
+        m.container.observeField("focusedChild", "onContainerFocus")
+        m.list.observeField("itemFocused", "onItemFocused")
+        m.overlay.observeField("focusedChild", "onOverlayFocusChange")
+
+        ' Scenario 4's tree: a container whose focusedChild observer loads three lists.
+        m.loaderContainer = createObject("roSGNode", "Group")
+        m.loaderContainer.focusable = true
+        m.loaderA = createObject("roSGNode", "LabelList")
+        m.loaderB = createObject("roSGNode", "LabelList")
+        m.loaderC = createObject("roSGNode", "LabelList")
+        m.loaderContainer.appendChild(m.loaderA)
+        m.loaderContainer.appendChild(m.loaderB)
+        m.loaderContainer.appendChild(m.loaderC)
+        m.top.appendChild(m.loaderContainer)
+        m.loaderA.observeField("itemFocused", "onLoaderFocused")
+        m.loaderB.observeField("itemFocused", "onLoaderFocused")
+        m.loaderContainer.observeField("focusedChild", "onLoaderContainerFocus")
+
+        m.overlay.setFocus(true)
+        m.top.observeField("runScenario", "onRunScenario")
+    end sub
+
+    sub onRunScenario(event as object)
+        m.scenario = event.getData()
+        m.focusedCount = 0
+        print "-- scenario"; m.scenario
+        if m.scenario = 3
+            ' Scenario 3 needs focus to LEAVE the overlay, so the overlay's own focus-loss observer
+            ' is the one raising the nested request. Put focus back on the overlay first, undoing
+            ' whatever scenario 2 left focused.
+            m.top.dialog = invalid
+            m.overlay.setFocus(true)
+            m.focusedCount = 0
+            m.list.setFocus(true)
+            return
+        end if
+        if m.scenario = 4
+            ' Focus the deferral-check container, whose observer runs the multi-list load below.
+            m.loaderContainer.setFocus(true)
+            return
+        end if
+        ' Scenarios 1 and 2: hand focus to the container, which redirects inward.
+        m.container.setFocus(true)
+        print "   after setFocus: listInChain="; m.list.isInFocusChain(); " overlayFocus="; m.overlay.hasFocus()
+    end sub
+
+    ' Scenario 4 pins that the settle still DEFERS. This is `deferred-observer-app`'s crash shape with
+    ' its trigger changed to a focusedChild notification: content + setFocus on two lists before the
+    ' third list's content is assigned, where each focus-gain settle's observer reads that third
+    ' list. Dispatching those settles inline runs them while `loaderC.content` is still invalid ->
+    ' dot-on-invalid crash. So the steal classification must NOT be bought by forcing the settle
+    ' synchronous; it has to travel with the deferred entry instead.
+    sub onLoaderContainerFocus(event as object)
+        if not m.loaderContainer.hasFocus() then return
+        print "   loader: start"
+        m.loaderA.content = buildContent(6)
+        m.loaderA.setFocus(true)
+        m.loaderA.jumpToItem = 3
+        m.loaderB.content = buildContent(12)
+        m.loaderB.setFocus(true)
+        m.loaderB.jumpToItem = 5
+        ' Assigned LAST, after the focus moves above have queued their observers.
+        m.loaderC.content = buildContent(31)
+        print "   loader: done"
+    end sub
+
+    sub onLoaderFocused(event as object)
+        print "   loader: observer sees loaderC count="; m.loaderC.content.getChildCount()
+    end sub
+
+    ' The container's redirect. After this the container is a PROPER ANCESTOR of the focused node,
+    ' which is the shape the target test gates on.
+    sub onContainerFocus(event as object)
+        if m.container.hasFocus() then m.list.setFocus(true)
+    end sub
+
+    ' Runs from the list's focus-gain settle, which is deferred to this handler's boundary.
+    sub onItemFocused(event as object)
+        m.focusedCount = m.focusedCount + 1
+        print "   onItemFocused index="; event.getData(); " fireCount="; m.focusedCount
+        if m.scenario = 1
+            ' A backwards steal: target sits outside the container the transaction just focused.
+            m.overlay.setFocus(true)
+            print "   steal: listInChain="; m.list.isInFocusChain(); " overlayFocus="; m.overlay.hasFocus()
+        else if m.scenario = 2
+            ' (a) a component that focuses itself from init(), before it is parented.
+            page = createObject("roSGNode", "SelfFocusingPage")
+            m.container.appendChild(page)
+            print "   selfFocusingPage hasFocus="; page.hasFocus()
+            ' (b) the scene's modal dialog, parented to the Scene rather than to the container.
+            dialog = createObject("roSGNode", "StandardDialog")
+            m.top.dialog = dialog
+            dialog.setFocus(true)
+            print "   dialog inFocusChain="; dialog.isInFocusChain()
+        end if
+    end sub
+
+    ' Scenario 3: a focus-LOSS observer re-asserting the node that is taking focus. Dropped, so the
+    ' focus transaction does not re-run and itemFocused is not published a second time.
+    sub onOverlayFocusChange(event as object)
+        if m.scenario = 3 and not m.overlay.hasFocus() and m.list.isInFocusChain()
+            m.list.setFocus(true)
+        end if
+    end sub
+
+    function buildContent(count as integer) as object
+        content = createObject("roSGNode", "ContentNode")
+        for i = 1 to count
+            item = createObject("roSGNode", "ContentNode")
+            item.title = i.toStr()
+            content.appendChild(item)
+        end for
+        return content
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/container-redirect-focus-app/components/SelfFocusingPage.xml
+++ b/test/cli/resources/container-redirect-focus-app/components/SelfFocusingPage.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    A page that focuses itself from init(). init() runs BEFORE the node is appended to its parent,
+    so `m.top.parent` is still invalid at this point - the shape scenario 2 measures.
+-->
+<component name="SelfFocusingPage" extends="Group">
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.focusable = true
+        m.top.setFocus(true)
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/container-redirect-focus-app/manifest
+++ b/test/cli/resources/container-redirect-focus-app/manifest
@@ -1,0 +1,4 @@
+title=Container Redirect Focus Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/container-redirect-focus-app/source/main.brs
+++ b/test/cli/resources/container-redirect-focus-app/source/main.brs
@@ -1,0 +1,27 @@
+sub Main()
+    print "=== Container Redirect Focus Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Each trigger runs one scenario from a top-level field write, so every nested focus request
+    ' below is raised from inside a real focus transaction rather than during init().
+    scene.runScenario = 1
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    scene.runScenario = 2
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    scene.runScenario = 3
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    scene.runScenario = 4
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    print "=== Container Redirect Focus Repro Complete ==="
+end sub

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -65,4 +65,79 @@ describe("SceneGraph focus management", () => {
         expect(focusedDuringALosingFocus).toBe(buttonB);
         expect(sgRoot.focused).toBe(buttonB);
     });
+    test("drops a backwards steal raised from a container's own focusedChild observer", () => {
+        // Device-measured shape (test/simulator/probes/list-refocus-settle-probe, R7): a container
+        // observes its own `focusedChild` and redirects focus to an inner child; something reached
+        // from that notification then re-grabs focus to an unrelated SIBLING of the container. That
+        // target sits outside the subtree the in-flight transaction just focused, so it is a backwards
+        // steal and must be dropped.
+        //
+        // Regression for an owner-keyed classifier: the container IS still in the focus chain (focus
+        // went to its own child), so testing only the notifying owner reads this as a legal forward
+        // focus and honors it — leaving the app focused on the node it was navigating away from.
+        const scene = focusableNode();
+        const container = focusableNode();
+        const inner = focusableNode();
+        const sibling = focusableNode();
+        scene.appendChildToParent(container);
+        container.appendChildToParent(inner);
+        scene.appendChildToParent(sibling);
+
+        sibling.setNodeFocus(true);
+
+        // The container redirects focus inward, then steals it back out to the sibling.
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        let redirected = false;
+        port.pushMessage = (event) => {
+            if (!redirected && container.isChildrenFocused() === false && sgRoot.focused === container) {
+                redirected = true;
+                inner.setNodeFocus(true);
+                // Raised while the container's notification is still dispatching: a backwards steal.
+                sibling.setNodeFocus(true);
+            }
+            originalPush(event);
+        };
+        container.fields
+            .get("focusedchild")
+            .addObserver("permanent", fakeInterpreter, port, container, focusedChildFieldArg);
+
+        container.setNodeFocus(true);
+
+        // The steal is dropped: focus stays where the redirect put it.
+        expect(sgRoot.focused).toBe(inner);
+        expect(sibling.getValueJS("focusable")).toBe(true);
+    });
+
+    test("still honors a forward focus onto a sibling of the focused child", () => {
+        // The mirror case that must keep working: a container hands focus from its first child to
+        // another of its own children (how a dialog highlights a specific button). The target is a
+        // SIBLING of the live focus, not a descendant of it, so a target-must-be-below-focus test
+        // would wrongly drop this.
+        const scene = focusableNode();
+        const container = focusableNode();
+        const childA = focusableNode();
+        const childB = focusableNode();
+        scene.appendChildToParent(container);
+        container.appendChildToParent(childA);
+        container.appendChildToParent(childB);
+
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        let forwarded = false;
+        port.pushMessage = (event) => {
+            if (!forwarded && sgRoot.focused === childA) {
+                forwarded = true;
+                childB.setNodeFocus(true);
+            }
+            originalPush(event);
+        };
+        container.fields
+            .get("focusedchild")
+            .addObserver("permanent", fakeInterpreter, port, container, focusedChildFieldArg);
+
+        childA.setNodeFocus(true);
+
+        expect(sgRoot.focused).toBe(childB);
+    });
 });

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -140,4 +140,41 @@ describe("SceneGraph focus management", () => {
 
         expect(sgRoot.focused).toBe(childB);
     });
+    test("honors a redirect out of a node observing its OWN focus gain", () => {
+        // The "I got focus but have nothing to show, pass it on" pattern: a node observes its own
+        // focusedChild and hands focus to a sibling (or up to its container). The focus transaction
+        // stages focusedChild on the focused leaf itself, so that leaf is also an `owner` — and an
+        // over-broad "target must be inside the owner's subtree" test dropped both redirects, which is a
+        // regression against long-standing behavior that focus-probe2 never covered (N1/N2 only measured
+        // forward focus INTO a container's subtree). The subtree test applies only when the owner is a
+        // PROPER ANCESTOR of the focused node, i.e. the container-redirect shape.
+        for (const targetIsSibling of [true, false]) {
+            sgRoot.setFocused();
+            const scene = focusableNode();
+            const container = focusableNode();
+            const leaf = focusableNode();
+            const sibling = focusableNode();
+            scene.appendChildToParent(container);
+            container.appendChildToParent(leaf);
+            container.appendChildToParent(sibling);
+
+            // Sibling redirect targets a peer; the other case hands focus UP to the container.
+            const redirectTo = targetIsSibling ? sibling : container;
+            const port = new RoMessagePort();
+            const originalPush = port.pushMessage.bind(port);
+            let redirected = false;
+            port.pushMessage = (event) => {
+                if (!redirected && sgRoot.focused === leaf) {
+                    redirected = true;
+                    redirectTo.setNodeFocus(true);
+                }
+                originalPush(event);
+            };
+            leaf.fields.get("focusedchild").addObserver("permanent", fakeInterpreter, port, leaf, focusedChildFieldArg);
+
+            leaf.setNodeFocus(true);
+
+            expect(sgRoot.focused).toBe(redirectTo);
+        }
+    });
 });

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -177,4 +177,44 @@ describe("SceneGraph focus management", () => {
             expect(sgRoot.focused).toBe(redirectTo);
         }
     });
+
+    test("drops a focus-loss observer re-asserting the node that is taking focus", () => {
+        // The "refresh focus" router pattern: a node's focus-LOSS observer calls setFocus on whatever
+        // it believes should be focused, which is the node currently TAKING focus. That must stay
+        // dropped like any other loss-observer request. Honoring it re-runs the whole focus
+        // transaction — `focusedChild` is alwaysNotify — so every observer fires a second time, and an
+        // ArrayGrid re-publishes its `itemFocused` settle, spuriously re-triggering an app side effect
+        // such as starting preview playback.
+        //
+        // Regression for testing `target === focused` BEFORE the owner-in-chain check: that ordering
+        // widens the honored set, because re-asserting the incoming node looks idempotent while the
+        // request is in fact coming from the outgoing one.
+        const parent = focusableNode();
+        const leaving = focusableNode();
+        const arriving = focusableNode();
+        parent.appendChildToParent(leaving);
+        parent.appendChildToParent(arriving);
+
+        leaving.setNodeFocus(true);
+
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        let transactions = 0;
+        port.pushMessage = (event) => {
+            if (sgRoot.focused !== leaving) {
+                transactions++;
+                arriving.setNodeFocus(true);
+            }
+            originalPush(event);
+        };
+        leaving.fields
+            .get("focusedchild")
+            .addObserver("permanent", fakeInterpreter, port, leaving, focusedChildFieldArg);
+
+        arriving.setNodeFocus(true);
+
+        // The re-assert is dropped, so the loss notification is not dispatched a second time.
+        expect(transactions).toBe(1);
+        expect(sgRoot.focused).toBe(arriving);
+    });
 });

--- a/test/simulator/probes/list-refocus-settle-probe/README.md
+++ b/test/simulator/probes/list-refocus-settle-probe/README.md
@@ -1,0 +1,265 @@
+# List Refocus Settle Probe
+
+Measures **whether** and **when** a `RowList` re-publishes its focus-settle fields (`itemFocused`,
+`itemUnfocused`, `currFocusRow`, `currFocusColumn`, `rowItemFocused`, `scrollingStatus`) when the list
+is handed focus **without its focused position having moved** — so brs-engine can be made to match.
+
+## Why this shape
+
+A common app pattern parents an overlay as a **sibling** of a list and re-shows that overlay from an
+observer on the list's `rowItemFocused`. Crucially, such an observer reads the field **live off the
+node**, not from `event.getData()`.
+
+A key handler that navigates *out of* the overlay must hand focus to the list **before** moving a row
+(a necessary ordering: the list's container may `jumpToItem` when focus changes). So the handler is:
+
+```brightscript
+row = list.currFocusRow
+container.setFocus(true)      ' (A) hand focus over FIRST
+list.animateToItem = row + 1  ' (B) then move a row
+hideOverlay()                 ' (C) fade the overlay out
+```
+
+Everything then hinges on **when** the focus-gain settle is delivered:
+
+| Delivery | Live read sees | Result |
+| --- | --- | --- |
+| synchronously, inside step (A) | the **outgoing** row | the observer re-shows the very overlay (C) is about to hide, and re-grabs focus with it |
+| from the message loop, after the handler | the **moved-to** row | the overlay is not re-shown |
+
+The app also focuses a **container**, never the list directly — the container's own `focusedChild`
+observer redirects focus inward. That intermediate observer turns out to matter (see Findings), so the
+probe measures both call shapes.
+
+## Run it on the Roku
+
+1. Zip the app:
+
+   ```
+   cd test/simulator/probes/list-refocus-settle-probe && zip -r ../list-refocus-settle-probe.zip manifest source components
+   ```
+
+2. Sideload: browse to `http://<roku-ip>` → Development Application Installer → upload
+   `list-refocus-settle-probe.zip` → **Replace**.
+
+3. Capture the trace **before the app finishes** — open a second terminal first:
+
+   ```
+   telnet <roku-ip> 8085 | tee device-trace.txt
+   ```
+
+   (or `nc <roku-ip> 8085 | tee device-trace.txt`)
+
+4. The app auto-runs R1–R5 over about 10 seconds. When it prints
+
+   ```
+   PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote.
+   ```
+
+   press **Down** once, then **Back**. Back exits the probe.
+
+5. Send back `device-trace.txt` (the `PROBE|` lines are enough).
+
+Capture the engine side with:
+
+```
+node packages/node/bin/brs.cli.js -r test/simulator/probes/list-refocus-settle-probe -c 0 -e
+```
+
+then `curl -X POST http://localhost:8060/keypress/Down` for the R6 press (and `.../Back` to exit).
+`engine-trace.txt` in this folder was captured that way.
+
+## What each scenario answers
+
+| Scenario | Question |
+|---|---|
+| `R1-first-focus` | Content loaded while unfocused, then the first `setFocus(true)`. Which fields fire? (The one case already pinned: focus genuinely moves onto item 0.) |
+| `R2-refocus-unchanged` | Move to row 1, park focus on a sibling, hand focus **back** with the position unchanged. **Does the settle re-fire at all?** And does its record land between `before`/`after` (synchronous) or after `after` (message loop)? |
+| `R3-focus-then-move` | The app's (A)→(B) sequence in one handler, via the **container**, driven from a Timer observer. Which row does the observer's **live** read see? |
+| `R4-refocus-after-horiz` | Same as R2 after a horizontal-only move (column changed, row did not). |
+| `R5-unfocused-jump` | `jumpToRowItem` written while unfocused — silent at the time, but is the recorded position published on the next focus-gain? |
+| `R6-key-down` | The same (A)→(B)→(C) sequence driven from **`onKeyEvent`** rather than a Timer observer. A key handler starts at observer depth zero, which can move where a deferred notification drains. |
+| `R7-key-down-regrab` | The **complete** app behavior: the re-show also **re-focuses** the overlay. That is a nested `setFocus` targeting a node *outside* the chain the in-flight `setFocus` just committed — a "backwards steal". `focus-probe2` established a device drops those. Is it dropped here, and if it is honored, does the (B) row move go silent? |
+
+`R2` + `R6` decide the fix; `R1`/`R5` guard rules that are already pinned
+(`test/cli/resources/list-initial-focus-app`).
+
+## Trace format
+
+```
+PROBE|<seq>|<scenario>|<point>|<key=value ...>
+```
+
+Live state accompanies every record — this read-back is the whole point, since it is what the app
+does:
+
+- `liveRIF` — `rowItemFocused` read live off the node, as `[row,col]`
+- `liveIF` / `liveIU` — `itemFocused` / `itemUnfocused`
+- `liveCFR` / `liveCFC` — `currFocusRow` / `currFocusColumn`
+- `listInChain` — `list.isInFocusChain()` (`T`/`F`)
+- `overlayFocus` — `overlay.hasFocus()`
+
+Special points:
+
+- `OBS-<field>` — that field's observer fired. `data=` is the event payload; compare it against
+  `liveRIF` on the same line — a disagreement means the notification arrived *after* a later move.
+- `OBS-containerFocus-redirect` / `-done` — the container's `focusedChild` observer handing focus down
+  to the list (the app's intermediate observer).
+- **`WOULD-RESHOW`** — the failure reproducing. The `rowItemFocused` observer's **live** read still
+  reports the overlay's row, so an app would re-show the overlay (and re-grab focus) at the exact
+  moment its handler is trying to hide it.
+
+Because each scenario is stepped from a repeating `Timer`, synchronous vs. deferred dispatch is
+directly visible: a synchronous notification prints **between** a scenario's `before` and `after`
+records; a message-loop one prints **after** `after`.
+
+## Engine findings (pre-fix baseline, `engine-trace.txt`)
+
+`engine-trace.txt` is captured **before** the fix on purpose: it is the record of the bug, so R7 there
+still shows the steal being honored (`listInChain=T` → `F`). Re-running the probe on a fixed build shows
+record 156 as `listInChain=T overlayFocus=F` instead.
+
+Captured against the engine as of this probe's commit. **The device trace is what decides the fix** —
+these are the numbers to diff against.
+
+1. **The settle re-fires for an unchanged position.** `R2-refocus-unchanged` (records 017-018) emits
+   `itemFocused=1` and `rowItemFocused=[1,0]` even though the focused row never moved. Same in
+   `R4` (039-040) and `R5` (056-057). Source: `ArrayGrid.setNodeFocus` unconditionally re-runs
+   `setFocusedItem(itemFocused)` on focus-gain.
+
+2. **The bug reproduces only on the key-driven path.** `R6-key-down` (064-076) is the failure:
+
+   ```
+   064 A-before-setFocus              row=0, overlay focused
+   065 OBS-containerFocus-redirect    container hands focus down to the list
+   067 OBS-itemFocused      data=0    <- settle fires INSIDE step (A)
+   068 OBS-rowItemFocused   data=[0,0]   liveRIF=[0,0]
+   069 WOULD-RESHOW         liveRow=0 <- overlay re-shown before the row ever moves
+   070 A-after-setFocus
+   071-074                            (B) finally moves the row to 1
+   076 C-hide-overlay                 too late: 069 already re-grabbed focus
+   ```
+
+3. **The Timer-driven path does *not* reproduce it** — `R3-focus-then-move` (032-033) shows a stale
+   payload (`data=[0,0]`) but a live read of `[2,0]`, so no `WOULD-RESHOW`.
+
+4. **Why the two differ — the drain boundary depends on the caller's observer depth.** The settle is
+   emitted under `Field.enterInternalUpdate()`, so a reentrant notification is queued and drained by
+   `Field.executeCallbacks`, which only drains when `observerDepth === 1`
+   (`src/extensions/scenegraph/nodes/Field.ts:761`):
+
+   - **R6** — `onKeyEvent` is not a field observer, so it starts at depth **0**. The container's
+     `focusedChild` observer becomes depth 1 and therefore drains the queue at *its own* boundary —
+     still inside step (A), before the row moves.
+   - **R3** — `onStepTimer` is a `fire` observer, so it starts at depth **1**. The container observer
+     becomes depth 2, no drain happens there, and the queue drains only when the outer Timer observer
+     unwinds — by which time (B) has moved the row.
+
+   The delivery point of a focus-gain settle should not depend on whether the caller happens to be
+   inside another observer. That depth-sensitivity is the engine artifact this probe pins.
+
+## Device findings (`device-trace.txt`, Roku Streaming Stick+ / OS 15.3)
+
+The device measurement **refutes both** candidate fixes that were on the table.
+
+1. **A refocus on an unchanged position DOES re-emit the settle.** `R2-refocus-unchanged` (038-039)
+   emits `itemFocused=1` and `rowItemFocused=[1,0]` with the row unmoved; same in `R4` (106-107) and
+   `R5` (116-117). So suppressing the re-emission would diverge from the device — and would break the
+   app pattern that relies on `setFocus(true)` firing `rowItemFocused`.
+
+2. **That re-emission is SYNCHRONOUS, and the engine wrongly defers it.** On device the records land
+   *between* `before` and `after`; in the engine they land *after* `after`:
+
+   | | device | engine |
+   | --- | --- | --- |
+   | `R1` | 004-005 before `after`(007) | 004-005 after `after`(003) |
+   | `R2` | 038-039 before `after`(040) | 017-018 after `after`(016) |
+   | `R4` | 106-107 before `after`(108) | 039-040 after `after`(038) |
+   | `R5` | 116-117 before `after`(119) | 048-049 after `after`(047) |
+
+   Consistent in all four. So deferring the settle to the message loop is the **wrong direction** —
+   the engine already defers it and should not.
+
+3. **`WOULD-RESHOW` fires on the device too** (`R6` record 128, matching engine 069). The overlay
+   being re-shown at step (A) is therefore **not** the divergence — it is what a real Roku does.
+
+4. **The real divergence is that `animateToItem` is instantaneous in the engine but animated on
+   device**, so the move's settle lands on opposite sides of the key handler:
+
+   | | device | engine |
+   | --- | --- | --- |
+   | (B) `animateToItem` | starts an animation; `scrollingStatus=T` (131), `itemUnfocused` (132) | completes instantly |
+   | `currFocusRow` | ~20 fractional steps (135-154), spanning frames | one jump to `1` (072) |
+   | settle for the NEW row | `itemFocused=1` (155), `rowItemFocused=[1,0]` (157) — **after** the handler returned at 134 | (073-074) — **inside** the handler, before (C) |
+
+   On device the whole move outlives the key handler; in the engine it finishes within it. That is
+   what changes the state the app's (C) fade-out and its `isInFocusChain()` completion guard observe.
+
+5. Minor, noted not fixed here: `currFocusColumn` defaults to `-1` on device, `0` in the engine
+   (record 001); and the device emits a `currFocusRow=0` at init (002) that the engine does not.
+
+### R7 — the actual failure, and the fix
+
+`R7` arms the half the earlier scenarios omitted: the app's re-show does not merely make the overlay
+visible, it calls `setFocus(true)` on it. That is a **backwards steal** — a nested focus request targeting
+a node outside the subtree the in-flight transaction just focused.
+
+Pre-fix engine trace:
+
+```
+150 A-before-setFocus              row=0  listInChain=F overlayFocus=T
+151 OBS-containerFocus-redirect     container hands focus down to the list
+152 OBS-itemFocused      data=0     the focus-gain settle (device-correct per finding 1)
+153 OBS-rowItemFocused   data=[0,0]
+155 RESHOW-regrab                   nested overlay.setFocus(true)   <-- BACKWARDS STEAL
+156 RESHOW-regrab-done              listInChain=T -> F               <-- HONORED
+158 A-after-setFocus                the list already lost focus, inside step (A)
+161 B-after-animateToItem           row moved but listInChain=F -> published SILENTLY
+162 C-hide-overlay                  overlay still holds focus
+```
+
+Because the steal is honored the list leaves the focus chain **inside step (A)**, so (B)'s row move takes
+the silent path and the app never learns the row changed; the overlay keeps focus, and an app whose
+fade-out completion guard is `isInFocusChain() = false` never passes it. That is the reported symptom:
+the overlay stays on screen, and left/right keeps operating the overlay instead of the list.
+
+**Why the drop rule missed it.** `Node.isFocusRequestDropped` exists to drop exactly this, but it asked
+whether the *notifying owner* was still in the focus chain. Here the owner is the container, which **is**
+still in the chain — focus went to its own child — so the steal read as a legal forward focus. The rule
+`focus-probe2` established is about the **target**: dropped only when the target lies outside the subtree
+just focused. Both conditions are needed, and "inside the owner's subtree" is the right forward test,
+because forward focus routinely targets a *sibling* of the focused leaf (how a dialog highlights its
+buttons).
+
+**Fix** (`Node.isFocusRequestDropped`, `ArrayGrid.setNodeFocus`): classify by owner **and** target, and
+dispatch the focus-gain settle synchronously while a `focusedChild` notification is on the stack — the
+only window in which the steal can be classified at all. Finding 2 above is what makes that second half
+necessary: a deferred settle escapes the rule entirely. It is scoped to that window, because forcing a
+plain app `setFocus`'s settle inline re-creates the reentrancy the deferral exists to prevent
+(`deferred-observer-app`).
+
+Post-fix, record 156 reads `listInChain=T overlayFocus=F`: the steal is dropped, the list keeps focus,
+(B) publishes normally, and the sequence settles on the new row.
+
+**R6 is deliberately unchanged.** Its steal is raised after the settle has already drained, with no focus
+transaction on the stack, so nothing can classify it. That shape is not what the app does.
+
+Regressions: two tests in `test/extensions/scenegraph/Focus.test.js` — the steal case (fails without the
+target-keyed rule) and a companion forward-focus case that passes both ways, pinning that the rule does
+not over-drop.
+
+### Corrections recorded, so the trail is not re-walked
+
+Two conclusions drawn from earlier captures in this probe were **wrong**, and both are worth knowing
+because each cost a deploy:
+
+1. *"The device does not evict the list from the focus chain."* R7's `listInChain=T` was the container's
+   `focusedChild` observer re-redirecting focus into the list one record later (record 174 in the device
+   capture), not the steal being softened. A follow-up probe (`grid-scroll-animation-probe`, added with the
+   scroll-animation work) measured the steal in isolation and the device **does** evict. Consequence: the `.claude/docs/scenegraph-invariants.md`
+   "two nodes reporting focus at once is deliberately not modeled" decision **stands** — no focus-chain
+   model change was needed.
+2. *"Implementing scroll animation fixes this."* Finding 4 is a real divergence and worth fixing on its
+   own, but it does **not** fix this bug: A4/A5 show a focus steal is honored regardless, and an in-flight
+   animation neither stops nor returns focus on completion. Deploying animation alone made the symptom
+   worse — the visuals moved while focus stayed on the overlay.

--- a/test/simulator/probes/list-refocus-settle-probe/README.md
+++ b/test/simulator/probes/list-refocus-settle-probe/README.md
@@ -231,12 +231,29 @@ just focused. Both conditions are needed, and "inside the owner's subtree" is th
 because forward focus routinely targets a *sibling* of the focused leaf (how a dialog highlights its
 buttons).
 
-**Fix** (`Node.isFocusRequestDropped`, `ArrayGrid.setNodeFocus`): classify by owner **and** target, and
-dispatch the focus-gain settle synchronously while a `focusedChild` notification is on the stack — the
-only window in which the steal can be classified at all. Finding 2 above is what makes that second half
-necessary: a deferred settle escapes the rule entirely. It is scoped to that window, because forcing a
-plain app `setFocus`'s settle inline re-creates the reentrancy the deferral exists to prevent
-(`deferred-observer-app`).
+**Fix**, in two halves:
+
+1. **Classify by owner *and* target** (`Node.isFocusRequestDropped`). The target test applies only when
+   the owner is a *proper ancestor* of the focused node — the container shape. When the owner **is** the
+   focused node the transaction staged `focusedChild` on the leaf itself, so a redirect from there is the
+   ordinary "I got focus but have nothing to show, pass it on" pattern and must still be honored. Two
+   targets are likewise never steals, because they are not in the owner's tree when the request is
+   raised and a subtree walk would drop them: a node still unparented (a component focusing itself from
+   `init()`, which runs before `appendChild`) and the scene's `dialog` (parented to the Scene via
+   `setNodeParent`). The `target === focused` idempotence check is tested **after** the owner-in-chain
+   walk, never before — ahead of it, a focus-*loss* observer re-asserting the incoming node would be
+   honored, re-running the whole transaction and double-firing every observer.
+
+2. **Carry the classification through the deferral** (`Node.runWithFocusNotifyOwner`,
+   `Field.executeCallbacks`). Finding 2 above says the settle *should* dispatch synchronously, and that
+   was the first attempt — but the settle is also what carries an app's reentrant multi-list load, so
+   forcing it inline re-creates the crash `deferred-observer-app` pins (an earlier list's `content` is
+   still `invalid` when a later list's handler runs). The crash shape and this steal shape are both "a
+   container's `focusedChild` observer calls `setFocus` on a list", so no timing gate separates them.
+   Instead the queued entry remembers the notification it was raised under and reinstates it around the
+   deferred dispatch: the drop rule stays applicable without moving *when* the observer runs. Delivery
+   timing is therefore still the engine's (deferred), and finding 2 remains an open divergence —
+   independent of this bug, since the classification no longer depends on it.
 
 Post-fix, record 156 reads `listInChain=T overlayFocus=F`: the steal is dropped, the list keeps focus,
 (B) publishes normally, and the sequence settles on the new row.
@@ -244,9 +261,11 @@ Post-fix, record 156 reads `listInChain=T overlayFocus=F`: the steal is dropped,
 **R6 is deliberately unchanged.** Its steal is raised after the settle has already drained, with no focus
 transaction on the stack, so nothing can classify it. That shape is not what the app does.
 
-Regressions: two tests in `test/extensions/scenegraph/Focus.test.js` — the steal case (fails without the
-target-keyed rule) and a companion forward-focus case that passes both ways, pinning that the rule does
-not over-drop.
+Regressions: `test/extensions/scenegraph/Focus.test.js` (the steal case, which fails without the
+target-keyed rule; a forward-focus companion pinning that the rule does not over-drop; the own-focus-gain
+redirect; and the loss-observer re-assert) plus `container-redirect-focus-app` in
+`test/cli/cli-scenegraph.test.js`, which drives all four shapes end-to-end through the **deferred**
+settle — the unit tests use port observers, which never defer, so only the CLI fixture covers half 2.
 
 ### Corrections recorded, so the trail is not re-walked
 

--- a/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeItem.xml
+++ b/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeItem.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Minimal RowList item component. The probe measures field emission, not rendering, so this only
+    needs to be a valid itemComponentName target that shows which cell is focused.
+-->
+<component name="RefocusProbeItem" extends="Group">
+    <children>
+        <Rectangle id="bg" width="300" height="200" color="0x223344FF" />
+        <Label id="label" translation="[12, 12]" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.bg = m.top.findNode("bg")
+        m.label = m.top.findNode("label")
+        m.top.observeField("itemContent", "onItemContent")
+        m.top.observeField("itemHasFocus", "onItemHasFocus")
+    end sub
+
+    sub onItemContent()
+        if m.top.itemContent <> invalid
+            m.label.text = m.top.itemContent.title
+        end if
+    end sub
+
+    sub onItemHasFocus()
+        if m.top.itemHasFocus
+            m.bg.color = "0x4488CCFF"
+        else
+            m.bg.color = "0x223344FF"
+        end if
+    end sub
+    ]]></script>
+</component>

--- a/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeScene.xml
+++ b/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeScene.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    List Refocus Settle Probe.
+
+    Measures WHETHER and WHEN a RowList re-publishes its "focus settle" fields (itemFocused,
+    itemUnfocused, currFocusRow, currFocusColumn, rowItemFocused, scrollingStatus) when the list is
+    handed focus WITHOUT its focused position having moved.
+
+    Why this matters: a common app shape parents an overlay as a SIBLING of the list and re-shows it
+    from an observer on the list's `rowItemFocused`. That observer reads the field LIVE off the node
+    (not from event.getData()). A key handler that hands focus to the list BEFORE moving a row - a
+    necessary ordering, because a container may jumpToItem when focus changes - then depends entirely
+    on the delivery timing:
+
+      * settle dispatched SYNCHRONOUSLY inside setFocus() -> the live read sees the OUTGOING row, so
+        the observer re-shows the very overlay the handler is about to hide.
+      * settle dispatched from the MESSAGE LOOP -> by delivery time the row has moved, the live read
+        sees the new row, and the overlay is not re-shown.
+
+    Each scenario is stepped from a repeating Timer so the message loop drains in between. That is
+    what makes SYNCHRONOUS vs. DEFERRED dispatch visible: a synchronous notification prints BETWEEN
+    the "before" and "after" records of the call that caused it; a message-loop notification prints
+    AFTER "after".
+
+    TWO CALL SHAPES, and the difference is the point. The app never focuses the RowList directly: it
+    focuses a CONTAINER, whose own `focusedChild` observer redirects focus down to the inner list.
+    That intermediate observer changes where a deferred notification drains, so the probe measures
+    both:
+
+      * DIRECT   - `list.setFocus(true)`      (R2/R4/R5)
+      * INDIRECT - `container.setFocus(true)` -> container's focusedChild observer ->
+                   `list.setFocus(true)`      (R3, R6) - the real app's shape
+
+    Scenarios
+      R1  first focus-gain on a list whose content was loaded while unfocused
+      R2  DIRECT refocus after moving to row 1, focus parked on a sibling (does the settle re-fire?)
+      R3  INDIRECT, the app sequence in ONE handler: container.setFocus(true) then
+          animateToItem = row+1 (which row does an observer's LIVE read of rowItemFocused see?)
+      R4  DIRECT refocus after a horizontal-only move (column changed, row did not)
+      R5  jumpToRowItem written while unfocused, then focus (is the silent position published?)
+      R6  the same INDIRECT sequence driven from onKeyEvent instead of a Timer observer - the
+          genuine repro, since a key handler starts at observer depth zero
+-->
+<component name="RefocusProbeScene" extends="Scene">
+    <interface>
+        <field id="probeExit" type="boolean" value="false" />
+    </interface>
+    <children>
+        <!--
+            The container mirrors the real app: a Group that owns the list and redirects focus down
+            to it from its own focusedChild observer. Focusing the container - never the list - is
+            what the app's key handler does.
+        -->
+        <Group id="container">
+            <RowList
+                id="list"
+                itemComponentName="RefocusProbeItem"
+                itemSize="[1000, 240]"
+                rowItemSize="[[300, 200]]"
+                numRows="3"
+                translation="[100, 300]" />
+        </Group>
+        <!-- The overlay: a focusable SIBLING of the container, the shape the real failure has. -->
+        <Rectangle
+            id="overlay"
+            width="600"
+            height="160"
+            translation="[100, 100]"
+            color="0xCC7722FF"
+            focusable="true" />
+        <Timer id="stepTimer" duration="0.6" repeat="true" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.seq = 0
+        m.step = 0
+        m.scenario = "init"
+
+        m.list = m.top.findNode("list")
+        m.container = m.top.findNode("container")
+        m.overlay = m.top.findNode("overlay")
+        ' Tracks whether the overlay would be re-shown, i.e. whether a rowItemFocused observer that
+        ' reads the field LIVE decides the focused row is the overlay's row (row 0 here).
+        m.overlayRow = 0
+        ' Armed only for R7 - the re-focus half of the app's re-show. Left off for R1-R6 so those
+        ' scenarios measure emission/timing without focus churn confusing the picture.
+        m.regrabOnReshow = false
+
+        ' Content is loaded while the list is UNFOCUSED, as an async content Task does. Per the
+        ' documented rule this must NOT fire itemFocused - only the later focus-gain should.
+        content = createObject("roSGNode", "ContentNode")
+        for r = 0 to 2
+            row = content.createChild("ContentNode")
+            row.title = "Row" + str(r).trim()
+            for c = 0 to 1
+                item = row.createChild("ContentNode")
+                item.title = "R" + str(r).trim() + "C" + str(c).trim()
+            end for
+        end for
+        m.list.content = content
+
+        ' The container redirects focus inward, exactly as the real app's container does.
+        m.container.observeField("focusedChild", "onContainerFocusChange")
+
+        m.list.observeField("rowItemFocused", "onRowItemFocused")
+        m.list.observeField("itemFocused", "onItemFocused")
+        m.list.observeField("itemUnfocused", "onItemUnfocused")
+        m.list.observeField("currFocusRow", "onCurrFocusRow")
+        m.list.observeField("scrollingStatus", "onScrollingStatus")
+
+        p("init", "ready", ls())
+
+        m.stepTimer = m.top.findNode("stepTimer")
+        m.stepTimer.observeField("fire", "onStepTimer")
+        m.stepTimer.control = "start"
+    end sub
+
+    ' ---------------------------------------------------------------- trace helpers
+
+    sub p(scenario as string, point as string, detail = "" as string)
+        m.seq = m.seq + 1
+        num = "00" + str(m.seq).trim()
+        print "PROBE|" + Right(num, 3) + "|" + scenario + "|" + point + "|" + detail
+    end sub
+
+    function b(value as boolean) as string
+        if value then return "T"
+        return "F"
+    end function
+
+    ' Renders an int-array field (rowItemFocused) as [r,c], tolerating the empty default.
+    function arr(value as object) as string
+        if value = invalid then return "invalid"
+        if type(value) <> "roArray" then return "type:" + type(value)
+        if value.count() = 0 then return "[]"
+        out = "["
+        for i = 0 to value.count() - 1
+            if i > 0 then out = out + ","
+            out = out + str(value[i]).trim()
+        end for
+        return out + "]"
+    end function
+
+    ' The LIVE state read straight off the node - the whole point of this probe. An app's
+    ' rowItemFocused observer reads the field this way rather than from event.getData(), so this is
+    ' what decides whether it acts on the outgoing or the incoming row.
+    function ls() as string
+        return "liveRIF=" + arr(m.list.rowItemFocused) + " liveIF=" + str(m.list.itemFocused).trim() + " liveIU=" + str(m.list.itemUnfocused).trim() + " liveCFR=" + str(m.list.currFocusRow).trim() + " liveCFC=" + str(m.list.currFocusColumn).trim() + " listInChain=" + b(m.list.isInFocusChain()) + " overlayFocus=" + b(m.overlay.hasFocus())
+    end function
+
+    ' ---------------------------------------------------------------- observers
+    '
+    ' Every observer prints BOTH the event payload and the live read-back, so a payload/live
+    ' disagreement (the settle arriving after a subsequent move) is visible on one line.
+
+    ' The container's own focusedChild observer, redirecting focus down to the list. This is the
+    ' intermediate observer the real app has, and it matters: a notification raised inside it drains
+    ' at ITS boundary, not at the end of the outer key handler.
+    sub onContainerFocusChange()
+        if m.container.hasFocus()
+            p(m.scenario, "OBS-containerFocus-redirect", "calling list.setFocus(true) " + ls())
+            m.list.setFocus(true)
+            p(m.scenario, "OBS-containerFocus-done", ls())
+        end if
+    end sub
+
+    ' Models the app's decision precisely: read rowItemFocused LIVE off the node (NOT from
+    ' event.getData()) and re-show the overlay when the focused row is the overlay's row. A
+    ' "WOULD-RESHOW" record is the bug reproducing - the overlay being re-shown (and re-grabbing
+    ' focus) at the very moment the handler is trying to hide it.
+    sub onRowItemFocused(event as object)
+        p(m.scenario, "OBS-rowItemFocused", "data=" + arr(event.getData()) + " " + ls())
+        live = m.list.rowItemFocused
+        if live <> invalid and live.count() = 2 and live[0] = m.overlayRow
+            p(m.scenario, "WOULD-RESHOW", "liveRow=" + str(live[0]).trim() + " (overlay re-shown from a LIVE read)")
+            ' The app does not merely re-SHOW the overlay here - it also re-FOCUSES it. That is a
+            ' nested setFocus targeting a node OUTSIDE the chain just committed by the setFocus we
+            ' are currently notifying for, i.e. a "backwards steal". focus-probe2 established that a
+            ' real Roku DROPS such a request (while honoring a forward focus into the committed
+            ' chain). If it is honored instead, the list loses focus again and the (B) row move that
+            ' follows goes silent - which is what leaves the overlay stuck on screen.
+            if m.regrabOnReshow
+                p(m.scenario, "RESHOW-regrab", "calling overlay.setFocus(true) " + ls())
+                m.overlay.setFocus(true)
+                p(m.scenario, "RESHOW-regrab-done", ls())
+            end if
+        end if
+    end sub
+
+    sub onItemFocused(event as object)
+        p(m.scenario, "OBS-itemFocused", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onItemUnfocused(event as object)
+        p(m.scenario, "OBS-itemUnfocused", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onCurrFocusRow(event as object)
+        p(m.scenario, "OBS-currFocusRow", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onScrollingStatus(event as object)
+        p(m.scenario, "OBS-scrollingStatus", "data=" + b(event.getData()) + " " + ls())
+    end sub
+
+    ' ---------------------------------------------------------------- scenario driver
+
+    sub onStepTimer()
+        m.step = m.step + 1
+
+        if m.step = 1
+            ' R1: content was loaded while unfocused (in init). The first focus-gain is the one case
+            ' the docs and existing regressions DO pin: focus genuinely moves onto item 0.
+            m.scenario = "R1-first-focus"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 2
+            ' Move down one row so the remembered position is row 1, not the default 0.
+            m.scenario = "R2-prep-move"
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 1
+            p(m.scenario, "after", ls())
+
+        else if m.step = 3
+            ' Park focus on the sibling overlay - the list leaves the focus chain.
+            m.scenario = "R2-park"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 4
+            ' THE question: hand focus back with the position unchanged (still row 1).
+            ' Any OBS- record here means the settle re-fires for an unchanged position; whether it
+            ' lands before or after "after" answers the timing half.
+            m.scenario = "R2-refocus-unchanged"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 5
+            ' One settled frame later: anything arriving here was dispatched from the message loop.
+            m.scenario = "R2-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 6
+            ' Re-park for R3, with the remembered row set to the OVERLAY's row (0) - the state the
+            ' app is in when the user presses down out of the overlay. A stale settle then describes
+            ' row 0 and trips WOULD-RESHOW; a correctly-timed one describes the moved-to row.
+            m.scenario = "R3-park"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [m.overlayRow, 0]
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 7
+            ' R3: the exact app sequence, all inside ONE handler, via the CONTAINER (not the list) -
+            ' focus first, THEN move the row. If the settle dispatches while still inside step (A),
+            ' an observer's live read sees the OLD row. If it defers past the handler, by delivery
+            ' time (B) has moved it. Park the position on the overlay's row first so a stale read
+            ' trips WOULD-RESHOW.
+            m.scenario = "R3-focus-then-move"
+            p(m.scenario, "before", ls())
+            m.container.setFocus(true)
+            p(m.scenario, "mid-after-setFocus", ls())
+            m.list.animateToItem = 2
+            p(m.scenario, "after-animateToItem", ls())
+
+        else if m.step = 8
+            m.scenario = "R3-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 9
+            ' R4: a horizontal-only move - column changes, row does not.
+            m.scenario = "R4-prep-horiz"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [2, 1]
+            p(m.scenario, "after", ls())
+
+        else if m.step = 10
+            m.scenario = "R4-park"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 11
+            m.scenario = "R4-refocus-after-horiz"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 12
+            m.scenario = "R4-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 13
+            ' R5: park, then write a position while UNFOCUSED. The write itself should be silent;
+            ' the question is whether the focus-gain that follows publishes it.
+            m.scenario = "R5-park"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 14
+            m.scenario = "R5-unfocused-jump"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [0, 0]
+            p(m.scenario, "after", ls())
+
+        else if m.step = 15
+            m.scenario = "R5-refocus-after-jump"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 16
+            ' R6 setup: put the remembered position back on the overlay's row and park focus on the
+            ' overlay, so the next DOWN press is the genuine repro.
+            m.scenario = "R6-prep"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [m.overlayRow, 0]
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+            m.stepTimer.control = "stop"
+            print "PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote."
+
+        end if
+    end sub
+
+    ' ---------------------------------------------------------------- key-driven repro (R6)
+    '
+    ' R1-R5 are driven from a Timer observer, which already sits at observer depth >= 1. A real key
+    ' handler starts at depth ZERO, which can move where a deferred notification drains - so the
+    ' genuine repro has to come through onKeyEvent. This mirrors the app's handler exactly:
+    '   (A) hand focus to the container   (B) move a row   (C) hide the overlay
+    function onKeyEvent(key as string, press as boolean) as boolean
+        if key = "back" and press
+            p(m.scenario, "exit", "probe complete")
+            m.top.probeExit = true
+            return true
+        end if
+
+        if key = "down" and press and m.overlay.hasFocus()
+            ' First DOWN = R6 (re-show only). Second DOWN = R7, with the re-focus armed: the FULL app
+            ' behavior, where the re-show also grabs focus back. R7 is the one that decides whether a
+            ' nested backwards steal is honored (engine) or dropped (device, per focus-probe2).
+            if m.regrabOnReshow
+                m.scenario = "R7-key-down-regrab"
+            else
+                m.scenario = "R6-key-down"
+            end if
+            row = m.list.currFocusRow
+            p(m.scenario, "A-before-setFocus", "row=" + str(row).trim() + " " + ls())
+            m.container.setFocus(true)
+            p(m.scenario, "A-after-setFocus", ls())
+            m.list.animateToItem = row + 1
+            p(m.scenario, "B-after-animateToItem", ls())
+            p(m.scenario, "C-hide-overlay", "overlay would be faded out here " + ls())
+
+            if not m.regrabOnReshow
+                ' Arm R7 and put the state back so a second DOWN reruns the same sequence.
+                m.regrabOnReshow = true
+                m.list.jumpToRowItem = [m.overlayRow, 0]
+                m.overlay.setFocus(true)
+                print "PROBE|---|R7-key|MANUAL|Now press DOWN once more, then BACK."
+            end if
+            return true
+        end if
+
+        return false
+    end function
+    ]]></script>
+</component>

--- a/test/simulator/probes/list-refocus-settle-probe/device-trace.txt
+++ b/test/simulator/probes/list-refocus-settle-probe/device-trace.txt
@@ -1,0 +1,171 @@
+PROBE|000|boot|start|
+PROBE|000|boot|device|model=Roku Streaming Stick+ os=15.3
+PROBE|001|init|ready|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=-1 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|002|init|OBS-currFocusRow|data=0 liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|003|R1-first-focus|before|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|004|R1-first-focus|OBS-itemFocused|data=0 liveRIF=[] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|005|R1-first-focus|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|006|R1-first-focus|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|007|R1-first-focus|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|008|R2-prep-move|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|009|R2-prep-move|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|010|R2-prep-move|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|011|R2-prep-move|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|012|R2-prep-move|OBS-currFocusRow|data=0.1041667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1041667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|013|R2-prep-move|OBS-currFocusRow|data=0.1333333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1333333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|014|R2-prep-move|OBS-currFocusRow|data=0.175 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.175 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|015|R2-prep-move|OBS-currFocusRow|data=0.25 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.25 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|016|R2-prep-move|OBS-currFocusRow|data=0.3791667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3791667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|017|R2-prep-move|OBS-currFocusRow|data=0.475 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.475 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|018|R2-prep-move|OBS-currFocusRow|data=0.5708333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5708333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|019|R2-prep-move|OBS-currFocusRow|data=0.65 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.65 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|020|R2-prep-move|OBS-currFocusRow|data=0.7166666 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.7166666 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|021|R2-prep-move|OBS-currFocusRow|data=0.7791666 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.7791666 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|022|R2-prep-move|OBS-currFocusRow|data=0.8291667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.8291667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|023|R2-prep-move|OBS-currFocusRow|data=0.8666667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.8666667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|024|R2-prep-move|OBS-currFocusRow|data=0.9041666 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9041666 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|025|R2-prep-move|OBS-currFocusRow|data=0.9333333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9333333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|026|R2-prep-move|OBS-currFocusRow|data=0.9541667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9541667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|027|R2-prep-move|OBS-currFocusRow|data=0.9708334 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9708334 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|028|R2-prep-move|OBS-currFocusRow|data=0.9833333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9833333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|029|R2-prep-move|OBS-currFocusRow|data=0.9875 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9875 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|030|R2-prep-move|OBS-currFocusRow|data=0.9958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9958333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|031|R2-prep-move|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|032|R2-prep-move|OBS-itemFocused|data=1 liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|033|R2-prep-move|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|034|R2-prep-move|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|035|R2-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|036|R2-park|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|037|R2-refocus-unchanged|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|038|R2-refocus-unchanged|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|039|R2-refocus-unchanged|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|040|R2-refocus-unchanged|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|041|R2-settled|settled|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|042|R3-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|043|R3-park|OBS-currFocusRow|data=0 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|044|R3-park|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|045|R3-park|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|046|R3-park|after|liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|047|R3-focus-then-move|before|liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|048|R3-focus-then-move|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|049|R3-focus-then-move|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|050|R3-focus-then-move|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|051|R3-focus-then-move|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|052|R3-focus-then-move|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|053|R3-focus-then-move|mid-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|054|R3-focus-then-move|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|055|R3-focus-then-move|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|056|R3-focus-then-move|after-animateToItem|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|057|R3-focus-then-move|OBS-currFocusRow|data=0.01666667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.01666667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|058|R3-focus-then-move|OBS-currFocusRow|data=0.04166667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.04166667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|059|R3-focus-then-move|OBS-currFocusRow|data=0.1125 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1125 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|060|R3-focus-then-move|OBS-currFocusRow|data=0.1916667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1916667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|061|R3-focus-then-move|OBS-currFocusRow|data=0.3208333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3208333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|062|R3-focus-then-move|OBS-currFocusRow|data=0.4541667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.4541667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|063|R3-focus-then-move|OBS-currFocusRow|data=0.5791667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5791667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|064|R3-focus-then-move|OBS-currFocusRow|data=0.6833333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.6833333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|065|R3-focus-then-move|OBS-currFocusRow|data=0.7958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.7958333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|066|R3-focus-then-move|OBS-currFocusRow|data=0.9 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|067|R3-focus-then-move|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|068|R3-focus-then-move|OBS-currFocusRow|data=1.095833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.095833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|069|R3-focus-then-move|OBS-currFocusRow|data=1.183333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.183333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|070|R3-focus-then-move|OBS-currFocusRow|data=1.258333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.258333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|071|R3-focus-then-move|OBS-currFocusRow|data=1.333333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.333333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|072|R3-focus-then-move|OBS-currFocusRow|data=1.404167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.404167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|073|R3-focus-then-move|OBS-currFocusRow|data=1.4625 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.4625 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|074|R3-focus-then-move|OBS-currFocusRow|data=1.525 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.525 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|075|R3-focus-then-move|OBS-currFocusRow|data=1.579167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.579167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|076|R3-focus-then-move|OBS-currFocusRow|data=1.633333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.633333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|077|R3-focus-then-move|OBS-currFocusRow|data=1.679167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.679167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|078|R3-focus-then-move|OBS-currFocusRow|data=1.720833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.720833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|079|R3-focus-then-move|OBS-currFocusRow|data=1.7625 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.7625 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|080|R3-focus-then-move|OBS-currFocusRow|data=1.795833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.795833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|081|R3-focus-then-move|OBS-currFocusRow|data=1.825 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.825 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|082|R3-focus-then-move|OBS-currFocusRow|data=1.854167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.854167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|083|R3-focus-then-move|OBS-currFocusRow|data=1.879167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.879167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|084|R3-focus-then-move|OBS-currFocusRow|data=1.9 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.9 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|085|R3-focus-then-move|OBS-currFocusRow|data=1.916667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.916667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|086|R3-focus-then-move|OBS-currFocusRow|data=1.933333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.933333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|087|R3-focus-then-move|OBS-currFocusRow|data=1.945833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.945833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|088|R3-focus-then-move|OBS-currFocusRow|data=1.958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.958333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|089|R3-focus-then-move|OBS-currFocusRow|data=1.970833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.970833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|090|R3-focus-then-move|OBS-currFocusRow|data=1.979167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.979167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|091|R3-focus-then-move|OBS-currFocusRow|data=1.983333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.983333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|092|R3-focus-then-move|OBS-currFocusRow|data=1.9875 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.9875 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|093|R3-focus-then-move|OBS-currFocusRow|data=1.991667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.991667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|094|R3-settled|settled|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.991667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|095|R3-settled|OBS-currFocusRow|data=1.995833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.995833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|096|R3-settled|OBS-currFocusRow|data=2 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|097|R3-settled|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|098|R3-settled|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|099|R3-settled|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|100|R4-prep-horiz|before|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|101|R4-prep-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|102|R4-prep-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|103|R4-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|104|R4-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|105|R4-refocus-after-horiz|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|106|R4-refocus-after-horiz|OBS-itemFocused|data=2 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|107|R4-refocus-after-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|108|R4-refocus-after-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|109|R4-settled|settled|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|110|R5-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|111|R5-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|112|R5-unfocused-jump|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|113|R5-unfocused-jump|OBS-currFocusRow|data=0 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|114|R5-unfocused-jump|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|115|R5-refocus-after-jump|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|116|R5-refocus-after-jump|OBS-itemFocused|data=0 liveRIF=[2,1] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|117|R5-refocus-after-jump|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|118|R5-refocus-after-jump|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|119|R5-refocus-after-jump|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|121|R6-prep|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|122|R6-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|123|R6-prep|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|124|R6-prep|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote.
+PROBE|125|R6-key-down|A-before-setFocus|row=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|126|R6-key-down|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=F
+PROBE|127|R6-key-down|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|128|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|129|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|130|R6-key-down|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|131|R6-key-down|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|132|R6-key-down|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|133|R6-key-down|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|134|R6-key-down|B-after-animateToItem|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|135|R6-key-down|C-hide-overlay|overlay would be faded out here liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|136|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|137|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|138|R6-key-down|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|139|R6-key-down|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|---|R7-key|MANUAL|Now press DOWN once more, then BACK.
+PROBE|140|R6-key-down|OBS-currFocusRow|data=0.075 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.075 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|160|R6-key-down|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|161|R6-key-down|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|162|R6-key-down|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|163|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|164|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|165|R6-key-down|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|166|R6-key-down|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|167|R7-key-down-regrab|A-before-setFocus|row=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|168|R7-key-down-regrab|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=F overlayFocus=F
+PROBE|169|R7-key-down-regrab|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|170|R7-key-down-regrab|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|171|R7-key-down-regrab|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|172|R7-key-down-regrab|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|173|R7-key-down-regrab|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|174|R7-key-down-regrab|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|175|R7-key-down-regrab|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|176|R7-key-down-regrab|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|177|R7-key-down-regrab|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|178|R7-key-down-regrab|B-after-animateToItem|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|179|R7-key-down-regrab|C-hide-overlay|overlay would be faded out here liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|180|R7-key-down-regrab|OBS-currFocusRow|data=1.05 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.05 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|200|R7-key-down-regrab|OBS-currFocusRow|data=2 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|201|R7-key-down-regrab|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|202|R7-key-down-regrab|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|203|R7-key-down-regrab|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|204|R7-key-down-regrab|exit|probe complete
+PROBE|999|boot|end|
+PROBE|999|capture-note|manual|Second capture (DOWN pressed twice) adds R7. R2-prep-move record 031 and R6-key-down 141-159 / R7 181-199 fractional currFocusRow steps elided for brevity; the endpoints are kept.

--- a/test/simulator/probes/list-refocus-settle-probe/engine-trace.txt
+++ b/test/simulator/probes/list-refocus-settle-probe/engine-trace.txt
@@ -1,0 +1,100 @@
+PROBE|000|boot|start|
+PROBE|000|boot|device|model=Roku TV os=15.0
+PROBE|001|init|ready|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|002|R1-first-focus|before|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|003|R1-first-focus|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|004|R1-first-focus|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|005|R1-first-focus|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|006|R1-first-focus|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|007|R2-prep-move|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|008|R2-prep-move|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|009|R2-prep-move|OBS-itemUnfocused|data=0 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|010|R2-prep-move|OBS-currFocusRow|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|011|R2-prep-move|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|012|R2-prep-move|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|013|R2-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|014|R2-park|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|015|R2-refocus-unchanged|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|016|R2-refocus-unchanged|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|017|R2-refocus-unchanged|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|018|R2-refocus-unchanged|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|019|R2-settled|settled|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|020|R3-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|021|R3-park|after|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|022|R3-park|OBS-itemUnfocused|data=1 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|023|R3-park|OBS-currFocusRow|data=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|024|R3-park|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|025|R3-park|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|026|R3-park|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|027|R3-focus-then-move|before|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|028|R3-focus-then-move|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|029|R3-focus-then-move|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|030|R3-focus-then-move|mid-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|031|R3-focus-then-move|after-animateToItem|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|032|R3-focus-then-move|OBS-itemFocused|data=0 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|033|R3-focus-then-move|OBS-rowItemFocused|data=[0,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|034|R3-focus-then-move|OBS-itemUnfocused|data=0 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|035|R3-focus-then-move|OBS-currFocusRow|data=2 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|036|R3-focus-then-move|OBS-itemFocused|data=2 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|037|R3-focus-then-move|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|038|R3-settled|settled|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|039|R4-prep-horiz|before|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|040|R4-prep-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|041|R4-prep-horiz|OBS-itemFocused|data=2 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|042|R4-prep-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|043|R4-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|044|R4-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|045|R4-refocus-after-horiz|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|046|R4-refocus-after-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|047|R4-refocus-after-horiz|OBS-itemFocused|data=2 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|048|R4-refocus-after-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|049|R4-settled|settled|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|050|R5-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|051|R5-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|052|R5-unfocused-jump|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|053|R5-unfocused-jump|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|054|R5-refocus-after-jump|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|055|R5-refocus-after-jump|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|056|R5-refocus-after-jump|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|057|R5-refocus-after-jump|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|058|R5-refocus-after-jump|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|059|R6-prep|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|060|R6-prep|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote.
+PROBE|061|R6-prep|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|062|R6-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|063|R6-prep|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|064|R6-key-down|A-before-setFocus|row=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|065|R6-key-down|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|066|R6-key-down|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|067|R6-key-down|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|068|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|069|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|070|R6-key-down|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|071|R6-key-down|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|072|R6-key-down|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|073|R6-key-down|OBS-itemFocused|data=1 liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|074|R6-key-down|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|075|R6-key-down|B-after-animateToItem|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|076|R6-key-down|C-hide-overlay|overlay would be faded out here liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|077|R6-key-down|OBS-itemUnfocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|078|R6-key-down|OBS-currFocusRow|data=0 liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|079|R6-key-down|OBS-itemFocused|data=0 liveRIF=[1,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|080|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|081|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|082|R6-key-down|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|083|R6-key-down|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|---|R7-key|MANUAL|Now press DOWN once more, then BACK.
+PROBE|084|R7-key-down-regrab|A-before-setFocus|row=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|085|R7-key-down-regrab|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|086|R7-key-down-regrab|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|087|R7-key-down-regrab|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|088|R7-key-down-regrab|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|089|R7-key-down-regrab|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|090|R7-key-down-regrab|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|091|R7-key-down-regrab|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|092|R7-key-down-regrab|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|093|R7-key-down-regrab|B-after-animateToItem|liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|094|R7-key-down-regrab|C-hide-overlay|overlay would be faded out here liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|095|R7-key-down-regrab|exit|probe complete
+PROBE|999|boot|end|

--- a/test/simulator/probes/list-refocus-settle-probe/manifest
+++ b/test/simulator/probes/list-refocus-settle-probe/manifest
@@ -1,0 +1,4 @@
+title=List Refocus Settle Probe
+major_version=1
+minor_version=0
+build_version=1

--- a/test/simulator/probes/list-refocus-settle-probe/source/main.brs
+++ b/test/simulator/probes/list-refocus-settle-probe/source/main.brs
@@ -1,0 +1,33 @@
+' List Refocus Settle Probe - entry point.
+'
+' Prints a machine-diffable trace of WHETHER and WHEN a RowList re-publishes its focus-settle fields
+' when the list is handed focus without its focused position having moved. Every trace record has
+' the shape:
+'
+'     PROBE|<seq>|<scenario>|<point>|<key=value ...>
+'
+' Capture on device with:  telnet <roku-ip> 8085
+' Capture in the engine with:  brs-cli test/simulator/probes/list-refocus-settle-probe
+sub Main()
+    print "PROBE|000|boot|start|"
+    di = CreateObject("roDeviceInfo")
+    print "PROBE|000|boot|device|model=" + di.GetModelDisplayName() + " os=" + di.GetOSVersion().major + "." + di.GetOSVersion().minor
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("RefocusProbeScene")
+    screen.show()
+
+    ' Pump the message loop. The scene drives the scenarios from a repeating Timer, so this loop only
+    ' has to stay alive and let the render thread run.
+    while true
+        msg = wait(500, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then exit while
+        end if
+        if scene.probeExit then exit while
+    end while
+
+    print "PROBE|999|boot|end|"
+end sub


### PR DESCRIPTION
## Problem

An app that parents an overlay as a **sibling** of a `RowList` and re-shows it from an observer on the
list's focus fields could be left permanently focused on that overlay after navigating out of it. The
symptom: the row visually takes focus, but left/right keeps operating the overlay and its poster stays
on screen.

The app's re-show does not merely make the overlay visible — it calls `setFocus(true)` on it. That is a
**backwards steal**: a nested focus request targeting a node outside the subtree the in-flight focus
transaction just committed. `Node.isFocusRequestDropped` exists to drop exactly that, and it missed this
case.

## Root cause

Two independent gaps, both required for the failure:

1. **The drop rule classified by the notifying owner, not the target.** In the common container shape a
   container observes its own `focusedChild`, redirects focus to its inner list, and the list's
   focus-gain settle runs an app observer that re-grabs focus to an unrelated sibling. The owner (the
   container) **is** still in the focus chain — focus went to its own child — so an owner-keyed test read
   the steal as a legal forward focus and honored it.

   The rule `test/simulator/probes/focus-probe2` established is about the **target**: dropped only when
   the target lies outside the subtree just focused. Both conditions are now required, and "inside the
   owner's subtree" is the forward test rather than "at or below the live focus", because forward focus
   routinely targets a *sibling* of the focused leaf — which is how a dialog highlights its buttons.

2. **The focus-gain settle was deferred, putting the steal outside the only window where it can be
   classified.** Device-measured (`list-refocus-settle-probe`, R2/R4/R5): a real Roku re-publishes the
   settle on a focus-gain and dispatches those observers *before* `setFocus` returns. We deferred them,
   so by dispatch time `Node.focusNotifyOwners` was empty and rule 1 could not see the steal at all.

   `ArrayGrid.setNodeFocus` now dispatches that settle synchronously — but **only** while a
   `focusedChild` notification is on the stack. A plain `setFocus` from app code has no transaction to
   defend, and forcing its settle inline there re-creates the reentrancy the deferral exists to prevent
   (`deferred-observer-app` crashed on dot-on-invalid).

## Consequence of the steal being honored

The list left the focus chain *inside* the app's `setFocus` step, so the row move that followed took
`setFocusedItem`'s silent path — the app never learned the row changed — and the overlay kept focus, so a
fade-out completion guard of `isInFocusChain() = false` never passed.

## Verification

- **Probe:** `test/simulator/probes/list-refocus-settle-probe` (committed with device + pre-fix engine
  traces). R7 post-fix settles at `listInChain=T overlayFocus=F`; the row move publishes normally.
- **Regressions:** two tests in `test/extensions/scenegraph/Focus.test.js` — the steal case (verified
  failing without change 1) and a companion forward-focus case that passes both ways, pinning that the
  rule does not over-drop.
- **Full suite:** 209 files, 2666 tests, 0 failures. `dialog-buttongroup-focus-app`, `focus-steal-app`,
  `init-focus-observer-app` and the `panelset-*` fixtures all stay green.
- Confirmed fixed in a real app running under brs-desktop.

## Notes

The probe README records two conclusions I drew from earlier captures that turned out to be **wrong**,
so the trail is not re-walked: the device *does* evict the list on a steal (so the "two nodes reporting
focus is deliberately not modeled" decision stands, and no focus-chain model change was needed), and
implementing scroll animation does **not** fix this — that is a separate, real divergence handled in a
follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)