### PR TITLE
Animate the list/grid focus scroll for animateToItem

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -1205,6 +1205,15 @@ device-measured on a Roku Streaming Stick+ (OS 15.3) with
   row's own pitch (`rowHeights` can differ per row). It also renders **one extra row** while a scroll is
   in flight, to fill the gap the shift opens at the bottom. Pinned by the "visibly slides the drawn rows"
   test, which records each row's drawn y-origin.
+
+  **Only `RowList` consumes the offset today.** The helpers are expressed in ROW space (see
+  `scrollRowPosition` — it divides by `numCols`, so they stay meaningful for a multi-column grid rather
+  than returning an item fraction), but the other `ArrayGrid` render paths (`MarkupGrid`, `PosterGrid`,
+  `MarkupList`, `LabelList`, `ZoomRowList`, `TimeGrid`, `CheckList`, `RadioButtonList`) do not apply it
+  yet: they ramp the fields and snap the pixels at the settle. Each one settles `currRow` then advances an
+  `itemRect` the same way, so extending them is a call to the same two helpers per subclass — the
+  non-obvious part to carry over is the extra row plus the reported-extent compensation
+  (`RowList.renderContent`), without which `boundingRect()` grows a row mid-scroll.
 - **The settle happens only at completion**, through the normal `setFocusedItem`, so the existing
   focus gate applies: an **unfocused** list still pulses and still ramps (device-confirmed) but publishes
   no `itemFocused`/`rowItemFocused`.

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -1105,8 +1105,12 @@ Per `zoomrowlist.md` the field is "set to true whenever the list is scrolling th
 vertically". It is documented only under `ZoomRowList` but exists on **every** `ArrayGrid`-derived node on
 a device, and apps alias it up from a plain `RowList`. On a device the scroll spans several frames: the
 field goes true, the focus fields pass through in-transit values, and it goes **false before the focus
-finally settles**. Our scroll is instant, so both edges land in one frame — which makes their **order
-relative to the focus fields the entire contract**, and the two rules below easy to get backwards. Both
+finally settles**.
+
+**Two paths now, and they differ.** An app-written `animateToItem` genuinely animates across frames (see
+the next section). Everything else — key navigation, `jumpToItem`/`jumpToRowItem`, a focus-gain
+re-emission — still settles instantly, so both edges land in one frame, which makes their **order
+relative to the focus fields the entire contract** and the two rules below easy to get backwards. Both
 were regressed once each while this was being written.
 
 1. **The falling edge must precede the settled focus fields.** Apps depend on the interleave in both
@@ -1174,6 +1178,59 @@ no-op) before settling `rowItemFocused` last — that ordering is unchanged.
 
 Regression: `test/extensions/scenegraph/ArrayGridFields.test.js`, describe block
 `"ArrayGrid currFocusRow/currFocusColumn reflect the new focus before itemFocused fires"`.
+
+### `animateToItem` animates across frames — and that timing is load-bearing
+
+An app-written `animateToItem` starts a real multi-frame scroll (`ArrayGrid.startScrollAnimation`,
+`tickScrollAnimation`, driven from `sgRoot.processScrollAnimations` in the render loop). All of it is
+device-measured on a Roku Streaming Stick+ (OS 15.3) with
+`test/simulator/probes/grid-scroll-animation-probe` — read that probe's README before changing any of it.
+
+- **Duration scales with distance:** ~340 ms **per row traversed** (measured 364/686/1021 ms for 1/2/3
+  rows), ease-in-out. Not a fixed total.
+- **`scrollingStatus = true` and `itemUnfocused` fire at animation START**, synchronously, *before the
+  app's assignment returns* — deliberately **not** inside an `enterInternalUpdate` bracket, which would
+  defer them past the writing statement. This is the opposite of the key-navigation path, which emits
+  `itemUnfocused` as part of the settle. `setFocusedItem` skips both when `settlingScrollAnim` is set, so
+  one scroll reports them exactly once.
+- **`currFocusRow` carries fractional in-transit values** each frame via `publishScrollPosition`. A
+  RowList overrides it to write **only** `currFocusRow`: a device's vertical scroll emitted no
+  `currFocusColumn` at all during the ramp.
+- **The settle happens only at completion**, through the normal `setFocusedItem`, so the existing
+  focus gate applies: an **unfocused** list still pulses and still ramps (device-confirmed) but publishes
+  no `itemFocused`/`rowItemFocused`.
+- **A mid-flight write retargets** from the current fractional position — no restart, no second rising
+  edge, nothing emitted for the abandoned target. That is why `ScrollAnimation.from` is a float.
+- **`jumpToItem`/`jumpToRowItem` stay instant** and cancel any in-flight scroll (`cancelScrollAnimation`,
+  which must close the pulse or `scrollingStatus` is stranded at `true` and silently suppresses every
+  later notification — it is not `alwaysNotify`).
+
+**Why it matters beyond smoothness.** A real app failed because of the *ordering*, not the visuals: an
+overlay parented as a sibling of a list, re-shown from a `rowItemFocused` observer that reads the field
+live, with a key handler that must hand focus to the list **before** moving a row (the list's container
+may `jumpToItem` on focus change). With an instant move, (B)'s settle landed inside the handler
+describing the **outgoing** row and re-showed the very overlay the handler was about to hide. Animated,
+that settle lands ~340 ms later and describes the row moved *to*.
+
+**Deliberately scoped out: key navigation.** A device animates it too, but `ArrayGrid.handleKey` sets
+`keyNavMove` so a subclass writing `animateToItem` as its internal move shortcut (`MarkupGrid.handleUpDown`)
+still settles instantly. Animating key nav would rewrite the key-driven emission order pinned by
+`ArrayGridFields.test.js` and read synchronously by several CLI fixtures; it needs its own regression pass.
+
+**Known one-record deviation:** a device interleaves the falling edge *inside* the settle
+(`itemFocused` → `scrollingStatus=false` → `rowItemFocused`); we emit it after the whole settle. Matching
+exactly would mean suppressing `rowItemFocused` inside `RowList.setFocusedItem` and re-emitting it here,
+fighting the "rowItemFocused settles last" invariant and four other `setRowItemFocused` call sites. Both
+orders keep the property apps rely on (edge and settle adjacent, teardown followed by a rebuild).
+
+`skipFocusAnimations` is declared on `ArrayGrid` but **intentionally not wired** to any of this: the probe
+measured that setting it `true` on a device does **not** suppress the scroll (its wording is about the
+focus *indicator*). It exists so an app reading the documented field gets `false` instead of `invalid`,
+which used to crash a strongly-typed BrightScript helper.
+
+Regressions: `test/extensions/scenegraph/ArrayGridScrollAnimation.test.js` (drives the injectable
+`sgClock` for determinism) and `list-refocus-overlay-app` in `test/cli/cli-scenegraph.test.js`, whose
+`inflight:` line is what an instant move cannot produce.
 
 ## Focus chain consistency (`focusedChild` ↔ live focus)
 

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -1217,11 +1217,23 @@ that settle lands ~340 ms later and describes the row moved *to*.
 still settles instantly. Animating key nav would rewrite the key-driven emission order pinned by
 `ArrayGridFields.test.js` and read synchronously by several CLI fixtures; it needs its own regression pass.
 
-**Known one-record deviation:** a device interleaves the falling edge *inside* the settle
-(`itemFocused` → `scrollingStatus=false` → `rowItemFocused`); we emit it after the whole settle. Matching
-exactly would mean suppressing `rowItemFocused` inside `RowList.setFocusedItem` and re-emitting it here,
-fighting the "rowItemFocused settles last" invariant and four other `setRowItemFocused` call sites. Both
-orders keep the property apps rely on (edge and settle adjacent, teardown followed by a rebuild).
+**The falling edge is INTERLEAVED into the settle, not appended after it.** A device emits
+`itemFocused` → `scrollingStatus=false` → `rowItemFocused` (probe A1 records 067/068/069), and
+`pendingScrollFallingEdge` / `emitPendingScrollFallingEdge` reproduce that: `ArrayGrid.setFocusedItem`
+emits the edge right after `itemFocused` (outside the `enterInternalUpdate` bracket, so it dispatches
+synchronously), and `RowList.setFocusedItem` emits it between `itemFocused` and its own
+`setRowItemFocused`. `tickScrollAnimation` calls the hook again as a backstop, because a settle that
+publishes nothing (an unfocused list, a rejected target) never reaches the interleave point — and a
+stranded `true` silently suppresses every later notification, the field not being `alwaysNotify`.
+
+This ordering was initially dismissed as a harmless one-record deviation and **that was wrong**: an app
+tears transient scroll state down on the rising edge and *rebuilds* its focused-item overlay on the
+falling edge, reading the settled focus position there, while treating the `rowItemFocused` observer as
+the authoritative settle that re-derives its own state. With the edge emitted last, the rebuild ran
+first and the settle handler overwrote it — the overlay stayed hidden until a later navigation
+re-triggered it (visible as "the focused-poster overlay only appears after moving horizontally").
+Note the edge still precedes `rowItemFocused`, so rule 1 above and the "rowItemFocused settles last"
+invariant both continue to hold.
 
 `skipFocusAnimations` is declared on `ArrayGrid` but **intentionally not wired** to any of this: the probe
 measured that setting it `true` on a device does **not** suppress the scroll (its wording is about the

--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -1196,6 +1196,15 @@ device-measured on a Roku Streaming Stick+ (OS 15.3) with
 - **`currFocusRow` carries fractional in-transit values** each frame via `publishScrollPosition`. A
   RowList overrides it to write **only** `currFocusRow`: a device's vertical scroll emitted no
   `currFocusColumn` at all during the ramp.
+- **The rows visibly slide, and that took a second step.** The render path lays rows out from an integer
+  anchor (`currRow`) plus a per-row Y advance, so publishing fractional fields alone left the layout
+  frozen until the settle snapped it — the fields ramped while the screen jumped, which is exactly how
+  the first version of this shipped. `ArrayGrid.scrollRowOffset`/`scrollAnchorRow` split the animated
+  position into "which row is on top" and "how far past it we are"; `RowList.renderContent` re-anchors
+  the window to that row and shifts the layout up by the remainder, converted to pixels with the anchor
+  row's own pitch (`rowHeights` can differ per row). It also renders **one extra row** while a scroll is
+  in flight, to fill the gap the shift opens at the bottom. Pinned by the "visibly slides the drawn rows"
+  test, which records each row's drawn y-origin.
 - **The settle happens only at completion**, through the normal `setFocusedItem`, so the existing
   focus gate applies: an **unfocused** list still pulses and still ramps (device-confirmed) but publishes
   no `itemFocused`/`rowItemFocused`.

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -664,6 +664,11 @@ export class SGRoot {
      * @returns True if any scroll updated, so the frame is marked dirty.
      */
     processScrollAnimations(): boolean {
+        if (this._scrollAnimations.length === 0) {
+            // The common case by far — skip the snapshot allocation below rather than building a dead
+            // array every frame for every app, animating or not.
+            return false;
+        }
         let updated = false;
         // Snapshot into a local, not a `for…of` over the live array: a scroll that completes removes
         // itself mid-loop, and its settle emission runs app observers that can start another scroll on

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -21,7 +21,7 @@ import { ThreadInfo } from "./SGTypes";
 import type { SoundEffect } from "./nodes/SoundEffect";
 import type { RoSGNode } from "./components/RoSGNode";
 import type { RoSGScreen } from "./components/RoSGScreen";
-import type { AnimationBase, Audio, Dialog, Node, Scene, StandardDialog, Task, Timer, Video } from "./nodes";
+import type { AnimationBase, ArrayGrid, Audio, Dialog, Node, Scene, StandardDialog, Task, Timer, Video } from "./nodes";
 import type { RoRenderThreadQueue } from "./components/RoRenderThreadQueue";
 
 /**
@@ -47,6 +47,7 @@ export class SGRoot {
     private readonly _threads: Map<number, { task?: Task; info: ThreadInfo }>;
     private readonly _timers: Timer[];
     private readonly _animations: AnimationBase[];
+    private readonly _scrollAnimations: ArrayGrid[];
     private readonly _sfx: (SoundEffect | undefined)[];
     private _audio?: Audio;
     private _video?: Video;
@@ -189,6 +190,15 @@ export class SGRoot {
         return this._timers;
     }
 
+    /**
+     * Grids with an animated focus scroll in flight (`animateToItem`). Separate from `_animations`,
+     * which holds `Animation` nodes an app declares: a scroll is engine-internal, has no `state`
+     * field and no app-visible node, so it must not appear in that list.
+     */
+    get scrollAnimations(): ArrayGrid[] {
+        return this._scrollAnimations;
+    }
+
     get animations(): AnimationBase[] {
         return this._animations;
     }
@@ -293,6 +303,7 @@ export class SGRoot {
         this._sfx = [];
         this._timers = [];
         this._animations = [];
+        this._scrollAnimations = [];
         this._threads = new Map();
         // Add Render thread by default
         this._threadId = 0;
@@ -639,6 +650,27 @@ export class SGRoot {
         let updated = false;
         for (const animation of this._animations) {
             if (animation.tick()) {
+                updated = true;
+            }
+        }
+        return updated;
+    }
+
+    /**
+     * Advances every in-flight animated focus scroll (`animateToItem`) one frame.
+     *
+     * Iterates a snapshot: a scroll that completes removes itself from the list mid-loop, and its
+     * settle emission runs app observers that can start another scroll on any grid.
+     * @returns True if any scroll updated, so the frame is marked dirty.
+     */
+    processScrollAnimations(): boolean {
+        let updated = false;
+        // Snapshot into a local, not a `for…of` over the live array: a scroll that completes removes
+        // itself mid-loop, and its settle emission runs app observers that can start another scroll on
+        // any grid. Iterating the live array would skip or repeat entries.
+        const grids = this._scrollAnimations.slice();
+        for (const grid of grids) {
+            if (grid.tickScrollAnimation()) {
                 updated = true;
             }
         }

--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -196,6 +196,7 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
                 const libsUpdated = sgRoot.processComponentLibraries();
                 const timersFired = sgRoot.processTimers();
                 const animUpdated = sgRoot.processAnimations();
+                const scrollUpdated = sgRoot.processScrollAnimations();
                 const tasksUpdated = sgRoot.processTasks();
                 const queuesDrained = sgRoot.processRenderQueues();
                 const audioUpdated = sgRoot.processAudio();
@@ -205,6 +206,7 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
                     libsUpdated ||
                     timersFired ||
                     animUpdated ||
+                    scrollUpdated ||
                     tasksUpdated ||
                     queuesDrained ||
                     audioUpdated ||

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -21,6 +21,7 @@ import { createNode } from "../factory/NodeFactory";
 import { normalizeBlendColor } from "../SGUtil";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
+import { sgClock } from "../SGClock";
 import { ContentNode } from "./ContentNode";
 import { Font } from "./Font";
 
@@ -61,6 +62,26 @@ export declare namespace ArrayGrid {
         index: number;
         divider: boolean;
         sectionTitle: string;
+    };
+    /**
+     * An in-flight animated focus scroll started by `animateToItem`.
+     *
+     * `from` is fractional so a mid-flight retarget continues from the position currently on screen
+     * rather than restarting — device-measured (probe A3: an interrupt at 0.52 resumed at 0.658).
+     */
+    type ScrollAnimation = {
+        /** Fractional content index the scroll started from. */
+        from: number;
+        /** Content index being scrolled to. */
+        to: number;
+        /** Target index as the app wrote it, for the `itemFocused` payload at completion. */
+        toIndex: number;
+        /** Column to settle on, for the list types that track one; -1 to reuse the remembered one. */
+        toColumn: number;
+        /** `sgClock.perfNow()` at the frame the scroll started. */
+        start: number;
+        /** Total duration in ms, scaled by the distance travelled. */
+        duration: number;
     };
 }
 
@@ -118,6 +139,14 @@ export class ArrayGrid extends Group {
         // apps observe it to track scroll direction (e.g. to position an in-transit overlay toward the
         // incoming row). Emitted as up/down on a vertical nav then reset to "none".
         { name: "vertFocusDirection", type: "string", value: "none" },
+        // Documented on ArrayGrid: "Specifies whether changes in the focus item should be animated."
+        // Declared for compatibility so an app reading it gets `false` rather than `invalid` (which
+        // crashes a strongly-typed BrightScript helper). Deliberately NOT wired to the scroll
+        // animation: device-measured (grid-scroll-animation-probe A7) that setting it true does NOT
+        // suppress the scroll — the move still ramped over the same ~1s/3 rows. Its wording is about
+        // the focus *indicator*'s repositioning/scaling, so treating it as a scroll on/off switch
+        // would diverge from hardware.
+        { name: "skipFocusAnimations", type: "boolean", value: "false" },
     ];
     protected readonly dividerUri = "common:/images/dividerHorizontal.9.png";
     /**
@@ -153,6 +182,31 @@ export class ArrayGrid extends Group {
     protected scrollPulseArmed: boolean = false;
     /** The rising edge has been emitted and the falling edge is still owed. */
     protected scrollPulseActive: boolean = false;
+    /**
+     * The in-flight `animateToItem` scroll, or undefined when settled.
+     *
+     * Device-measured (`test/simulator/probes/grid-scroll-animation-probe`): `animateToItem` starts a
+     * multi-frame eased scroll, ~340 ms per row traversed, publishing fractional `currFocusRow` every
+     * frame and the settled focus fields only at completion. `jumpToItem` stays instant.
+     */
+    protected scrollAnim?: ArrayGrid.ScrollAnimation;
+    /**
+     * Set while an animated scroll's settle runs, so `setFocusedItem` skips the two emissions the
+     * animation already made at its START: the `scrollingStatus` pulse and `itemUnfocused`. Without
+     * this the settle would re-emit both, which a device does exactly once per scroll.
+     */
+    protected settlingScrollAnim: boolean = false;
+    /**
+     * Set while the grid's own key handling writes `animateToItem` as an internal shortcut, so the
+     * write takes the INSTANT path instead of starting an animated scroll.
+     *
+     * A device animates key navigation too, but that is a much wider behavior change: the key-driven
+     * emission order is pinned by `test/extensions/scenegraph/ArrayGridFields.test.js` and several CLI
+     * fixtures read focus fields synchronously right after `handleKey`. Animating app-written
+     * `animateToItem` is what the reported failure needs; animating key navigation is a separate
+     * change that should come with its own regression pass.
+     */
+    protected keyNavMove: boolean = false;
     protected hasNinePatch: boolean;
     protected focusField: string;
     protected vertFocusAnimationStyleName: string = FocusStyle.FloatingFocus.toLowerCase();
@@ -206,8 +260,18 @@ export class ArrayGrid extends Group {
             this.refreshContent();
             this.resetFocusForNewContent(true);
             return;
-        } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
+        } else if (fieldName === "jumptoitem" && isNumberComp(value)) {
+            // Documented as an immediate move, and device-measured as one (probe A2: no
+            // scrollingStatus, no fractional currFocusRow, every focus field in the same millisecond).
+            this.cancelScrollAnimation();
             this.setFocusedItem(jsValueOf(value));
+        } else if (fieldName === "animatetoitem" && isNumberComp(value)) {
+            if (this.keyNavMove) {
+                // The grid's own key handler routes through this field; keep that instant (see keyNavMove).
+                this.setFocusedItem(jsValueOf(value));
+            } else {
+                this.startScrollAnimation(jsValueOf(value) as number);
+            }
         } else if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
             const style = resolveFocusStyle(value.toString());
             if (style) {
@@ -343,7 +407,7 @@ export class ArrayGrid extends Group {
         }
         const nodeFocus = sgRoot.focused === this;
         const inFocusChain = nodeFocus || this.isChildrenFocused();
-        if (inFocusChain) {
+        if (inFocusChain && !this.settlingScrollAnim) {
             // Emit the scroll pulse BEFORE the settled focus fields go out: on a device
             // scrollingStatus falls while the scroll finishes and the focus settles afterward, and
             // apps depend on that order (the falling edge tears transient scroll state down, the
@@ -351,6 +415,8 @@ export class ArrayGrid extends Group {
             // bracket below — these notifications must dispatch synchronously here, not defer past
             // the settle they precede. Skipped when unfocused: that path publishes no focus fields at
             // all, so a pulse would be a teardown with nothing to rebuild from (see armScrollPulse).
+            // Also skipped while an animated scroll settles: that pulse opened at animation start and
+            // its falling edge is emitted by tickScrollAnimation.
             this.emitScrollPulse();
         }
         // Focus fields are emitted by the grid's internal machinery, not by a direct BrightScript
@@ -365,7 +431,11 @@ export class ArrayGrid extends Group {
             this.updateHorizScroll(newFocus);
             this.updateItemFocus(this.focusIndex, true, nodeFocus);
             if (inFocusChain) {
-                super.setValue("itemUnfocused", new Int32(focusedIndex));
+                // An animated scroll already emitted itemUnfocused at its start (device-measured), so
+                // re-emitting it here would double-report one scroll.
+                if (!this.settlingScrollAnim) {
+                    super.setValue("itemUnfocused", new Int32(focusedIndex));
+                }
                 // currFocusRow/currFocusColumn must already reflect the new position before
                 // itemFocused fires: apps commonly read them synchronously from an itemFocused
                 // observer (see RowList.setFocusedItem for the same ordering requirement).
@@ -490,6 +560,184 @@ export class ArrayGrid extends Group {
         super.setValue("scrollingStatus", BrsBoolean.False);
     }
 
+    /**
+     * Milliseconds of scroll per row/column traversed.
+     *
+     * Device-measured on a Roku Streaming Stick+ (OS 15.3), `grid-scroll-animation-probe`: a 1-row
+     * move took 364 ms, 2 rows 686 ms, 3 rows 1021 ms — i.e. the duration scales with the distance
+     * rather than being fixed, at ~340 ms per row.
+     */
+    protected static readonly scrollMsPerItem = 340;
+
+    /**
+     * Starts (or retargets) the animated focus scroll for `animateToItem`.
+     *
+     * Emission contract, all device-measured (probe A1):
+     * - `scrollingStatus = true` and `itemUnfocused` go out **here**, at animation START, before the
+     *   app's assignment even returns — NOT in the settle bracket where the key-navigation path emits
+     *   `itemUnfocused`.
+     * - `currFocusRow`/`currFocusColumn` then carry fractional in-transit values every frame
+     *   (`tickScrollAnimation`).
+     * - The settled fields (`itemFocused`, `rowItemFocused`) are emitted only at completion.
+     *
+     * A write landing while a scroll is already running RETARGETS it, continuing from the fractional
+     * position currently on screen — no restart, no second pulse, and nothing emitted for the
+     * abandoned target (probe A3).
+     *
+     * @param index Content index to scroll to, as the app wrote it.
+     * @param column Column to settle on, or -1 to reuse the row's remembered column (RowList).
+     */
+    protected startScrollAnimation(index: number, column: number = -1) {
+        const target = this.findContentIndex(index);
+        if (target === -1) {
+            return;
+        }
+        const retarget = this.scrollAnim;
+        // Continue from where the scroll actually is, so a retarget does not visibly jump back.
+        const from = retarget ? this.currentScrollPosition(retarget) : this.focusIndex;
+        if (!retarget) {
+            // Start-of-scroll emissions. An unfocused grid still pulses and still ramps on a device
+            // (probe A6) — only the SETTLE fields are focus-gated — so this is deliberately not
+            // wrapped in an inFocusChain check. itemUnfocused reports the sentinel when nothing was
+            // focused, exactly as the device did (A6 record 248: itemUnfocused = -1).
+            // Both dispatch synchronously, matching the device: it emitted scrollingStatus=true and
+            // itemUnfocused BEFORE the app's assignment returned (probe A1 records 008-009 precede
+            // `after-write` at 010). Deliberately NOT wrapped in enterInternalUpdate, which would
+            // defer them past the writing statement.
+            super.setValue("scrollingStatus", BrsBoolean.True);
+            super.setValue("itemUnfocused", new Int32(this.getValueJS("itemFocused") as number));
+        }
+        const distance = Math.abs(target - from) || 1;
+        this.scrollAnim = {
+            from,
+            to: target,
+            toIndex: index,
+            toColumn: column,
+            start: sgClock.perfNow(),
+            duration: distance * ArrayGrid.scrollMsPerItem,
+        };
+        this.enqueueScrollAnimation();
+    }
+
+    /**
+     * Publishes an in-transit fractional scroll position to the focus-position fields.
+     *
+     * A grid's flat content index maps onto both axes; a list scrolls only along rows and leaves the
+     * column alone (device-measured: a RowList's vertical scroll emitted no `currFocusColumn` at all
+     * during the ramp), so RowList overrides this.
+     * @param position Fractional content index currently on screen.
+     */
+    protected publishScrollPosition(position: number) {
+        const numCols = Math.max(1, this.numCols || 1);
+        super.setValue("currFocusRow", new Float(position / numCols));
+        super.setValue("currFocusColumn", new Float(position % numCols));
+    }
+
+    /** The fractional content index an in-flight scroll currently sits at. */
+    private currentScrollPosition(anim: ArrayGrid.ScrollAnimation): number {
+        const elapsed = sgClock.perfNow() - anim.start;
+        if (elapsed >= anim.duration || anim.duration <= 0) {
+            return anim.to;
+        }
+        const eased = ArrayGrid.easeInOut(Math.max(0, elapsed) / anim.duration);
+        return anim.from + (anim.to - anim.from) * eased;
+    }
+
+    /**
+     * Ease-in-out over a normalized 0..1 progress. The device curve accelerates to ~0.13 rows/frame
+     * mid-flight and decays to ~0.004 approaching the target; smoothstep reproduces that shape.
+     */
+    private static easeInOut(t: number): number {
+        const clamped = Math.min(1, Math.max(0, t));
+        return clamped * clamped * (3 - 2 * clamped);
+    }
+
+    /**
+     * Advances the in-flight scroll one frame. Called from the render loop via
+     * `sgRoot.processScrollAnimations`.
+     * @returns True while the scroll is still running (so the frame is marked dirty).
+     */
+    tickScrollAnimation(): boolean {
+        const anim = this.scrollAnim;
+        if (!anim) {
+            return false;
+        }
+        const elapsed = sgClock.perfNow() - anim.start;
+        if (elapsed < anim.duration) {
+            // In transit: publish the fractional position. currFocusRow/currFocusColumn are floats
+            // precisely so they can carry these values (arraygrid.md: currFocusRow "will go directly
+            // from 3.0 to 4.0 instead of taking on values between" only when animations are skipped).
+            this.focusLayoutDirty = true;
+            Field.enterInternalUpdate();
+            try {
+                this.publishScrollPosition(this.currentScrollPosition(anim));
+            } finally {
+                Field.exitInternalUpdate();
+            }
+            return true;
+        }
+        // Completed: hand off to the normal settle path, which applies the focus gate to the settled
+        // fields (and stays silent for an unfocused grid, matching probe A6).
+        this.scrollAnim = undefined;
+        this.dequeueScrollAnimation();
+        this.settleScrollAnimation(anim);
+        // Falling edge last, i.e. after the whole settle.
+        //
+        // KNOWN ONE-RECORD DEVIATION: a device interleaves it INSIDE the settle — probe A1 measured
+        // `itemFocused` (067), `scrollingStatus=false` (068), `rowItemFocused` (069). Reproducing that
+        // exactly would mean suppressing `rowItemFocused` inside `RowList.setFocusedItem` and
+        // re-emitting it here, which fights the pinned "rowItemFocused settles last" invariant
+        // (RowList.test.js) and touches four other `setRowItemFocused` call sites. Both orders keep the
+        // property apps actually rely on — the falling edge and the settle are adjacent, and an app
+        // that tears transient scroll state down on the edge still has the settle to rebuild from —
+        // so the interleave is left as-is until an app is found that depends on it.
+        super.setValue("scrollingStatus", BrsBoolean.False);
+        return true;
+    }
+
+    /**
+     * Emits the settled focus fields at the end of an animated scroll. Overridden by the list types
+     * that settle a [row, column] pair rather than a single index.
+     */
+    protected settleScrollAnimation(anim: ArrayGrid.ScrollAnimation) {
+        this.settlingScrollAnim = true;
+        try {
+            this.setFocusedItem(anim.toIndex);
+        } finally {
+            this.settlingScrollAnim = false;
+        }
+    }
+
+    /**
+     * Abandons an in-flight scroll without emitting anything. Used by `jumpToItem` (an immediate move
+     * supersedes a running one) and by teardown paths.
+     */
+    protected cancelScrollAnimation() {
+        if (!this.scrollAnim) {
+            return;
+        }
+        this.scrollAnim = undefined;
+        this.dequeueScrollAnimation();
+        // The pulse was opened by startScrollAnimation, so it must be closed or the field is stranded
+        // at true — which would silently suppress every later notification (it is not alwaysNotify).
+        super.setValue("scrollingStatus", BrsBoolean.False);
+    }
+
+    /** Registers with sgRoot so the render loop ticks this grid's scroll each frame. */
+    private enqueueScrollAnimation() {
+        if (!sgRoot.scrollAnimations.includes(this)) {
+            sgRoot.scrollAnimations.push(this);
+        }
+    }
+
+    /** Removes this grid from the render loop's scroll list. */
+    private dequeueScrollAnimation() {
+        const index = sgRoot.scrollAnimations.indexOf(this);
+        if (index > -1) {
+            sgRoot.scrollAnimations.splice(index, 1);
+        }
+    }
+
     handleKey(key: string, press: boolean): boolean {
         if (!press && this.lastPressHandled === key) {
             this.lastPressHandled = "";
@@ -503,6 +751,9 @@ export class ArrayGrid extends Group {
                 // Arm inside the try so an exception from either edge's observers still unwinds
                 // through the finally below and cannot strand the field at true.
                 this.armScrollPulse();
+                // Mark this as internal key navigation, so a subclass writing `animateToItem` as its
+                // move shortcut settles instantly rather than starting an animated scroll.
+                this.keyNavMove = true;
                 if (key === "up" || key === "down") {
                     handled = this.handleUpDown(key);
                 } else if (key === "left" || key === "right") {
@@ -511,6 +762,7 @@ export class ArrayGrid extends Group {
                     handled = this.handlePageUpDown(key);
                 }
             } finally {
+                this.keyNavMove = false;
                 // Disarm: a key that scrolled nothing emits no pulse at all (see armScrollPulse).
                 this.endScrollPulse();
             }

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -257,7 +257,34 @@ export class ArrayGrid extends Group {
                 }
             }
             if (focusIndex >= 0) {
-                this.setFocusedItem(focusIndex);
+                // Device-measured (`test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5): a
+                // focus-gain re-publishes the settle and its observers run BETWEEN the probe's
+                // `before` and `after` records — i.e. before `setFocus` returns.
+                //
+                // That timing is load-bearing, not cosmetic: an app that re-grabs focus from the
+                // resulting `rowItemFocused` observer (an overlay re-showing itself) must be
+                // classified by `Node.isFocusRequestDropped` as a backwards steal and dropped. That
+                // rule keys off `Node.focusNotifyOwners`, which is loaded only while the focus
+                // transaction is on the stack — so a deferred settle escapes it, the steal wins the
+                // live focus, and the app is stranded on the node it was navigating away from.
+                //
+                // Scoped to exactly that case: inline ONLY when a `focusedChild` notification is
+                // dispatching. A plain `setFocus` from app code has no transaction to defend, and
+                // forcing its settle inline there re-creates the reentrancy the deferral exists to
+                // prevent — an observer that assigns content to several lists and moves focus between
+                // the assignments would have a later list's `itemFocused` handler run while an
+                // earlier `content` is still `invalid` (deferred-observer-app).
+                const syncSettle = Node.inFocusNotification();
+                if (syncSettle) {
+                    Field.enterSyncFocusSettle();
+                }
+                try {
+                    this.setFocusedItem(focusIndex);
+                } finally {
+                    if (syncSettle) {
+                        Field.exitSyncFocusSettle();
+                    }
+                }
             }
         }
         return focus;

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -197,6 +197,12 @@ export class ArrayGrid extends Group {
      */
     protected settlingScrollAnim: boolean = false;
     /**
+     * A completing animated scroll still owes its `scrollingStatus=false`, which the settle path emits
+     * at the device's interleave point — after `itemFocused`, before `rowItemFocused`. See
+     * `emitPendingScrollFallingEdge`.
+     */
+    protected pendingScrollFallingEdge: boolean = false;
+    /**
      * Set while the grid's own key handling writes `animateToItem` as an internal shortcut, so the
      * write takes the INSTANT path instead of starting an animated scroll.
      *
@@ -454,6 +460,12 @@ export class ArrayGrid extends Group {
         } finally {
             Field.exitInternalUpdate();
         }
+        // A completing animated scroll closes its pulse HERE, right after itemFocused — the device's
+        // interleave point (see emitPendingScrollFallingEdge). Outside the bracket above so it
+        // dispatches synchronously rather than deferring past the settle it must sit inside. A grid
+        // type settles entirely in this method; RowList overrides the placement so the edge still
+        // precedes its own rowItemFocused.
+        this.emitPendingScrollFallingEdge();
     }
 
     protected findContentIndex(index: number) {
@@ -680,19 +692,39 @@ export class ArrayGrid extends Group {
         // fields (and stays silent for an unfocused grid, matching probe A6).
         this.scrollAnim = undefined;
         this.dequeueScrollAnimation();
-        this.settleScrollAnimation(anim);
-        // Falling edge last, i.e. after the whole settle.
+        // The falling edge is INTERLEAVED into the settle, not appended after it: a device emits
+        // `itemFocused`, then `scrollingStatus=false`, then `rowItemFocused` last (probe A1 records
+        // 067/068/069). `pendingScrollFallingEdge` makes the settle path emit it at that point.
         //
-        // KNOWN ONE-RECORD DEVIATION: a device interleaves it INSIDE the settle — probe A1 measured
-        // `itemFocused` (067), `scrollingStatus=false` (068), `rowItemFocused` (069). Reproducing that
-        // exactly would mean suppressing `rowItemFocused` inside `RowList.setFocusedItem` and
-        // re-emitting it here, which fights the pinned "rowItemFocused settles last" invariant
-        // (RowList.test.js) and touches four other `setRowItemFocused` call sites. Both orders keep the
-        // property apps actually rely on — the falling edge and the settle are adjacent, and an app
-        // that tears transient scroll state down on the edge still has the settle to rebuild from —
-        // so the interleave is left as-is until an app is found that depends on it.
-        super.setValue("scrollingStatus", BrsBoolean.False);
+        // This is load-bearing, not cosmetic. An app tears transient scroll state down on the RISING
+        // edge and rebuilds it on the FALLING edge, reading the settled focus position there — while
+        // treating the `rowItemFocused` observer as the authoritative "focus settled" callback that
+        // then re-derives its own state. Emitting the edge AFTER `rowItemFocused` inverts that: the
+        // rebuild runs first and the settle handler overwrites it, leaving the overlay hidden until
+        // some later navigation re-triggers it.
+        this.pendingScrollFallingEdge = true;
+        try {
+            this.settleScrollAnimation(anim);
+        } finally {
+            // Backstop: if the settle path never reached the interleave point (an empty/rejected
+            // target, or a subclass that settles without emitting), the edge must still close or
+            // `scrollingStatus` is stranded at true and silently suppresses every later notification.
+            this.emitPendingScrollFallingEdge();
+        }
         return true;
+    }
+
+    /**
+     * Emits the owed `scrollingStatus=false` for a completing animated scroll, if it has not gone out
+     * yet. Called from the settle path at the device's interleave point (between `itemFocused` and
+     * `rowItemFocused`) and again as a backstop when the settle returns.
+     */
+    protected emitPendingScrollFallingEdge() {
+        if (!this.pendingScrollFallingEdge) {
+            return;
+        }
+        this.pendingScrollFallingEdge = false;
+        super.setValue("scrollingStatus", BrsBoolean.False);
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -76,12 +76,18 @@ export declare namespace ArrayGrid {
         to: number;
         /** Target index as the app wrote it, for the `itemFocused` payload at completion. */
         toIndex: number;
-        /** Column to settle on, for the list types that track one; -1 to reuse the remembered one. */
-        toColumn: number;
         /** `sgClock.perfNow()` at the frame the scroll started. */
         start: number;
         /** Total duration in ms, scaled by the distance travelled. */
         duration: number;
+        /**
+         * Fractional position sampled once per frame by `tickScrollAnimation`, so every reader within
+         * that frame agrees. Reading the clock per accessor instead let the anchor's `Math.floor` and
+         * the sub-row remainder straddle a row boundary — a one-row layout jump — and violated the
+         * clock-free layout-pass contract (`docs/scenegraph-layout-passes.md`), since `renderContent`
+         * is reachable from a layout pass.
+         */
+        position: number;
     };
 }
 
@@ -603,7 +609,7 @@ export class ArrayGrid extends Group {
      * @param index Content index to scroll to, as the app wrote it.
      * @param column Column to settle on, or -1 to reuse the row's remembered column (RowList).
      */
-    protected startScrollAnimation(index: number, column: number = -1) {
+    protected startScrollAnimation(index: number) {
         const target = this.findContentIndex(index);
         if (target === -1) {
             return;
@@ -627,9 +633,9 @@ export class ArrayGrid extends Group {
             from,
             to: target,
             toIndex: index,
-            toColumn: column,
             start: sgClock.perfNow(),
             duration: this.scrollDuration(from, target),
+            position: from,
         };
         this.enqueueScrollAnimation();
     }
@@ -664,13 +670,23 @@ export class ArrayGrid extends Group {
         // `currFocusColumn` oscillated 0.14, 0.50, 0.02, … on a field whose only valid value is 0; and on
         // a multi-column grid a purely vertical move swept the column 0 → numCols-1 → 0 while the focused
         // column never changed. A device emits no column ramp for a vertical scroll at all.
-        if (
-            numCols > 1 &&
-            this.scrollAnim &&
-            Math.floor(this.scrollAnim.from) % numCols !== this.scrollAnim.to % numCols
-        ) {
+        if (this.scrollCrossesColumns()) {
             super.setValue("currFocusColumn", new Float(position % numCols));
         }
+    }
+
+    /**
+     * Whether the in-flight scroll actually changes the focused column.
+     *
+     * `from` is fractional (a retarget resumes mid-flight), so the starting column comes from its floor.
+     * A vertical-only move keeps the column, and a device emits no column ramp for one.
+     */
+    private scrollCrossesColumns(): boolean {
+        const numCols = Math.max(1, this.numCols || 1);
+        if (numCols === 1 || !this.scrollAnim) {
+            return false;
+        }
+        return Math.floor(this.scrollAnim.from) % numCols !== this.scrollAnim.to % numCols;
     }
 
     /**
@@ -683,11 +699,23 @@ export class ArrayGrid extends Group {
      * animating, so every non-animated path renders exactly as before.
      */
     protected scrollRowOffset(): number {
+        const row = this.scrollRowPosition();
+        return row === undefined ? 0 : row - Math.floor(row);
+    }
+
+    /**
+     * The in-flight scroll's position in ROW space, or undefined when nothing is animating.
+     *
+     * Row space, not flat content index: a grid's index spans columns, so `position` on a 6-column
+     * MarkupGrid mid-way through `animateToItem(6)` is 3.4 — an *item* fraction of 0.4, where the true
+     * row progress is 3.4/6. Dividing here keeps `scrollRowOffset`/`scrollAnchorRow` meaningful for
+     * every subclass rather than only for RowList, whose indices already are rows.
+     */
+    protected scrollRowPosition(): number | undefined {
         if (!this.scrollAnim) {
-            return 0;
+            return undefined;
         }
-        const position = this.currentScrollPosition(this.scrollAnim);
-        return position - Math.floor(position);
+        return this.scrollAnim.position / Math.max(1, this.numCols || 1);
     }
 
     /**
@@ -699,7 +727,8 @@ export class ArrayGrid extends Group {
         if (!this.scrollAnim) {
             return undefined;
         }
-        return Math.floor(this.currentScrollPosition(this.scrollAnim));
+        const row = this.scrollRowPosition();
+        return row === undefined ? undefined : Math.floor(row);
     }
 
     /** The fractional content index an in-flight scroll currently sits at. */
@@ -732,14 +761,24 @@ export class ArrayGrid extends Group {
             return false;
         }
         const elapsed = sgClock.perfNow() - anim.start;
+        // Sample once per frame; every reader this frame (publish below, and the render path's
+        // scrollRowOffset/scrollAnchorRow) uses this value rather than re-reading the clock.
+        anim.position = this.currentScrollPosition(anim);
         if (elapsed < anim.duration) {
             // In transit: publish the fractional position. currFocusRow/currFocusColumn are floats
             // precisely so they can carry these values (arraygrid.md: currFocusRow "will go directly
             // from 3.0 to 4.0 instead of taking on values between" only when animations are skipped).
-            this.focusLayoutDirty = true;
+            //
+            // Deliberately NOT setting focusLayoutDirty here. Its only consumer is
+            // needsSubBoundingRectRefresh, which makes a subBoundingRect query run a full-scene layout
+            // refresh — doing that per in-transit frame turns one layout pass per scroll into ~60 for
+            // any app measuring from a currFocusRow observer, which this ramp is what causes to fire
+            // every frame. The tick returns true so the frame repaints anyway, leaving rects at most one
+            // frame stale (the staleness Node.getSubBoundingRect already declares acceptable), and the
+            // settle still marks it dirty.
             Field.enterInternalUpdate();
             try {
-                this.publishScrollPosition(this.currentScrollPosition(anim));
+                this.publishScrollPosition(anim.position);
             } finally {
                 Field.exitInternalUpdate();
             }
@@ -813,6 +852,15 @@ export class ArrayGrid extends Group {
         // The pulse was opened by startScrollAnimation, so it must be closed or the field is stranded
         // at true — which would silently suppress every later notification (it is not alwaysNotify).
         super.setValue("scrollingStatus", BrsBoolean.False);
+    }
+
+    /**
+     * A detached grid stops scrolling: keep ticking and it forces a repaint every frame and eventually
+     * runs its settle — dispatching focus observers — on a node no longer in the tree.
+     */
+    removeParent() {
+        this.cancelScrollAnimation();
+        super.removeParent();
     }
 
     /** Registers with sgRoot so the render loop ticks this grid's scroll each frame. */

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -272,8 +272,12 @@ export class ArrayGrid extends Group {
             this.cancelScrollAnimation();
             this.setFocusedItem(jsValueOf(value));
         } else if (fieldName === "animatetoitem" && isNumberComp(value)) {
-            if (this.keyNavMove) {
-                // The grid's own key handler routes through this field; keep that instant (see keyNavMove).
+            // `keyNavMove` marks the grid's OWN move shortcut during key handling. An app observer that
+            // fires synchronously from the key-driven settle and writes animateToItem itself must not be
+            // caught by it — that write is app-initiated and should animate. Field.invoke already stashes
+            // the engine-emission markers for the duration of a callback for the same reason; this asks
+            // it whether a callback is executing right now.
+            if (this.keyNavMove && !Field.inObserverCallback()) {
                 this.setFocusedItem(jsValueOf(value));
             } else {
                 this.startScrollAnimation(jsValueOf(value) as number);
@@ -619,16 +623,29 @@ export class ArrayGrid extends Group {
             super.setValue("scrollingStatus", BrsBoolean.True);
             super.setValue("itemUnfocused", new Int32(this.getValueJS("itemFocused") as number));
         }
-        const distance = Math.abs(target - from) || 1;
         this.scrollAnim = {
             from,
             to: target,
             toIndex: index,
             toColumn: column,
             start: sgClock.perfNow(),
-            duration: distance * ArrayGrid.scrollMsPerItem,
+            duration: this.scrollDuration(from, target),
         };
         this.enqueueScrollAnimation();
+    }
+
+    /**
+     * Duration for a scroll from `from` to `to`, both flat content indices.
+     *
+     * `scrollMsPerItem` is per ROW traversed (device-measured), so the distance has to be converted out
+     * of the flat index space first: on a 6-column grid one row down is a flat delta of 6, and charging
+     * 340 ms per flat step made that move take ~2 s instead of ~364 ms. A grid scrolls vertically, so the
+     * row delta is what counts; RowList overrides this because its indices ARE rows.
+     */
+    protected scrollDuration(from: number, to: number): number {
+        const numCols = Math.max(1, this.numCols || 1);
+        const rows = Math.abs(Math.floor(to / numCols) - Math.floor(from / numCols));
+        return Math.max(1, rows) * ArrayGrid.scrollMsPerItem;
     }
 
     /**
@@ -642,7 +659,18 @@ export class ArrayGrid extends Group {
     protected publishScrollPosition(position: number) {
         const numCols = Math.max(1, this.numCols || 1);
         super.setValue("currFocusRow", new Float(position / numCols));
-        super.setValue("currFocusColumn", new Float(position % numCols));
+        // Only ramp the column when the scroll actually crosses columns. Mapping a flat index onto both
+        // axes emitted nonsense otherwise: on a single-column list `position % 1` is the ROW fraction, so
+        // `currFocusColumn` oscillated 0.14, 0.50, 0.02, … on a field whose only valid value is 0; and on
+        // a multi-column grid a purely vertical move swept the column 0 → numCols-1 → 0 while the focused
+        // column never changed. A device emits no column ramp for a vertical scroll at all.
+        if (
+            numCols > 1 &&
+            this.scrollAnim &&
+            Math.floor(this.scrollAnim.from) % numCols !== this.scrollAnim.to % numCols
+        ) {
+            super.setValue("currFocusColumn", new Float(position % numCols));
+        }
     }
 
     /**
@@ -779,6 +807,9 @@ export class ArrayGrid extends Group {
         }
         this.scrollAnim = undefined;
         this.dequeueScrollAnimation();
+        // Drop any owed interleave edge with the animation that owed it, or it leaks into whatever
+        // settles next and closes a pulse that settle never opened.
+        this.pendingScrollFallingEdge = false;
         // The pulse was opened by startScrollAnimation, so it must be closed or the field is stranded
         // at true — which would silently suppress every later notification (it is not alwaysNotify).
         super.setValue("scrollingStatus", BrsBoolean.False);
@@ -811,6 +842,14 @@ export class ArrayGrid extends Group {
             try {
                 // Arm inside the try so an exception from either edge's observers still unwinds
                 // through the finally below and cannot strand the field at true.
+                // A key press supersedes an app-initiated scroll that is still in flight, exactly as
+                // jumpToItem does. Without this the abandoned animation kept ticking against the old
+                // target and the pulse came out garbled: emitScrollPulse's rising edge was a no-op (the
+                // animation had already set scrollingStatus true), its falling edge fired mid-scroll, and
+                // the settle's own falling edge then wrote an already-false value and notified nobody —
+                // so an app that rebuilds state on the falling edge saw the teardown but never the
+                // rebuild. Cancel first, so the pulse below starts from a clean false.
+                this.cancelScrollAnimation();
                 this.armScrollPulse();
                 // Mark this as internal key navigation, so a subclass writing `animateToItem` as its
                 // move shortcut settles instantly rather than starting an animated scroll.

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -645,6 +645,35 @@ export class ArrayGrid extends Group {
         super.setValue("currFocusColumn", new Float(position % numCols));
     }
 
+    /**
+     * How far, in rows, an in-flight animated scroll has travelled past the row the render window is
+     * anchored to — always in `[0, 1)` after the integer part is folded into the anchor row.
+     *
+     * This is what makes the scroll VISIBLE rather than merely observable: the render path lays rows out
+     * from an integer anchor (`currRow`) plus a per-row Y advance, so without a sub-row offset the
+     * fields ramp while the pixels stay put until the settle snaps them. Returns 0 when nothing is
+     * animating, so every non-animated path renders exactly as before.
+     */
+    protected scrollRowOffset(): number {
+        if (!this.scrollAnim) {
+            return 0;
+        }
+        const position = this.currentScrollPosition(this.scrollAnim);
+        return position - Math.floor(position);
+    }
+
+    /**
+     * The integer row the render window is anchored to while a scroll is in flight, or undefined when
+     * nothing is animating. Together with `scrollRowOffset` this splits the fractional position into
+     * "which row is at the top" and "how far past it we are".
+     */
+    protected scrollAnchorRow(): number | undefined {
+        if (!this.scrollAnim) {
+            return undefined;
+        }
+        return Math.floor(this.currentScrollPosition(this.scrollAnim));
+    }
+
     /** The fractional content index an in-flight scroll currently sits at. */
     private currentScrollPosition(anim: ArrayGrid.ScrollAnimation): number {
         const elapsed = sgClock.perfNow() - anim.start;

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -155,6 +155,18 @@ export class Field {
         Field.syncFocusSettleDepth--;
     }
 
+    /**
+     * Whether an app observer callback is executing right now.
+     *
+     * Lets an engine site tell its own bookkeeping apart from a write made by app BrightScript that its
+     * emission just dispatched — e.g. `ArrayGrid` marks key navigation for the duration of a key press,
+     * but an app observer firing from that key's settle and writing `animateToItem` is app-initiated and
+     * must animate.
+     */
+    static inObserverCallback(): boolean {
+        return Field.observerDepth > 0;
+    }
+
     /** Marks entry into a component's `init()` (the init hierarchy walk). */
     static enterInit() {
         Field.initDepth++;

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -75,6 +75,12 @@ export class Field {
      */
     private static internalUpdateDepth = 0;
     /**
+     * >0 while a focus-GAIN settle is being published, which a device dispatches synchronously even
+     * though every other grid emission defers. Overrides the deferral in `executeCallbacks`; see
+     * `enterSyncFocusSettle` for why the timing is load-bearing.
+     */
+    private static syncFocusSettleDepth = 0;
+    /**
      * >0 while a component's `init()` is running (the `init` hierarchy walk in `initializeNode`).
      * Focus emissions raised during `init` must defer until the OUTERMOST init unwinds — on Roku a
      * `setFocus(true)` in `init()` dispatches its `focusedChild` observers from the message loop
@@ -129,6 +135,24 @@ export class Field {
     /** Marks exit from an engine-initiated field emission. */
     static exitInternalUpdate() {
         Field.internalUpdateDepth--;
+    }
+
+    /**
+     * Marks a focus-gain settle that must dispatch SYNCHRONOUSLY rather than defer.
+     *
+     * Device-measured (`test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5): when a grid gains
+     * focus it re-publishes its focus fields and those observers run before `setFocus` returns. Every
+     * other engine-initiated grid emission defers (see `internalUpdateDepth`), and applying that here
+     * broke the focus-steal drop rule, which can only classify a nested `setFocus` while the focus
+     * transaction is still on the stack (`Node.focusNotifyOwners`).
+     */
+    static enterSyncFocusSettle() {
+        Field.syncFocusSettleDepth++;
+    }
+
+    /** Marks exit from a synchronous focus-gain settle. */
+    static exitSyncFocusSettle() {
+        Field.syncFocusSettleDepth--;
     }
 
     /** Marks entry into a component's `init()` (the init hierarchy walk). */
@@ -197,6 +221,7 @@ export class Field {
         Field.observerDepth = 0;
         Field.parentCascadeDepth = 0;
         Field.internalUpdateDepth = 0;
+        Field.syncFocusSettleDepth = 0;
         Field.initDepth = 0;
         Field.focusEmissionDepth = 0;
         Field.draining = false;
@@ -749,7 +774,10 @@ export class Field {
             Field.internalUpdateDepth > 0 &&
             Field.observerDepth > 0 &&
             !Field.draining &&
-            Field.parentCascadeDepth === 0
+            Field.parentCascadeDepth === 0 &&
+            // A focus-gain settle dispatches inline: a device runs these observers before setFocus
+            // returns, and the focus-steal drop rule depends on that (see enterSyncFocusSettle).
+            Field.syncFocusSettleDepth === 0
         ) {
             Field.deferredQueue.push({ field: this, callback, event });
             return;
@@ -840,13 +868,20 @@ export class Field {
         // re-enters them on its own.
         const stashedInternalDepth = Field.internalUpdateDepth;
         const stashedFocusDepth = Field.focusEmissionDepth;
+        // Stashed for the same reason: the sync-dispatch exemption applies to the focus-gain settle
+        // itself, not to whatever the handler goes on to trigger. A grid emission raised from inside
+        // this callback must defer as usual, or a reentrant cascade dispatches inline and loses the
+        // handler-boundary ordering the deferral exists to preserve.
+        const stashedSyncSettle = Field.syncFocusSettleDepth;
         Field.internalUpdateDepth = 0;
         Field.focusEmissionDepth = 0;
+        Field.syncFocusSettleDepth = 0;
         try {
             this.invokeCallable(callback, event);
         } finally {
             Field.internalUpdateDepth = stashedInternalDepth;
             Field.focusEmissionDepth = stashedFocusDepth;
+            Field.syncFocusSettleDepth = stashedSyncSettle;
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1541,6 +1541,19 @@ export class Node extends RoSGNode implements BrsValue {
         if (ownerInChain !== owner) {
             return true;
         }
+        // The target test applies ONLY when the owner is a PROPER ANCESTOR of the focused node, i.e. the
+        // container shape: the owner handed focus down into its own subtree, and something reached from
+        // that notification is now trying to pull focus back out. That is the steal to drop.
+        //
+        // When the owner IS the focused node the transaction staged `focusedChild` on the leaf itself
+        // (see setNodeFocus's final stageFocusedChild), so the node observing its own focus gain is
+        // simply deciding where focus should go next — the "I got focus but have nothing to show, pass it
+        // on" pattern, which legitimately targets a sibling or its own parent. Applying the subtree test
+        // there dropped both, a regression against pre-change behavior that `focus-probe2` never covered
+        // (N1/N2 only measured forward focus INTO a container's subtree).
+        if (owner === focused) {
+            return false;
+        }
         let targetUnderOwner: BrsType = target;
         while (targetUnderOwner instanceof Node && targetUnderOwner !== owner) {
             targetUnderOwner = targetUnderOwner.parent;

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -92,6 +92,18 @@ export class Node extends RoSGNode implements BrsValue {
      * focus onward) from a focus-loss one (whose focus requests a Roku ignores).
      */
     private static readonly focusNotifyOwners: Node[] = [];
+
+    /**
+     * Whether a `focusedChild` notification is dispatching right now, i.e. a focus transaction is on
+     * the stack and a nested `setFocus` raised from here can still be classified by
+     * `isFocusRequestDropped`.
+     *
+     * Read by `ArrayGrid.setNodeFocus` to decide whether its focus-gain settle must dispatch inline:
+     * only then does the timing matter, because only then is there a transaction to defend.
+     */
+    static inFocusNotification(): boolean {
+        return Node.focusNotifyOwners.length > 0;
+    }
     /**
      * Set while a focus transaction stages its `focusedChild` writes: `setValue` applies the value
      * but routes the notification here instead of dispatching it — see `stageFocusedChild`.
@@ -1329,7 +1341,7 @@ export class Node extends RoSGNode implements BrsValue {
      * @returns Whether the node is focusable.
      */
     setNodeFocus(focusOn: boolean): boolean {
-        if (focusOn && Node.isFocusRequestDropped()) {
+        if (focusOn && Node.isFocusRequestDropped(this)) {
             // Device-measured: Roku ignores a focus request raised from a focus-LOSS notification
             // (see notifyStagedFocus). Report the request as not applied, so a subclass override
             // gated on `super.setNodeFocus(...)` skips its focus bookkeeping too (an ArrayGrid must
@@ -1492,20 +1504,48 @@ export class Node extends RoSGNode implements BrsValue {
      * pointing at different nodes.
      * @returns True when the in-flight notification is a focus loss, so the request is ignored.
      */
-    private static isFocusRequestDropped(): boolean {
+    private static isFocusRequestDropped(target: Node): boolean {
         const owner = Node.focusNotifyOwners.at(-1);
         const focused = sgRoot.focused;
         if (!owner || !(focused instanceof Node)) {
             return false;
         }
-        // Is the owner still in the focus chain? Cheap upward walk from the focused node, the same
-        // shape restoreFocusChainOnAttach uses — an O(subtree) descent would be walked on every
-        // focus request made from inside a notification.
-        let ancestor: BrsType = focused;
-        while (ancestor instanceof Node && ancestor !== owner) {
-            ancestor = ancestor.parent;
+        // Classify by BOTH the notifying owner and the TARGET.
+        //
+        // The rule `focus-probe2` established is (a): a nested request is dropped only when it targets
+        // a node OUTSIDE the subtree the in-flight transaction just focused, while redirecting focus
+        // WITHIN that subtree is allowed. "Within" means inside the notifying owner — forward focus
+        // routinely targets a SIBLING of the focused leaf (a container handing focus from its first
+        // child to another, which is how a dialog highlights its buttons), so testing only whether the
+        // target sits at-or-below the live focus is too strict and breaks that pattern.
+        //
+        // Two conditions, and both matter:
+        //   1. The owner must still be in the focus chain. A request from a node that just LOST focus
+        //      is the classic backwards steal (probe2 N3).
+        //   2. The target must be inside the owner's subtree. Otherwise a container that observes its
+        //      own `focusedChild`, redirects focus to its inner list, and then has the list's
+        //      focus-gain settle run an app observer that re-grabs focus to an unrelated sibling would
+        //      slip through: the owner IS still in the chain (focus went to its own child), so
+        //      condition 1 alone reads that steal as a legal forward focus and strands the app on the
+        //      node it was navigating away from.
+        if (target === focused) {
+            // Re-asserting the node that just took focus is idempotent, never a steal (probe2 N4).
+            return false;
         }
-        return ancestor !== owner;
+        // Cheap upward walks, the same shape restoreFocusChainOnAttach uses — an O(subtree) descent
+        // would run on every nested focus request.
+        let ownerInChain: BrsType = focused;
+        while (ownerInChain instanceof Node && ownerInChain !== owner) {
+            ownerInChain = ownerInChain.parent;
+        }
+        if (ownerInChain !== owner) {
+            return true;
+        }
+        let targetUnderOwner: BrsType = target;
+        while (targetUnderOwner instanceof Node && targetUnderOwner !== owner) {
+            targetUnderOwner = targetUnderOwner.parent;
+        }
+        return targetUnderOwner !== owner;
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -165,6 +165,11 @@ export class RowList extends ArrayGrid {
         super.setValue("currFocusRow", new Float(position));
     }
 
+    /** A RowList's indices are already rows, so no flat-index-to-row conversion is needed. */
+    protected scrollDuration(from: number, to: number): number {
+        return Math.max(1, Math.abs(to - from)) * ArrayGrid.scrollMsPerItem;
+    }
+
     /**
      * Settles an animated scroll on a row, reusing the row's remembered column.
      *
@@ -702,6 +707,7 @@ export class RowList extends ArrayGrid {
         // `scrollRowOffset` is the [0,1) remainder, converted to pixels with the anchor row's own pitch
         // because rows may differ in height (rowHeights).
         const scrollOffset = this.scrollRowOffset();
+        let scrollShift = 0;
         if (scrollOffset > 0) {
             const anchor = this.scrollAnchorRow();
             if (anchor !== undefined) {
@@ -712,7 +718,8 @@ export class RowList extends ArrayGrid {
             const rowHeight = context.rowHeights[this.currRow] ?? context.itemSize[1] ?? 0;
             const pitch =
                 rowHeight + this.calculateRowSpacing(this.currRow, context.rowSpacings, context.globalSpacing);
-            context.itemRect.y -= scrollOffset * pitch;
+            scrollShift = scrollOffset * pitch;
+            context.itemRect.y -= scrollShift;
         }
 
         // Rows advance by their own height plus, when the label/counter band does not fit in the row's
@@ -727,12 +734,18 @@ export class RowList extends ArrayGrid {
         // viewport test still stops the pass early when that row lands off screen, and the row count
         // reported to updateRect below is the settled `displayRows` either way.
         const rowsToRender = scrollOffset > 0 ? context.displayRows + 1 : context.displayRows;
+        // Extent contributed by the extra row, so the reported rect can exclude it (see below).
+        let extraRowExtent = 0;
         for (let r = 0; r < rowsToRender; r++) {
             const rowIndex = this.calculateActualRowIndex(r);
             if (rowIndex === -1) {
                 break;
             }
+            const beforeY = context.itemRect.y;
             const fits = this.renderSingleRow(rowIndex, r, context);
+            if (r >= context.displayRows) {
+                extraRowExtent = context.itemRect.y - beforeY;
+            }
             renderedRows++;
             trailingSpacing = this.calculateRowSpacing(rowIndex, context.rowSpacings, context.globalSpacing);
             if (!fits) {
@@ -740,7 +753,15 @@ export class RowList extends ArrayGrid {
             }
         }
         const margin = this.rectMargins();
-        const height = renderedRows === 0 ? 0 : context.itemRect.y - startY - trailingSpacing + margin.y * 2;
+        let height = renderedRows === 0 ? 0 : context.itemRect.y - startY - trailingSpacing + margin.y * 2;
+        if (scrollOffset > 0) {
+            // Report the SETTLED extent while scrolling, not the transient one. The loop above drew an
+            // extra row and started a sub-row higher, so the accumulated extent overstates the list by
+            // most of a row pitch — an app sizing a background or overlay from boundingRect() would watch
+            // it grow and shrink every frame of the scroll. Recompute from the rows the list actually
+            // occupies once settled, dropping the extra row and the shift.
+            height = Math.max(0, height - (extraRowExtent + scrollShift));
+        }
         this.updateRect(rect, context.displayRows, context.itemSize, { height, firstRow: this.currRow });
     }
 

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -695,6 +695,26 @@ export class RowList extends ArrayGrid {
             this.currRow = this.topRow;
         }
 
+        // While an animated scroll is in flight, anchor the window to the row it has reached and shift
+        // the whole layout up by the sub-row remainder, so the rows visibly slide instead of snapping at
+        // the settle. `scrollAnchorRow` is the integer part of the animated position and takes over from
+        // the settled `currRow`/`topRow` above (which still hold the pre-move row until completion);
+        // `scrollRowOffset` is the [0,1) remainder, converted to pixels with the anchor row's own pitch
+        // because rows may differ in height (rowHeights).
+        const scrollOffset = this.scrollRowOffset();
+        if (scrollOffset > 0) {
+            const anchor = this.scrollAnchorRow();
+            if (anchor !== undefined) {
+                this.currRow = this.isFixedFocusMode() ? anchor : Math.max(0, anchor);
+            }
+            // Same row-height resolution renderSingleRow uses (rowHeights indexed by absolute row,
+            // falling back to itemSize), plus that row's spacing — the pitch to the next row down.
+            const rowHeight = context.rowHeights[this.currRow] ?? context.itemSize[1] ?? 0;
+            const pitch =
+                rowHeight + this.calculateRowSpacing(this.currRow, context.rowSpacings, context.globalSpacing);
+            context.itemRect.y -= scrollOffset * pitch;
+        }
+
         // Rows advance by their own height plus, when the label/counter band does not fit in the row's
         // slack, that band's height (see renderSingleRow). No arithmetic in updateRect can reproduce
         // that without re-measuring the label, so accumulate the extent the loop actually laid out and
@@ -702,7 +722,12 @@ export class RowList extends ArrayGrid {
         const startY = context.itemRect.y;
         let renderedRows = 0;
         let trailingSpacing = 0;
-        for (let r = 0; r < context.displayRows; r++) {
+        // Shifting the layout up by a sub-row offset opens a gap at the bottom of the window, so draw
+        // one extra row while a scroll is in flight — the row sliding in. renderSingleRow's own
+        // viewport test still stops the pass early when that row lands off screen, and the row count
+        // reported to updateRect below is the settled `displayRows` either way.
+        const rowsToRender = scrollOffset > 0 ? context.displayRows + 1 : context.displayRows;
+        for (let r = 0; r < rowsToRender; r++) {
             const rowIndex = this.calculateActualRowIndex(r);
             if (rowIndex === -1) {
                 break;

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -146,6 +146,8 @@ export class RowList extends ArrayGrid {
         } else if (fieldName === "jumptorowitem" && value instanceof RoArray) {
             const rowItem = jsValueOf(value) as any[];
             if (typeof rowItem[0] === "number" && typeof rowItem[1] === "number") {
+                // An immediate move supersedes any in-flight animated scroll, as jumpToItem does.
+                this.cancelScrollAnimation();
                 this.setFocusedItem(rowItem[0], rowItem[1]);
             }
         } else if (["horizfocusanimationstyle", "numcolumns"].includes(fieldName)) {
@@ -153,6 +155,29 @@ export class RowList extends ArrayGrid {
             return;
         }
         super.setValue(index, value, alwaysNotify, kind);
+    }
+
+    /**
+     * A RowList's scroll position IS a row index, and a vertical scroll leaves the focused column
+     * alone — device-measured: the ramp emitted `currFocusRow` only, never `currFocusColumn`.
+     */
+    protected publishScrollPosition(position: number) {
+        super.setValue("currFocusRow", new Float(position));
+    }
+
+    /**
+     * Settles an animated scroll on a row, reusing the row's remembered column.
+     *
+     * Overridden because `ArrayGrid.setFocusedItem` takes a single index while a RowList settles a
+     * [row, column] pair — and because the base class's flat `index` is a row index here.
+     */
+    protected settleScrollAnimation(anim: ArrayGrid.ScrollAnimation) {
+        this.settlingScrollAnim = true;
+        try {
+            this.setFocusedItem(anim.toIndex, anim.toColumn);
+        } finally {
+            this.settlingScrollAnim = false;
+        }
     }
 
     protected setFocusedItem(rowIndex: number, colIndex: number = -1) {
@@ -170,15 +195,16 @@ export class RowList extends ArrayGrid {
         // but do NOT notify observers; setNodeFocus re-emits on focus-gain. See ArrayGrid.setFocusedItem.
         const inFocusChain = sgRoot.focused === this || this.isChildrenFocused();
 
-        if (inFocusChain) {
+        if (inFocusChain && !this.settlingScrollAnim) {
             // Emit the scroll pulse before ANY of the settled focus fields go out — itemUnfocused
             // below included, so the order matches ArrayGrid.setFocusedItem. See armScrollPulse for
             // why the pulse precedes the settle, and why it is skipped entirely when the list is
-            // outside the focus chain (that path notifies nothing).
+            // outside the focus chain (that path notifies nothing). Skipped while an animated scroll
+            // settles: that pulse opened at animation start (see startScrollAnimation).
             this.emitScrollPulse();
         }
 
-        if (isChangingRow && inFocusChain) {
+        if (isChangingRow && inFocusChain && !this.settlingScrollAnim) {
             // Engine-initiated emission (not a direct BrightScript assignment): on Roku its
             // observers dispatch from the message loop, so a reentrant notification defers
             // (see Field.enterInternalUpdate).

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -287,6 +287,12 @@ export class RowList extends ArrayGrid {
             } finally {
                 Field.exitInternalUpdate();
             }
+            // A completing animated scroll closes its pulse between itemFocused (just emitted) and
+            // rowItemFocused (emitted by setRowItemFocused below) — the device's interleave point.
+            // An app rebuilds its focused-item overlay on this falling edge and then treats the
+            // rowItemFocused observer as the authoritative settle; reversing the two lets the settle
+            // handler overwrite the rebuild. See ArrayGrid.emitPendingScrollFallingEdge.
+            this.emitPendingScrollFallingEdge();
             this.setRowItemFocused(rowIndex, colIndex);
         } else {
             // Unfocused: remember the row/column silently (no observer notification). The values are

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -157,34 +157,6 @@ export class RowList extends ArrayGrid {
         super.setValue(index, value, alwaysNotify, kind);
     }
 
-    /**
-     * A RowList's scroll position IS a row index, and a vertical scroll leaves the focused column
-     * alone — device-measured: the ramp emitted `currFocusRow` only, never `currFocusColumn`.
-     */
-    protected publishScrollPosition(position: number) {
-        super.setValue("currFocusRow", new Float(position));
-    }
-
-    /** A RowList's indices are already rows, so no flat-index-to-row conversion is needed. */
-    protected scrollDuration(from: number, to: number): number {
-        return Math.max(1, Math.abs(to - from)) * ArrayGrid.scrollMsPerItem;
-    }
-
-    /**
-     * Settles an animated scroll on a row, reusing the row's remembered column.
-     *
-     * Overridden because `ArrayGrid.setFocusedItem` takes a single index while a RowList settles a
-     * [row, column] pair — and because the base class's flat `index` is a row index here.
-     */
-    protected settleScrollAnimation(anim: ArrayGrid.ScrollAnimation) {
-        this.settlingScrollAnim = true;
-        try {
-            this.setFocusedItem(anim.toIndex, anim.toColumn);
-        } finally {
-            this.settlingScrollAnim = false;
-        }
-    }
-
     protected setFocusedItem(rowIndex: number, colIndex: number = -1) {
         if (rowIndex < 0 || rowIndex >= this.content.length) {
             return;
@@ -715,7 +687,10 @@ export class RowList extends ArrayGrid {
             }
             // Same row-height resolution renderSingleRow uses (rowHeights indexed by absolute row,
             // falling back to itemSize), plus that row's spacing — the pitch to the next row down.
-            const rowHeight = context.rowHeights[this.currRow] ?? context.itemSize[1] ?? 0;
+            // resolveTrackValue, not `?? itemSize[1]`: it is the shared resolver for these per-row
+            // arrays (see ArrayGrid.updateRect) and it rejects non-finite entries, so a NaN in
+            // rowHeights cannot propagate into the shift and blank the layout for the whole scroll.
+            const rowHeight = this.resolveTrackValue(context.rowHeights, this.currRow, context.itemSize[1]);
             const pitch =
                 rowHeight + this.calculateRowSpacing(this.currRow, context.rowSpacings, context.globalSpacing);
             scrollShift = scrollOffset * pitch;

--- a/test/cli/cli-scenegraph.test.js
+++ b/test/cli/cli-scenegraph.test.js
@@ -371,6 +371,42 @@ describe.concurrent("cli scenegraph", () => {
         ]);
     }, 30000);
 
+    it("Animates animateToItem so the focus settle outlives the key handler that wrote it", async () => {
+        let command = ["node", brsCliPath, "-r list-refocus-overlay-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // An overlay is a SIBLING of a RowList and is re-shown from an observer on the list's
+        // rowItemFocused that reads the field LIVE. The key handler must hand focus to the list BEFORE
+        // moving a row (a list's container may jumpToItem on focus change), so (A) setFocus,
+        // (B) animateToItem, (C) hide run in one call.
+        //
+        // Verified on a real Roku (test/simulator/probes/grid-scroll-animation-probe): animateToItem
+        // starts an ANIMATED scroll, ~340 ms per row, that outlives the handler. The `inflight:` line
+        // is sampled a few frames after the handler returned and is what an instant move cannot
+        // produce: still scrolling, currFocusRow between two rows, itemFocused still on the OUTGOING
+        // row. Previously the move completed inside the handler, so (B)'s settle landed before (C)
+        // describing the outgoing row and re-showed the overlay (C) was about to hide.
+        //
+        // The showOverlay between A and B is expected and device-accurate: it comes from (A)'s
+        // focus-gain re-emission for an unchanged position, not from the move.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== List Refocus Overlay Repro ===",
+            "scenario ready: overlayFocus = true row =  0",
+            "A: handing focus to the list (row =  0)",
+            "showOverlay (live row =  0)",
+            "B: animateToItem =  1",
+            "C: hiding the overlay",
+            "inflight: scrolling = true settled = false itemFocused =  0",
+            "final: overlayVisible = false currFocusRow =  1 itemFocused =  1",
+            "=== List Refocus Overlay Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     it("Defers a focusedChild notification raised during init() so a later-registered observer fires", async () => {
         let command = ["node", brsCliPath, "-r init-focus-observer-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/list-refocus-overlay-app/components/MainScene.xml
+++ b/test/cli/resources/list-refocus-overlay-app/components/MainScene.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models a real app shape: an overlay parented as a SIBLING of a RowList, re-shown from an observer
+    on the list's `rowItemFocused` that reads the field LIVE off the node (not from event.getData()).
+
+    The key handler must hand focus to the list BEFORE moving a row — a necessary order, because a
+    list's container may jumpToItem when focus changes — so the sequence is:
+
+        (A) list.setFocus(true)
+        (B) list.animateToItem = currFocusRow + 1
+        (C) hideOverlay()
+
+    Verified on a real Roku device: `animateToItem` starts an ANIMATED scroll (~340 ms per row) that
+    OUTLIVES the key handler. What this app pins is that (B)'s settle does not land inside the handler:
+    a few frames after `pressDown` returns the list is still mid-scroll — `scrollingStatus` is true,
+    `currFocusRow` sits BETWEEN two rows, and `itemFocused` still reports the OUTGOING row. An instant
+    move cannot produce that state, so `inflight:` is what discriminates the two implementations.
+
+    Note the `showOverlay` between (A) and (B) is expected and device-accurate: it comes from (A)'s
+    focus-gain re-emission of `rowItemFocused` (a real Roku re-emits the settle for an unchanged
+    position — measured in `test/simulator/probes/list-refocus-settle-probe`, R2/R4/R5), NOT from the
+    move. The app tolerates it because (C) hides the overlay afterwards; what broke a real app was
+    (B)'s settle ALSO landing before (C) while describing the outgoing row, which the animated scroll
+    now defers past the handler.
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+        <function name="startScenario" />
+        <function name="pressDown" />
+        <function name="reportInFlight" />
+        <function name="report" />
+    </interface>
+    <children>
+        <RowList
+            id="list"
+            itemComponentName="OverlayItem"
+            itemSize="[1000, 240]"
+            rowItemSize="[[300, 200]]"
+            numRows="3"
+            translation="[100, 300]" />
+        <Rectangle
+            id="overlay"
+            width="600"
+            height="160"
+            translation="[100, 100]"
+            color="0xCC7722FF"
+            focusable="true" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.list = m.top.findNode("list")
+        m.overlay = m.top.findNode("overlay")
+        ' The overlay belongs to row 0; focusing that row is what re-shows it.
+        m.overlayRow = 0
+
+        content = createObject("roSGNode", "ContentNode")
+        for r = 0 to 3
+            row = content.createChild("ContentNode")
+            for c = 0 to 1
+                item = row.createChild("ContentNode")
+                item.title = "R" + str(r).trim() + "C" + str(c).trim()
+            end for
+        end for
+        m.list.content = content
+
+        m.list.observeField("rowItemFocused", "onRowItemFocused")
+    end sub
+
+    ' Reads rowItemFocused LIVE, as a real app does, and re-shows the overlay when the focused row is
+    ' the overlay's row. A "showOverlay" line printed between "A:" and "C:" is the bug reproducing.
+    sub onRowItemFocused()
+        live = m.list.rowItemFocused
+        if live <> invalid and live.count() = 2 and live[0] = m.overlayRow
+            print "showOverlay (live row = "; live[0]; ")"
+            m.overlay.visible = true
+        end if
+    end sub
+
+    ' Puts the app in the state the user is in: overlay visible and focused, list parked on row 0.
+    sub startScenario()
+        m.list.jumpToRowItem = [m.overlayRow, 0]
+        m.overlay.visible = true
+        m.overlay.setFocus(true)
+        print "scenario ready: overlayFocus = "; m.overlay.hasFocus(); " row = "; m.list.currFocusRow
+    end sub
+
+    ' The app's navigate-out-of-the-overlay handler, in the order a real app must use it.
+    sub pressDown()
+        row = m.list.currFocusRow
+        print "A: handing focus to the list (row = "; row; ")"
+        m.list.setFocus(true)
+        print "B: animateToItem = "; row + 1
+        m.list.animateToItem = row + 1
+        print "C: hiding the overlay"
+        m.overlay.visible = false
+    end sub
+
+    ' Sampled a few frames after the handler returned, while the scroll is still in flight. This is
+    ' the observable difference an instant move cannot produce: currFocusRow sits BETWEEN the rows
+    ' (fractional) and itemFocused still reports the OUTGOING row, because the settle has not run yet.
+    sub reportInFlight()
+        row = m.list.currFocusRow
+        print "inflight: scrolling = "; m.list.scrollingStatus; " settled = "; (row = int(row)); " itemFocused = "; m.list.itemFocused
+    end sub
+
+    sub report()
+        print "final: overlayVisible = "; m.overlay.visible; " currFocusRow = "; m.list.currFocusRow; " itemFocused = "; m.list.itemFocused
+        m.top.done = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/list-refocus-overlay-app/components/OverlayItem.xml
+++ b/test/cli/resources/list-refocus-overlay-app/components/OverlayItem.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Minimal item component: this app pins field-emission ordering, not rendering. -->
+<component name="OverlayItem" extends="Group">
+    <children>
+        <Rectangle id="bg" width="300" height="200" color="0x223344FF" />
+        <Label id="label" translation="[12, 12]" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.observeField("itemContent", "onItemContent")
+    end sub
+
+    sub onItemContent()
+        if m.top.itemContent <> invalid
+            m.top.findNode("label").text = m.top.itemContent.title
+        end if
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/list-refocus-overlay-app/manifest
+++ b/test/cli/resources/list-refocus-overlay-app/manifest
@@ -1,0 +1,4 @@
+title=List Refocus Overlay Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/list-refocus-overlay-app/source/main.brs
+++ b/test/cli/resources/list-refocus-overlay-app/source/main.brs
@@ -1,0 +1,33 @@
+sub Main()
+    print "=== List Refocus Overlay Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+
+    ' Let the scene render and settle before arming the scenario.
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    scene.callFunc("startScenario")
+
+    for i = 0 to 3
+        msg = wait(20, port)
+    end for
+    ' The whole (A)(B)(C) handler runs inside this one call, as a key handler would.
+    scene.callFunc("pressDown")
+
+    ' Sample while the scroll is still in flight (a few frames in, well under the ~340ms duration).
+    for i = 0 to 2
+        msg = wait(20, port)
+    end for
+    scene.callFunc("reportInFlight")
+
+    ' Pump well past the ~340ms scroll so the animation completes and settles.
+    for i = 0 to 40
+        msg = wait(20, port)
+    end for
+    scene.callFunc("report")
+    print "=== List Refocus Overlay Repro Complete ==="
+end sub

--- a/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
+++ b/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
@@ -1,0 +1,271 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot, sgClock } = scenegraph;
+const { BrsDevice, BrsBoolean, BrsString, Int32, RoArray, RoMessagePort } = core;
+
+/** Builds a root → rows → items ContentNode tree; `rows` is an array of arrays of item titles. */
+function buildContent(rows) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (const items of rows) {
+        const rowNode = SGNodeFactory.createNode("ContentNode");
+        for (const title of items) {
+            const itemNode = SGNodeFactory.createNode("ContentNode");
+            itemNode.setValue("title", new BrsString(title));
+            rowNode.appendChildToParent(itemNode);
+        }
+        root.appendChildToParent(rowNode);
+    }
+    return root;
+}
+
+/**
+ * `animateToItem` is an ANIMATED focus scroll on a real device, not an instant move. Measured on a
+ * Roku Streaming Stick+ (OS 15.3) with `test/simulator/probes/grid-scroll-animation-probe`:
+ *
+ *   - The duration scales with the distance travelled: 364 ms for 1 row, 686 ms for 2, 1021 ms for 3
+ *     (~340 ms per row), following an ease-in-out curve.
+ *   - `scrollingStatus = true` and `itemUnfocused` are emitted at animation START, before the app's
+ *     assignment even returns — NOT as part of the settle, which is where key navigation emits them.
+ *   - `currFocusRow` then carries fractional in-transit values every frame.
+ *   - The settled fields (`itemFocused`, `rowItemFocused`) are emitted only at COMPLETION.
+ *   - `jumpToItem` does not animate at all (probe A2).
+ *
+ * This matters behaviorally, not just visually: an app whose key handler hands focus to a list and
+ * THEN writes `animateToItem` (a necessary order — the list's container may jumpToItem on focus
+ * change) depends on the move outliving the handler. With an instant move the settle lands inside the
+ * handler and drives app logic off a position the user already navigated away from.
+ *
+ * Time is driven through the injectable `sgClock` so these are deterministic rather than wall-clock
+ * dependent (see SGClock.ts).
+ */
+describe("ArrayGrid animateToItem animates the focus scroll", () => {
+    let fakeNow = 0;
+
+    beforeAll(() => {
+        // List/grid nodes have font-typed defaults; mount the common: volume once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        fakeNow = 1000;
+        sgClock.setSource({ now: () => fakeNow, perfNow: () => fakeNow });
+    });
+
+    afterEach(() => {
+        sgClock.setSource();
+        sgRoot.setFocused();
+        sgRoot.scrollAnimations.length = 0;
+    });
+
+    const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+    /**
+     * Observes `fields` through one shared port and returns the merged notification log as
+     * `"field=value"` entries, so both the values AND their relative order are pinned.
+     */
+    function observe(node, fields) {
+        const log = [];
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            const name = event.fieldName ? event.fieldName.getValue() : "";
+            const value = event.fieldValue?.getValue?.();
+            log.push(`${name}=${Array.isArray(value) ? "[...]" : value}`);
+            originalPush(event);
+        };
+        for (const field of fields) {
+            node.addObserver(fakeInterpreter, "unscoped", new BrsString(field), port);
+        }
+        return log;
+    }
+
+    /** A focused RowList of `rows` single-item rows. */
+    function makeList(rows = 6) {
+        const list = SGNodeFactory.createNode("RowList");
+        const content = [];
+        for (let i = 0; i < rows; i++) {
+            content.push(["R" + i]);
+        }
+        list.setValue("content", buildContent(content));
+        list.setNodeFocus(true);
+        return list;
+    }
+
+    /** Advances the fake clock by `ms` and ticks the render loop's scroll pass once. */
+    function advance(ms) {
+        fakeNow += ms;
+        return sgRoot.processScrollAnimations();
+    }
+
+    test("emits scrollingStatus and itemUnfocused up front, then ramps, then settles", () => {
+        const list = makeList();
+        const log = observe(list, [
+            "scrollingStatus",
+            "itemUnfocused",
+            "itemFocused",
+            "currFocusRow",
+            "rowItemFocused",
+        ]);
+
+        list.setValue("animateToItem", new Int32(3));
+
+        // Start-of-scroll emissions land synchronously, inside the assignment above — matching the
+        // device, where they precede the `after-write` trace record.
+        expect(log).toEqual(["scrollingStatus=true", "itemUnfocused=0"]);
+        // Nothing has settled yet: the focused row is still the one we started on.
+        expect(list.getValueJS("itemFocused")).toBe(0);
+
+        // Mid-flight: currFocusRow carries a FRACTIONAL value and no settle has been published.
+        log.length = 0;
+        expect(advance(500)).toBe(true);
+        const midRow = list.getValueJS("currFocusRow");
+        expect(midRow).toBeGreaterThan(0);
+        expect(midRow).toBeLessThan(3);
+        expect(Number.isInteger(midRow)).toBe(false);
+        expect(log.some((e) => e.startsWith("currFocusRow="))).toBe(true);
+        expect(log.some((e) => e.startsWith("itemFocused="))).toBe(false);
+        expect(log.some((e) => e.startsWith("rowItemFocused="))).toBe(false);
+
+        // Past the full duration (3 rows × ~340 ms) the scroll completes and settles.
+        log.length = 0;
+        expect(advance(1100)).toBe(true);
+        expect(list.getValueJS("itemFocused")).toBe(3);
+        expect(list.getValueJS("currFocusRow")).toBe(3);
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+        expect(log).toContain("itemFocused=3");
+        expect(log).toContain("rowItemFocused=[...]");
+        expect(log).toContain("scrollingStatus=false");
+        // itemUnfocused is emitted ONCE per scroll (at the start), not again at the settle.
+        expect(log.some((e) => e.startsWith("itemUnfocused="))).toBe(false);
+        // And the animation deregisters itself.
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+    });
+
+    test("scales the duration with the distance travelled (~340 ms per row)", () => {
+        for (const [rows, expected] of [
+            [1, 340],
+            [3, 1020],
+        ]) {
+            const list = makeList();
+            list.setValue("animateToItem", new Int32(rows));
+
+            // Just before the expected end, the scroll is still running and unsettled.
+            advance(expected - 20);
+            expect(list.getValueJS("itemFocused")).toBe(0);
+            // Just after, it has settled.
+            advance(40);
+            expect(list.getValueJS("itemFocused")).toBe(rows);
+        }
+    });
+
+    test("jumpToItem does not animate — it settles immediately", () => {
+        const list = makeList();
+        const log = observe(list, ["scrollingStatus", "itemFocused", "currFocusRow", "rowItemFocused"]);
+
+        list.setValue("jumpToItem", new Int32(4));
+
+        expect(list.getValueJS("itemFocused")).toBe(4);
+        expect(list.getValueJS("currFocusRow")).toBe(4);
+        // No pulse at all for an immediate move (device A2 emitted no scrollingStatus).
+        expect(log.some((e) => e.startsWith("scrollingStatus="))).toBe(false);
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+    });
+
+    test("jumpToRowItem cancels an in-flight scroll and closes the pulse", () => {
+        const list = makeList();
+        list.setValue("animateToItem", new Int32(5));
+        advance(200);
+        expect(sgRoot.scrollAnimations).toHaveLength(1);
+
+        list.setValue("jumpToRowItem", new RoArray([new Int32(1), new Int32(0)]));
+
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+        expect(list.getValueJS("itemFocused")).toBe(1);
+        // The pulse opened by the animation must be closed, or the field is stranded at true — which
+        // would silently suppress every later notification (it is not alwaysNotify).
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+    });
+
+    test("a mid-flight write retargets from the current position without restarting", () => {
+        const list = makeList();
+        const log = observe(list, ["scrollingStatus", "itemUnfocused"]);
+
+        list.setValue("animateToItem", new Int32(5));
+        advance(400);
+        const midRow = list.getValueJS("currFocusRow");
+        expect(midRow).toBeGreaterThan(0);
+
+        log.length = 0;
+        list.setValue("animateToItem", new Int32(2));
+
+        // A retarget is one continuous scroll: no second rising edge and no second itemUnfocused
+        // (device A3 emitted neither, and the ramp resumed from the current fractional position).
+        expect(log).toEqual([]);
+        expect(sgRoot.scrollAnimations).toHaveLength(1);
+        // It continues forward from where it was rather than snapping back to the start.
+        expect(advance(20)).toBe(true);
+        expect(list.getValueJS("currFocusRow")).toBeGreaterThan(midRow);
+
+        advance(1200);
+        expect(list.getValueJS("itemFocused")).toBe(2);
+    });
+
+    test("an unfocused list still animates but publishes no settled focus fields", () => {
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A"], ["B"], ["C"], ["D"]]));
+        // Deliberately never focused.
+        const log = observe(list, ["scrollingStatus", "itemFocused", "currFocusRow", "rowItemFocused"]);
+
+        list.setValue("animateToItem", new Int32(2));
+        advance(300);
+
+        // The ramp and the pulse are NOT focus-gated on a device (probe A6).
+        expect(log).toContain("scrollingStatus=true");
+        expect(log.some((e) => e.startsWith("currFocusRow="))).toBe(true);
+
+        log.length = 0;
+        advance(600);
+        // ...but the settle fields are: an unfocused list fires neither, matching the documented rule
+        // that itemFocused only changes when focus moves onto an item.
+        expect(log.some((e) => e.startsWith("itemFocused="))).toBe(false);
+        expect(log.some((e) => e.startsWith("rowItemFocused="))).toBe(false);
+        expect(log).toContain("scrollingStatus=false");
+    });
+
+    test("key navigation stays instant (its emission order is pinned elsewhere)", () => {
+        // MarkupGrid.handleUpDown writes animateToItem as its internal move shortcut. A device
+        // animates key navigation too, but changing that here would rewrite the key-driven emission
+        // order that ArrayGridFields.test.js and several CLI fixtures pin, so it is scoped out.
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("numColumns", new Int32(2));
+        grid.setValue("content", buildContent([["A", "B", "C", "D"]]).getNodeChildren()[0]);
+        grid.setNodeFocus(true);
+
+        expect(grid.handleKey("right", true)).toBe(true);
+
+        // Settled synchronously, with no animation left in flight.
+        expect(grid.getValueJS("itemFocused")).toBe(1);
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+        expect(grid.getValueJS("scrollingStatus")).toBe(false);
+    });
+
+    test("skipFocusAnimations is readable and defaults to false", () => {
+        // Documented on ArrayGrid but previously undeclared, so reading it returned `invalid` and
+        // crashed a strongly-typed BrightScript helper. Device-measured that setting it does NOT
+        // suppress the scroll (probe A7), so it is declared for compatibility only.
+        const list = makeList();
+        expect(list.getValueJS("skipFocusAnimations")).toBe(false);
+
+        list.setValue("skipFocusAnimations", BrsBoolean.True);
+        expect(list.getValueJS("skipFocusAnimations")).toBe(true);
+
+        // Still animates, matching hardware.
+        list.setValue("animateToItem", new Int32(2));
+        expect(sgRoot.scrollAnimations).toHaveLength(1);
+        expect(list.getValueJS("itemFocused")).toBe(0);
+    });
+});

--- a/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
+++ b/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
@@ -310,4 +310,66 @@ describe("ArrayGrid animateToItem animates the focus scroll", () => {
         expect(list.getValueJS("scrollingStatus")).toBe(false);
         expect(sgRoot.scrollAnimations).toHaveLength(0);
     });
+    test("visibly slides the drawn rows, not just the observable fields", () => {
+        // The point of the animation is that PIXELS move. The render path lays rows out from an integer
+        // anchor row plus a per-row Y advance, so publishing fractional currFocusRow alone would leave
+        // the layout frozen until the settle snapped it — the fields would ramp while the screen jumped.
+        // scrollRowOffset/scrollAnchorRow split the animated position into "which row is on top" and
+        // "how far past it", and RowList.renderContent shifts the layout by the remainder.
+        const list = SGNodeFactory.createNode("RowList");
+
+        // Record the y-origin each row's item component is drawn at. Installed before focusing, because
+        // item components are cached across renders and focusing builds the focused row's component.
+        const drawn = {};
+        const original = list.createItemComponent.bind(list);
+        list.createItemComponent = (interp, itemRect, content) => {
+            const comp = original(interp, itemRect, content);
+            const render = comp.renderNode.bind(comp);
+            comp.renderNode = (i2, origin, angle, opacity, draw2D) => {
+                drawn[content.getValueJS("title")] = Math.round(origin[1]);
+                return render(i2, origin, angle, opacity, draw2D);
+            };
+            return comp;
+        };
+        const rows = [];
+        for (let i = 0; i < 6; i++) {
+            rows.push(["R" + i]);
+        }
+        list.setValue("content", buildContent(rows));
+        list.setValue("itemSize", new RoArray([new Int32(1280), new Int32(100)]));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(300), new Int32(100)])]));
+        list.setValue("itemSpacing", new RoArray([new Int32(0), new Int32(20)]));
+        list.setValue("numRows", new Int32(3));
+        list.setNodeFocus(true);
+
+        const renderRows = () => {
+            for (const key of Object.keys(drawn)) {
+                delete drawn[key];
+            }
+            list.renderNode({}, [0, 0], 0, 1);
+            return { ...drawn };
+        };
+
+        // Settled: rows sit on the 120px pitch (100 height + 20 spacing).
+        expect(renderRows()).toEqual({ R0: 0, R1: 120, R2: 240 });
+
+        list.setValue("animateToItem", new Int32(2));
+
+        // Mid-flight: the whole layout has shifted UP by a sub-row amount — not a whole row, and not
+        // zero. An extra row is drawn to fill the gap the shift opens at the bottom.
+        advance(100);
+        const early = renderRows();
+        expect(early.R0).toBeLessThan(0);
+        expect(early.R0).toBeGreaterThan(-120);
+        expect(early.R3).toBeDefined();
+
+        // Later in the flight it has slid further, still smoothly rather than snapping.
+        advance(200);
+        const later = renderRows();
+        expect(later.R0).toBeLessThan(early.R0);
+
+        // Settled at the target: row 2 is at the top, back on the exact pitch.
+        advance(1000);
+        expect(renderRows()).toEqual({ R2: 0, R3: 120, R4: 240 });
+    });
 });

--- a/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
+++ b/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
@@ -372,4 +372,107 @@ describe("ArrayGrid animateToItem animates the focus scroll", () => {
         advance(1000);
         expect(renderRows()).toEqual({ R2: 0, R3: 120, R4: 240 });
     });
+    test("scales the duration by ROWS traversed on a multi-column grid, not flat index delta", () => {
+        // scrollMsPerItem is per ROW (device-measured). A flat index delta charges numCols x too much:
+        // on a 6-column grid one row down is a delta of 6, which made a ~340 ms move take ~2 s.
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("numColumns", new Int32(6));
+        const items = [];
+        for (let i = 0; i < 24; i++) {
+            items.push("I" + i);
+        }
+        grid.setValue("content", buildContent([items]).getNodeChildren()[0]);
+        grid.setNodeFocus(true);
+
+        grid.setValue("animateToItem", new Int32(6)); // exactly one row down
+
+        // Still running just under one row's worth of time, settled just after.
+        advance(300);
+        expect(sgRoot.scrollAnimations).toHaveLength(1);
+        advance(80);
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+        expect(grid.getValueJS("itemFocused")).toBe(6);
+    });
+
+    test("does not ramp currFocusColumn when the scroll does not cross columns", () => {
+        // Mapping a flat index onto both axes emitted nonsense: on a single-column list `position % 1` is
+        // the ROW fraction, so currFocusColumn oscillated (0.14, 0.50, 0.02, ...) on a field whose only
+        // valid value is 0. A device emits no column ramp for a vertical scroll.
+        const list = SGNodeFactory.createNode("LabelList");
+        const items = [];
+        for (let i = 0; i < 8; i++) {
+            items.push("I" + i);
+        }
+        list.setValue("content", buildContent([items]).getNodeChildren()[0]);
+        list.setNodeFocus(true);
+        const log = observe(list, ["currFocusColumn"]);
+
+        list.setValue("animateToItem", new Int32(4));
+        for (let i = 0; i < 8; i++) {
+            advance(150);
+        }
+
+        expect(log).toEqual([]);
+        expect(list.getValueJS("currFocusColumn")).toBe(0);
+    });
+
+    test("a key press cancels an in-flight app scroll and emits a clean pulse", () => {
+        // Without cancelling, the abandoned animation kept ticking against the old target and the pulse
+        // came out garbled: the key's rising edge was a no-op (the animation had already set the field
+        // true), its falling edge fired mid-scroll, and the settle's own edge then wrote an already-false
+        // value and notified nobody — so an app rebuilding on the falling edge saw a teardown with no
+        // rebuild.
+        const list = makeList(10);
+        list.setValue("animateToItem", new Int32(8));
+        advance(400);
+        expect(sgRoot.scrollAnimations).toHaveLength(1);
+
+        const log = observe(list, ["scrollingStatus", "itemFocused"]);
+        expect(list.handleKey("down", true)).toBe(true);
+
+        // The abandoned scroll closes, then the key press opens and closes its own pulse, then settles.
+        expect(log).toEqual([
+            "scrollingStatus=false",
+            "scrollingStatus=true",
+            "scrollingStatus=false",
+            "itemFocused=1",
+        ]);
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+
+        // And the abandoned target never reasserts itself.
+        advance(3000);
+        expect(list.getValueJS("itemFocused")).toBe(1);
+    });
+
+    test("reports the settled extent from boundingRect while scrolling", () => {
+        // The extra row and the sub-row shift both inflate the laid-out extent, so an app sizing a
+        // background or overlay from boundingRect() would watch it grow a full row and shrink again every
+        // frame of the scroll.
+        const list = SGNodeFactory.createNode("RowList");
+        const rows = [];
+        for (let i = 0; i < 6; i++) {
+            rows.push(["R" + i]);
+        }
+        list.setValue("content", buildContent(rows));
+        list.setValue("itemSize", new RoArray([new Int32(1280), new Int32(100)]));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(300), new Int32(100)])]));
+        list.setValue("itemSpacing", new RoArray([new Int32(0), new Int32(20)]));
+        list.setValue("numRows", new Int32(3));
+        list.setNodeFocus(true);
+
+        list.renderNode({}, [0, 0], 0, 1);
+        const settled = list.rectLocal.height;
+
+        list.setValue("animateToItem", new Int32(3));
+        for (const dt of [100, 300]) {
+            advance(dt);
+            list.renderNode({}, [0, 0], 0, 1);
+            // Within a few px of the settled extent, not a full row (120px) larger.
+            expect(Math.abs(list.rectLocal.height - settled)).toBeLessThan(15);
+        }
+
+        advance(1000);
+        list.renderNode({}, [0, 0], 0, 1);
+        expect(list.rectLocal.height).toBe(settled);
+    });
 });

--- a/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
+++ b/test/extensions/scenegraph/ArrayGridScrollAnimation.test.js
@@ -268,4 +268,46 @@ describe("ArrayGrid animateToItem animates the focus scroll", () => {
         expect(sgRoot.scrollAnimations).toHaveLength(1);
         expect(list.getValueJS("itemFocused")).toBe(0);
     });
+    test("interleaves the falling edge between itemFocused and rowItemFocused", () => {
+        // Device-measured (grid-scroll-animation-probe A1 records 067/068/069): the completing scroll
+        // emits itemFocused, THEN scrollingStatus=false, THEN rowItemFocused last.
+        //
+        // The order is load-bearing. An app tears transient scroll state down on the rising edge and
+        // REBUILDS its focused-item overlay on the falling edge, reading the settled focus position
+        // there, while treating the rowItemFocused observer as the authoritative settle that
+        // re-derives its own state. Emitting the edge after rowItemFocused inverts that: the rebuild
+        // runs first and the settle handler overwrites it, so the overlay stays hidden until some
+        // later navigation re-triggers it.
+        const list = makeList();
+        const log = observe(list, ["scrollingStatus", "itemFocused", "rowItemFocused"]);
+
+        list.setValue("animateToItem", new Int32(2));
+        advance(1000);
+
+        const rising = log.indexOf("scrollingStatus=true");
+        const focused = log.indexOf("itemFocused=2");
+        const falling = log.indexOf("scrollingStatus=false");
+        const settled = log.lastIndexOf("rowItemFocused=[...]");
+
+        expect(rising).toBe(0);
+        expect(focused).toBeGreaterThan(rising);
+        expect(falling).toBeGreaterThan(focused);
+        // rowItemFocused settles LAST, after the falling edge.
+        expect(settled).toBeGreaterThan(falling);
+    });
+
+    test("closes the pulse even when the settle publishes nothing", () => {
+        // Backstop: an unfocused list publishes no settled focus fields, so the interleave point is
+        // never reached. scrollingStatus must still fall, or it is stranded at true — and because it is
+        // not alwaysNotify, a stranded true silently suppresses every later notification.
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A"], ["B"], ["C"]]));
+
+        list.setValue("animateToItem", new Int32(2));
+        expect(list.getValueJS("scrollingStatus")).toBe(true);
+
+        advance(1000);
+        expect(list.getValueJS("scrollingStatus")).toBe(false);
+        expect(sgRoot.scrollAnimations).toHaveLength(0);
+    });
 });

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -65,4 +65,79 @@ describe("SceneGraph focus management", () => {
         expect(focusedDuringALosingFocus).toBe(buttonB);
         expect(sgRoot.focused).toBe(buttonB);
     });
+    test("drops a backwards steal raised from a container's own focusedChild observer", () => {
+        // Device-measured shape (test/simulator/probes/list-refocus-settle-probe, R7): a container
+        // observes its own `focusedChild` and redirects focus to an inner child; something reached
+        // from that notification then re-grabs focus to an unrelated SIBLING of the container. That
+        // target sits outside the subtree the in-flight transaction just focused, so it is a backwards
+        // steal and must be dropped.
+        //
+        // Regression for an owner-keyed classifier: the container IS still in the focus chain (focus
+        // went to its own child), so testing only the notifying owner reads this as a legal forward
+        // focus and honors it — leaving the app focused on the node it was navigating away from.
+        const scene = focusableNode();
+        const container = focusableNode();
+        const inner = focusableNode();
+        const sibling = focusableNode();
+        scene.appendChildToParent(container);
+        container.appendChildToParent(inner);
+        scene.appendChildToParent(sibling);
+
+        sibling.setNodeFocus(true);
+
+        // The container redirects focus inward, then steals it back out to the sibling.
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        let redirected = false;
+        port.pushMessage = (event) => {
+            if (!redirected && container.isChildrenFocused() === false && sgRoot.focused === container) {
+                redirected = true;
+                inner.setNodeFocus(true);
+                // Raised while the container's notification is still dispatching: a backwards steal.
+                sibling.setNodeFocus(true);
+            }
+            originalPush(event);
+        };
+        container.fields
+            .get("focusedchild")
+            .addObserver("permanent", fakeInterpreter, port, container, focusedChildFieldArg);
+
+        container.setNodeFocus(true);
+
+        // The steal is dropped: focus stays where the redirect put it.
+        expect(sgRoot.focused).toBe(inner);
+        expect(sibling.getValueJS("focusable")).toBe(true);
+    });
+
+    test("still honors a forward focus onto a sibling of the focused child", () => {
+        // The mirror case that must keep working: a container hands focus from its first child to
+        // another of its own children (how a dialog highlights a specific button). The target is a
+        // SIBLING of the live focus, not a descendant of it, so a target-must-be-below-focus test
+        // would wrongly drop this.
+        const scene = focusableNode();
+        const container = focusableNode();
+        const childA = focusableNode();
+        const childB = focusableNode();
+        scene.appendChildToParent(container);
+        container.appendChildToParent(childA);
+        container.appendChildToParent(childB);
+
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        let forwarded = false;
+        port.pushMessage = (event) => {
+            if (!forwarded && sgRoot.focused === childA) {
+                forwarded = true;
+                childB.setNodeFocus(true);
+            }
+            originalPush(event);
+        };
+        container.fields
+            .get("focusedchild")
+            .addObserver("permanent", fakeInterpreter, port, container, focusedChildFieldArg);
+
+        childA.setNodeFocus(true);
+
+        expect(sgRoot.focused).toBe(childB);
+    });
 });

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -140,4 +140,41 @@ describe("SceneGraph focus management", () => {
 
         expect(sgRoot.focused).toBe(childB);
     });
+    test("honors a redirect out of a node observing its OWN focus gain", () => {
+        // The "I got focus but have nothing to show, pass it on" pattern: a node observes its own
+        // focusedChild and hands focus to a sibling (or up to its container). The focus transaction
+        // stages focusedChild on the focused leaf itself, so that leaf is also an `owner` — and an
+        // over-broad "target must be inside the owner's subtree" test dropped both redirects, which is a
+        // regression against long-standing behavior that focus-probe2 never covered (N1/N2 only measured
+        // forward focus INTO a container's subtree). The subtree test applies only when the owner is a
+        // PROPER ANCESTOR of the focused node, i.e. the container-redirect shape.
+        for (const targetIsSibling of [true, false]) {
+            sgRoot.setFocused();
+            const scene = focusableNode();
+            const container = focusableNode();
+            const leaf = focusableNode();
+            const sibling = focusableNode();
+            scene.appendChildToParent(container);
+            container.appendChildToParent(leaf);
+            container.appendChildToParent(sibling);
+
+            // Sibling redirect targets a peer; the other case hands focus UP to the container.
+            const redirectTo = targetIsSibling ? sibling : container;
+            const port = new RoMessagePort();
+            const originalPush = port.pushMessage.bind(port);
+            let redirected = false;
+            port.pushMessage = (event) => {
+                if (!redirected && sgRoot.focused === leaf) {
+                    redirected = true;
+                    redirectTo.setNodeFocus(true);
+                }
+                originalPush(event);
+            };
+            leaf.fields.get("focusedchild").addObserver("permanent", fakeInterpreter, port, leaf, focusedChildFieldArg);
+
+            leaf.setNodeFocus(true);
+
+            expect(sgRoot.focused).toBe(redirectTo);
+        }
+    });
 });

--- a/test/simulator/probes/grid-scroll-animation-probe/README.md
+++ b/test/simulator/probes/grid-scroll-animation-probe/README.md
@@ -1,0 +1,287 @@
+# Grid Scroll Animation Probe
+
+Measures how a real Roku **animates** a list/grid focus move, so brs-engine can implement the same
+thing. A device ramps `currFocusRow` through fractional values across many frames and settles the
+focus fields at the end; brs-engine completes every move instantly (`animateToItem` and `jumpToItem`
+both route to the same `setFocusedItem`).
+
+Companion to `test/simulator/probes/list-refocus-settle-probe`, which established *that* the
+divergence exists. This one measures *what to build*.
+
+## Why it matters beyond visual smoothness
+
+A common app shape parents an overlay as a sibling of a list and re-shows it from an observer on the
+list's `rowItemFocused`, reading the field live. A key handler navigating out of the overlay must hand
+focus to the list **before** moving a row (the list's container may `jumpToItem` on focus change):
+
+```brightscript
+row = list.currFocusRow
+container.setFocus(true)      ' (A)
+list.animateToItem = row + 1  ' (B)
+hideOverlay()                 ' (C)
+```
+
+On device the whole move outlives the handler, so (B) is still in flight at (C). In the engine it
+finishes inside the handler. In the device capture of the companion probe, the overlay that stole focus
+at (A) held it for the entire animation and lost it **exactly when the animation settled** — which is
+what rescues the app. That makes native scroll animation a candidate fix for a *behavioral* bug, not
+just a cosmetic one.
+
+## The load-bearing question (A4/A5)
+
+Two readings of the device evidence both fit, and they imply different amounts of work:
+
+- **(i) `animateToItem` is an animated focus MOVE**, and its completion re-asserts focus on the list —
+  so the app-level steal is simply overwritten when the animation lands. Implementing animation +
+  emitting the settle would then be **sufficient**.
+- **(ii) The steal never rewrote the chain**, and completion merely re-lands focus. Then the focus-chain
+  model has to change too (see the companion probe's README), and animation alone is **not** enough.
+
+`A4` steals focus from a `rowItemFocused` observer and then does **nothing else** — no row move, so no
+animation completion can rescue it. `A5` does the reverse: it steals focus with an animation **already
+in flight** and asks whether that animation still settles onto the list, taking focus back.
+
+- A4 overlay keeps focus **and** A5 animation still settles onto the list → reading **(i)**: animation
+  completion is the rescuing mechanism, and implementing it fixes the app failure.
+- A5 animation abandoned / never settles → reading **(ii)**: animation alone will not fix it.
+
+## Run it on the Roku
+
+1. Zip the app:
+
+   ```
+   cd test/simulator/probes/grid-scroll-animation-probe && zip -r ../grid-scroll-animation-probe.zip manifest source components
+   ```
+
+2. Sideload: browse to `http://<roku-ip>` → Development Application Installer → upload the zip →
+   **Replace**.
+
+3. Capture **before** it finishes — open a second terminal first:
+
+   ```
+   telnet <roku-ip> 8085 | tee device-trace.txt
+   ```
+
+4. It runs A0–A6 unattended in about 20 seconds, then exits on its own. No key presses needed (Back
+   aborts early if you want out).
+
+5. Send back the `PROBE3|` lines.
+
+Engine side:
+
+```
+node packages/node/bin/brs.cli.js -r test/simulator/probes/grid-scroll-animation-probe -c 0
+```
+
+## Scenarios
+
+| Scenario | Question |
+|---|---|
+| `A0-focus` | Baseline: focus the list. |
+| `A1-animate` | `animateToItem` on a focused list — the **reference ramp**. How long (ms), how many frames, what easing, and in what order do `scrollingStatus`/`itemUnfocused`/`currFocusRow`/`itemFocused`/`rowItemFocused` fall around it? |
+| `A2-jump` | `jumpToItem` for contrast — documented as an immediate move. Does it ramp at all, or settle in one step? This is what tells us whether the two fields need different code paths. |
+| `A3-interrupt` | A second `animateToItem` written 4 frames into the first. Does it **retarget** from the current fractional position, or restart from the settled row? Does the abandoned target emit anything? |
+| `A4-steal-no-move` | Steal focus from the `rowItemFocused` observer, then do nothing. Does the overlay keep focus? (Isolates whether the steal really rewrites the chain.) |
+| `A5-steal-midflight` | Steal focus **while an animation is in flight**. Does the animation still settle onto the list and take focus back? |
+| `A6-unfocused-animate` | `animateToItem` on an **unfocused** list — animated, or silent like the engine's current unfocused path? |
+| `A7-skipFocusAnimations` | `animateToItem` with `skipFocusAnimations = true` — the documented opt-out. A1's ramp must collapse to a single step, confirming this is the switch the engine should honor. |
+
+## Trace format
+
+```
+PROBE3|<seq>|<ms>ms|f<frame>|<scenario>|<point>|<key=value ...>
+```
+
+The **ms stamp** (`roTimespan`) and **frame counter** are what make the animation measurable: a value
+sequence alone cannot distinguish a 20-frame ramp from a 60-frame one sampled every third frame. The
+frame timer ticks at `duration="0.016"` — deliberately not `0`, which free-runs as fast as the
+interpreter loops (the engine hit ~250k "frames"/sec, making the counter meaningless).
+
+Live state on every record: `liveRIF` (`rowItemFocused`), `liveIF`/`liveIU`
+(`itemFocused`/`itemUnfocused`), `liveCFR` (`currFocusRow`), `liveSS` (`scrollingStatus`),
+`listInChain`, `overlayFocus`.
+
+## Engine baseline (`engine-trace.txt`)
+
+Every programmatic move completes **within the writing statement**:
+
+```
+006 A1-animate|before        liveCFR=0
+007 A1-animate|after-write   liveCFR=3   <-- already settled, same millisecond
+008   OBS-itemUnfocused data=0
+009   OBS-currFocusRow  data=3           <-- one jump, no fractional values
+010   OBS-itemFocused   data=3
+011   OBS-rowItemFocused data=[3,0]
+```
+
+Findings to diff against the device:
+
+1. **No ramp.** `currFocusRow` goes `0 → 3` in a single notification. The device emits ~20 fractional
+   steps over ~330 ms for a one-row move.
+2. **`animateToItem` and `jumpToItem` are indistinguishable** (A1 vs A2 — identical shapes). On device
+   `jumpToItem` is documented as immediate and `animateToItem` as "quickly scroll", so these should
+   *not* match.
+3. **`scrollingStatus` never pulses for a programmatic move** — `liveSS=F` throughout A1/A2/A3/A6, and
+   no `OBS-scrollingStatus` record appears anywhere in the engine trace. The device pulses it
+   `true`→`false` around the animation (companion probe, device records 009/033). The engine only
+   pulses on *key* navigation, by design (`armScrollPulse` is called from `handleKey`).
+4. **A3 retarget is trivially "instant twice"** — the first write fully settles on row 5 (021-025),
+   then the interrupt fully settles on row 2 (027-031). There is no in-flight state to retarget, so the
+   device's real behavior here is entirely unmeasured by the engine.
+5. **A4: the steal sticks** (`listInChain=F overlayFocus=T` at 046, still so at 047). Matches the
+   companion probe's engine result and is the app-level failure.
+6. **A5: nothing to abandon.** The animation had already settled before the mid-flight steal ran (053
+   vs 058), so the engine cannot even express the scenario — which is precisely why the device answer
+   is needed.
+7. **A6: an unfocused `animateToItem` moves silently** (`liveRIF` `[4,0]`→`[2,0]` with no `OBS-`
+   records). Consistent with the documented unfocused rule, but the device may still animate.
+8. **`skipFocusAnimations` is not implemented at all** — A7 reports `skipFocusAnimations=absent`
+   (`hasField` is false; the field is absent from `ArrayGrid.defaultFields`). Reading it returns
+   `Invalid`, which crashes a strongly-typed BrightScript helper — an app that legitimately checks the
+   documented field gets a runtime error rather than `false`. Worth adding **independently** of the
+   animation work, since it is a one-line field declaration whose absence is itself a compatibility bug.
+
+## Device findings (`device-trace.txt`, Roku Streaming Stick+ / OS 15.3)
+
+### The animation, measured
+
+`animateToItem` starts a multi-frame animated scroll. Emission order around it (A1, records 008-069):
+
+```
+008 scrollingStatus = true          <-- RISES FIRST, before the write even returns
+009 itemUnfocused   = 0             <-- also up-front, at animation START
+010 after-write                     (the BrightScript assignment returns here)
+011..066 currFocusRow 0.079 … 3.0   <-- ~59 frames of fractional values
+067 itemFocused     = 3             <-- settle
+068 scrollingStatus = false
+069 rowItemFocused  = [3,0]         <-- settles LAST
+```
+
+Timing (`scrollingStatus` rise → fall):
+
+| move | duration | frames |
+| --- | --- | --- |
+| 1 row (A4) | 364 ms | 21 |
+| 2 rows (A6) | 686 ms | 34 |
+| 3 rows (A1) | 1021 ms | 59 |
+
+So **~340 ms per row traversed**, not a fixed total — a 3-row move takes 3× as long as a 1-row move.
+Per-row splits within A1 confirm it is one continuous eased curve rather than per-row steps
+(0→1: 135 ms, 1→2: 183 ms, 2→3: 684 ms — decelerating into the target). The curve is ease-in-out:
+per-frame deltas ramp up to ~0.13 rows/frame mid-flight and decay to ~0.004 at the end.
+
+Ordering notes that differ from the engine's key-navigation pulse:
+
+- `scrollingStatus` **rises before the write returns** and `itemUnfocused` is emitted at animation
+  **start**, not at the settle. The engine emits `itemUnfocused` as part of the settle bracket.
+- The falling edge still precedes `rowItemFocused`, so the existing "falling edge before the settle"
+  invariant holds — but `itemFocused` (067) comes *before* `scrollingStatus=false` (068), whereas the
+  engine emits both edges ahead of every settled field.
+
+### A2 — `jumpToItem` does NOT animate (confirmed)
+
+Records 072-076: no `scrollingStatus` at all, `currFocusRow` goes straight to 0, all four focus fields
+in one millisecond. So the two fields genuinely need different paths, as suspected.
+
+### A3 — a mid-flight retarget continues from the current position
+
+The interrupt at 0.52 (records 088-089) does **not** restart or jump: the very next sample is 0.658 and
+the ramp continues smoothly to the new target 2. Neither the abandoned target nor a second
+`scrollingStatus`/`itemUnfocused` pair is emitted — one continuous animation, retargeted. Note the
+retarget was *toward* a farther row here; a reversal is untested.
+
+### A6 — an unfocused list DOES animate, but publishes no focus settle
+
+Records 247-287: full `scrollingStatus` pulse and a complete 34-frame ramp (4 → 2), yet **no
+`itemFocused` and no `rowItemFocused`** — and `itemUnfocused` fires with the sentinel `-1`. So
+`scrollingStatus` + `currFocusRow` are *not* gated on focus, while the settle fields are. The engine's
+unfocused path is silent for everything, which is right for the settle and wrong for the ramp.
+
+### A7 — `skipFocusAnimations` exists on device but did NOT skip the animation
+
+`hasField` returns true and the write takes (`skipFocusAnimations=T`, record 297), yet the move still
+ramps over 1028 ms / 60 frames — indistinguishable from A1. Either the field only suppresses the
+focus-*indicator* animation (its wording mentions "repositioning/scaling of the focus indicator") and
+not the scroll, or it must be set before the content/render pass to take effect. **Do not treat it as a
+scroll on/off switch** on this evidence. It is still absent from the engine (`skipFocusAnimations=absent`
+in `engine-trace.txt`), which remains a real gap worth closing on its own.
+
+### A4/A5 — the load-bearing answer: animation alone is NOT sufficient
+
+This is the pair that decides the original question, and it **refutes reading (i)**:
+
+- **A4** (steal after the settle, then no further move): `listInChain=T` → **`F`**, `overlayFocus=T`,
+  and it **sticks** (records 153-155). The device honors the steal and **does** evict the list.
+- **A5** (steal at 0.39 into a 4-row animation): the steal is honored and evicts the list
+  (172), the animation **keeps running to completion** across the next ~66 frames while the list is out
+  of the focus chain (173-242), and at completion it emits **only `scrollingStatus=false`** — **no
+  `itemFocused`, no `rowItemFocused`** (`liveRIF` stays `[0,0]`). Focus is **not** returned to the list.
+
+So an in-flight animation does **not** re-assert focus on completion. Implementing scroll animation is
+**necessary but not sufficient** to fix the overlay failure by itself.
+
+### Correction to the earlier R7 conclusion
+
+The companion probe's README (and my earlier reading of R7) claimed the device "does not evict the
+list from the focus chain" on a backwards steal. **A4 shows that is wrong** — the device evicts exactly
+as the engine does. R7 showed `listInChain=T` for a different reason visible in its own trace: at
+record 174, immediately after the steal, `OBS-containerFocus-done` fires — the container's
+`focusedChild` observer had *re-redirected* focus into the list. The `T` was the container handing
+focus back, not the steal being softened.
+
+That is good news for the engine's focus model: **no two-simultaneous-focus-holders change is needed**,
+and the `.claude/docs/scenegraph-invariants.md` "deliberately not modeled" decision stands.
+
+### So what actually fixes the app?
+
+Combining A1 with A4/A5: on device the app's `(A) setFocus → (B) animateToItem → (C) hideOverlay`
+handler works because **(B) is still animating when (C) runs and for ~340 ms afterwards**. The stale
+settle that re-shows the overlay is emitted at (B)'s *completion*, long after (C) has run and after the
+app's own 0.1 s + 0.1 s fade-out has finished — and by then the settle describes the **new** row, so the
+re-show never triggers. In the engine (B) completes inside the handler, so the stale settle lands
+*before* (C) and re-shows the overlay.
+
+That means the fix is exactly the animation, for the reason of *ordering*, not of focus re-assertion:
+deferring (B)'s settle past the key handler is what removes the stale re-show. A4/A5 only rule out the
+stronger claim that completion would also repair a focus steal.
+
+## What a native implementation will need
+
+Now grounded in the device numbers above:
+
+- A per-frame scroll animation driven from the existing render-thread hook (`sgRoot.processAnimations`
+  already ticks `AnimationBase` every frame), holding: origin row (fractional, so a retarget can
+  continue from it), target row, start time, duration, easing.
+- **Duration ≈ 340 ms × rows traversed** (measured: 364/686/1021 ms for 1/2/3 rows), ease-in-out.
+- `currFocusRow`/`currFocusColumn` written **fractionally** each frame while it runs (they are floats
+  precisely so they can carry in-transit values — `arraygrid.md` documents `currFocusRow` going "3.0 to
+  4.0 … taking on values between").
+- **`scrollingStatus = true` and `itemUnfocused` at animation START**, before the assignment returns —
+  not as part of the settle bracket, which is where the engine emits `itemUnfocused` today.
+- At completion: `currFocusRow` integral → `itemFocused` → `scrollingStatus = false` → `rowItemFocused`
+  last. The falling edge is INTERLEAVED into the settle, not appended after it — implemented, and
+  load-bearing: an app rebuilds its focused-item overlay on the falling edge and treats `rowItemFocused`
+  as the authoritative settle, so emitting the edge last lets the settle handler overwrite the rebuild.
+- **A retarget mid-flight continues from the current fractional position** (no restart, no second
+  pulse, no emission for the abandoned target).
+- **An unfocused list still animates** (`scrollingStatus` + the `currFocusRow` ramp) but emits **no**
+  `itemFocused`/`rowItemFocused`; `itemUnfocused` goes to the `-1` sentinel. So the focus gate belongs
+  on the settle fields only, not on the ramp.
+- `jumpToItem` keeps today's instant path — A2 confirms it does not animate at all.
+- **A focus steal mid-animation does not stop the animation, and completion does not return focus**
+  (A5). Do not make completion re-assert focus.
+- **`skipFocusAnimations`** (`arraygrid.md`, boolean, default `false`) is the documented opt-out, and its
+  wording describes the engine's current behavior exactly: *"any scrolling or repositioning/scaling of
+  the focus indicator occurs without an animation. This causes fields reflecting the focus status
+  (itemFocused, currFocusRow, currFocusColumn) to be updated instantly and not transition smoothly
+  between old and new values. For example, currFocusRow will go directly from 3.0 to 4.0 instead of
+  taking on values between 3.0 and 4.0."* So today's engine behaves as if this field were permanently
+  `true`. Implementing animation means honoring it: `true` keeps the current instant path, `false`
+  (the default) animates. `A7` measures it. `fadeFocusFeedbackWhenAutoScrolling` is a related
+  focus-indicator field worth checking at the same time.
+
+Care needed where instant-settle is currently load-bearing: `ArrayGrid.setNodeFocus` re-emits the settle
+on focus-gain, `resetFocusForNewContent` resets the cursor, and the CLI regression apps
+(`list-initial-focus-app`, `panelset-*`) assert on synchronous outcomes. Animating a focus-gain
+re-emission would break them, so the animation almost certainly belongs to
+`animateToItem`/`animateToRowItem` only, not to every `setFocusedItem` caller.

--- a/test/simulator/probes/grid-scroll-animation-probe/components/ScrollAnimItem.xml
+++ b/test/simulator/probes/grid-scroll-animation-probe/components/ScrollAnimItem.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Minimal RowList item component. This probe measures field emission and timing, not rendering, so
+    the item only needs to be a valid itemComponentName target that shows which cell is focused.
+-->
+<component name="ScrollAnimItem" extends="Group">
+    <children>
+        <Rectangle id="bg" width="300" height="200" color="0x223344FF" />
+        <Label id="label" translation="[12, 12]" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.bg = m.top.findNode("bg")
+        m.label = m.top.findNode("label")
+        m.top.observeField("itemContent", "onItemContent")
+        m.top.observeField("itemHasFocus", "onItemHasFocus")
+    end sub
+
+    sub onItemContent()
+        if m.top.itemContent <> invalid
+            m.label.text = m.top.itemContent.title
+        end if
+    end sub
+
+    sub onItemHasFocus()
+        if m.top.itemHasFocus
+            m.bg.color = "0x4488CCFF"
+        else
+            m.bg.color = "0x223344FF"
+        end if
+    end sub
+    ]]></script>
+</component>

--- a/test/simulator/probes/grid-scroll-animation-probe/components/ScrollAnimScene.xml
+++ b/test/simulator/probes/grid-scroll-animation-probe/components/ScrollAnimScene.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Grid Scroll Animation Probe.
+
+    A real Roku ANIMATES a list/grid focus move: `animateToItem` ramps `currFocusRow` through
+    fractional values across many frames before the focus fields settle. brs-engine completes the
+    move instantly (both `animateToItem` and `jumpToItem` route to the same `setFocusedItem`), so an
+    app's key handler observes a fully settled move where a device observes one still in flight.
+
+    This probe measures exactly what a native implementation has to reproduce. Every record carries a
+    MILLISECOND timestamp and a frame counter (from a repeat Timer with duration=0), so the ramp's
+    duration, frame count and easing curve can be reconstructed - not just its value sequence.
+
+    THE LOAD-BEARING QUESTION (A4/A5): on device, an overlay that steals focus from a
+    `rowItemFocused` observer keeps `hasFocus()` for the WHOLE animation and loses it exactly when the
+    animation settles. Two readings fit:
+      (i)  `animateToItem` is an animated focus MOVE, and its completion re-asserts focus on the list
+           (so the steal is simply overwritten at the end); or
+      (ii) the steal never rewrote the chain at all, and completion merely re-lands focus.
+    A4 separates them by stealing focus and then NOT moving a row: under (i) the overlay keeps focus
+    indefinitely, under (ii) it also keeps it - so A5 adds the reverse check, stealing focus with an
+    animation already in flight and observing whether the in-flight animation still settles onto the
+    list. Together they say whether implementing scroll animation is SUFFICIENT to fix the app-level
+    failure, or whether the focus-chain model has to change too.
+
+    Scenarios
+      A1  animateToItem on a focused list           - full ramp: duration, frames, easing, ordering
+      A2  jumpToItem on a focused list              - does it animate at all, or settle instantly?
+      A3  animateToItem interrupted mid-flight      - does a second write retarget or restart?
+      A4  steal focus from a rowItemFocused observer, WITHOUT moving a row afterwards
+      A5  steal focus while an animation is ALREADY in flight - does it still settle onto the list?
+      A6  animateToItem on an UNFOCUSED list        - animated, or silent like jumpToItem?
+      A7  animateToItem with skipFocusAnimations=true - the documented opt-out; the ramp must collapse
+-->
+<component name="ScrollAnimScene" extends="Scene">
+    <interface>
+        <field id="probeExit" type="boolean" value="false" />
+    </interface>
+    <children>
+        <RowList
+            id="list"
+            itemComponentName="ScrollAnimItem"
+            itemSize="[1000, 240]"
+            rowItemSize="[[300, 200]]"
+            numRows="3"
+            translation="[100, 300]" />
+        <Rectangle
+            id="overlay"
+            width="600"
+            height="160"
+            translation="[100, 100]"
+            color="0xCC7722FF"
+            focusable="true" />
+        <!--
+            Ticks close to one render frame (1/60s). Deliberately NOT duration=0: that free-runs as
+            fast as the interpreter loops (the engine reached ~250k "frames" per second), which makes
+            the counter meaningless as a frame metric. At 0.016 the counter tracks real frames closely
+            enough to convert a ramp into a frame count, and the ms stamp is the precise measure.
+        -->
+        <Timer id="frameTimer" duration="0.016" repeat="true" />
+        <Timer id="stepTimer" duration="1.2" repeat="true" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.seq = 0
+        m.step = 0
+        m.frame = 0
+        m.scenario = "init"
+        m.span = createObject("roTimespan")
+        m.span.mark()
+
+        m.list = m.top.findNode("list")
+        m.overlay = m.top.findNode("overlay")
+
+        ' Armed per-scenario: whether a rowItemFocused observer should steal focus to the overlay.
+        m.stealOnFocus = false
+        m.stealRow = -1
+        m.pendingInterrupt = false
+        m.interruptFrames = 0
+        m.pendingMidflightSteal = false
+        m.midflightFrames = 0
+
+        content = createObject("roSGNode", "ContentNode")
+        for r = 0 to 5
+            row = content.createChild("ContentNode")
+            row.title = "Row" + str(r).trim()
+            for c = 0 to 1
+                item = row.createChild("ContentNode")
+                item.title = "R" + str(r).trim() + "C" + str(c).trim()
+            end for
+        end for
+        m.list.content = content
+
+        m.list.observeField("rowItemFocused", "onRowItemFocused")
+        m.list.observeField("itemFocused", "onItemFocused")
+        m.list.observeField("itemUnfocused", "onItemUnfocused")
+        m.list.observeField("currFocusRow", "onCurrFocusRow")
+        m.list.observeField("currFocusColumn", "onCurrFocusColumn")
+        m.list.observeField("scrollingStatus", "onScrollingStatus")
+
+        p("init", "ready", ls())
+
+        m.frameTimer = m.top.findNode("frameTimer")
+        m.frameTimer.observeField("fire", "onFrameTimer")
+        m.frameTimer.control = "start"
+
+        m.stepTimer = m.top.findNode("stepTimer")
+        m.stepTimer.observeField("fire", "onStepTimer")
+        m.stepTimer.control = "start"
+    end sub
+
+    ' ---------------------------------------------------------------- trace helpers
+
+    ' Every record carries ms since boot and the current frame number, so the ramp's real duration and
+    ' per-frame step can be reconstructed (a value sequence alone cannot distinguish a 20-frame ramp
+    ' from a 60-frame one sampled every third frame).
+    sub p(scenario as string, point as string, detail = "" as string)
+        m.seq = m.seq + 1
+        num = "00" + str(m.seq).trim()
+        print "PROBE3|" + Right(num, 3) + "|" + str(m.span.totalMilliseconds()).trim() + "ms|f" + str(m.frame).trim() + "|" + scenario + "|" + point + "|" + detail
+    end sub
+
+    function b(value as boolean) as string
+        if value then return "T"
+        return "F"
+    end function
+
+    function arr(value as object) as string
+        if value = invalid then return "invalid"
+        if type(value) <> "roArray" then return "type:" + type(value)
+        if value.count() = 0 then return "[]"
+        out = "["
+        for i = 0 to value.count() - 1
+            if i > 0 then out = out + ","
+            out = out + str(value[i]).trim()
+        end for
+        return out + "]"
+    end function
+
+    function ls() as string
+        return "liveRIF=" + arr(m.list.rowItemFocused) + " liveIF=" + str(m.list.itemFocused).trim() + " liveIU=" + str(m.list.itemUnfocused).trim() + " liveCFR=" + str(m.list.currFocusRow).trim() + " liveSS=" + b(m.list.scrollingStatus) + " listInChain=" + b(m.list.isInFocusChain()) + " overlayFocus=" + b(m.overlay.hasFocus())
+    end function
+
+    ' Drives the frame counter, and fires the two MID-FLIGHT actions. They must land while an
+    ' animation is running, which only a per-frame hook can do: a step-timer tick is too coarse (the
+    ' whole ramp is ~0.3s on device, so a 1.2s step would always land after it settled).
+    sub onFrameTimer()
+        m.frame = m.frame + 1
+
+        ' A3: retarget 4 frames after the first animateToItem was written.
+        if m.pendingInterrupt = true
+            m.interruptFrames = m.interruptFrames + 1
+            if m.interruptFrames >= 4
+                m.pendingInterrupt = false
+                m.interruptFrames = 0
+                p(m.scenario, "INTERRUPT", "retargeting animateToItem = 2 mid-flight " + ls())
+                m.list.animateToItem = 2
+                p(m.scenario, "INTERRUPT-done", ls())
+            end if
+        end if
+
+        ' A5: steal focus 4 frames into the animation, while it is still ramping.
+        if m.pendingMidflightSteal = true
+            m.midflightFrames = m.midflightFrames + 1
+            if m.midflightFrames >= 4
+                m.pendingMidflightSteal = false
+                m.midflightFrames = 0
+                p(m.scenario, "MIDFLIGHT-STEAL", "calling overlay.setFocus(true) mid-animation " + ls())
+                m.overlay.setFocus(true)
+                p(m.scenario, "MIDFLIGHT-STEAL-done", ls())
+            end if
+        end if
+    end sub
+
+    ' ---------------------------------------------------------------- observers
+
+    sub onCurrFocusRow(event as object)
+        p(m.scenario, "OBS-currFocusRow", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onCurrFocusColumn(event as object)
+        p(m.scenario, "OBS-currFocusColumn", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onItemFocused(event as object)
+        p(m.scenario, "OBS-itemFocused", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onItemUnfocused(event as object)
+        p(m.scenario, "OBS-itemUnfocused", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onScrollingStatus(event as object)
+        p(m.scenario, "OBS-scrollingStatus", "data=" + b(event.getData()) + " " + ls())
+    end sub
+
+    ' The app-shaped observer: steal focus to the overlay when the focused row is the armed one.
+    sub onRowItemFocused(event as object)
+        p(m.scenario, "OBS-rowItemFocused", "data=" + arr(event.getData()) + " " + ls())
+        live = m.list.rowItemFocused
+        if m.stealOnFocus and live <> invalid and live.count() = 2 and live[0] = m.stealRow
+            m.stealOnFocus = false
+            p(m.scenario, "STEAL", "calling overlay.setFocus(true) " + ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "STEAL-done", ls())
+        end if
+    end sub
+
+    ' ---------------------------------------------------------------- scenario driver
+
+    sub onStepTimer()
+        m.step = m.step + 1
+
+        if m.step = 1
+            m.scenario = "A0-focus"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 2
+            ' A1: the reference ramp. Everything between "before" and the settle is the animation.
+            m.scenario = "A1-animate"
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 3
+            p(m.scenario, "after-write", ls())
+
+        else if m.step = 3
+            m.scenario = "A1-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 4
+            ' A2: jumpToItem for contrast - documented as an immediate move, so it should NOT ramp.
+            m.scenario = "A2-jump"
+            p(m.scenario, "before", ls())
+            m.list.jumpToItem = 0
+            p(m.scenario, "after-write", ls())
+
+        else if m.step = 5
+            m.scenario = "A2-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 6
+            ' A3: retarget mid-flight. The second write lands a few frames into the first animation.
+            m.scenario = "A3-interrupt"
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 5
+            p(m.scenario, "after-first-write", ls())
+            m.pendingInterrupt = true
+
+        else if m.step = 7
+            m.scenario = "A3-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 8
+            m.scenario = "A4-prep"
+            p(m.scenario, "before", ls())
+            m.list.jumpToItem = 0
+            p(m.scenario, "after", ls())
+
+        else if m.step = 9
+            ' A4: steal focus from the rowItemFocused observer and then do NOTHING else. If the
+            ' overlay still holds focus a second later, the steal genuinely rewrote the chain and
+            ' animation completion is what would have rescued it.
+            m.scenario = "A4-steal-no-move"
+            m.stealOnFocus = true
+            m.stealRow = 1
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 1
+            p(m.scenario, "after-write", ls())
+
+        else if m.step = 10
+            m.scenario = "A4-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 11
+            m.scenario = "A5-prep"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            m.list.jumpToItem = 0
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 12
+            ' A5: start an animation, then steal focus a few frames in (from the frame timer below).
+            ' Does the in-flight animation still settle onto the list, taking focus back?
+            m.scenario = "A5-steal-midflight"
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 4
+            p(m.scenario, "after-write", ls())
+            m.pendingMidflightSteal = true
+
+        else if m.step = 13
+            m.scenario = "A5-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 14
+            ' A6: unfocused animateToItem - animated or silent?
+            m.scenario = "A6-prep"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 15
+            m.scenario = "A6-unfocused-animate"
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 2
+            p(m.scenario, "after-write", ls())
+
+        else if m.step = 16
+            m.scenario = "A6-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 17
+            m.scenario = "A7-prep"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            m.list.jumpToItem = 0
+            p(m.scenario, "after", ls())
+
+        else if m.step = 18
+            ' A7: skipFocusAnimations is the documented opt-out (arraygrid.md) - with it true, the
+            ' focus fields "are updated instantly and not transition smoothly between old and new
+            ' values". That is exactly what the engine does unconditionally today, so this scenario
+            ' confirms the field is the right switch: A1's ramp must collapse to a single step here.
+            m.scenario = "A7-skipFocusAnimations"
+            ' hasField first: the engine does not declare skipFocusAnimations at all, so reading it
+            ' yields Invalid. Reporting "absent" is itself a finding (the documented opt-out is
+            ' missing), and it keeps the probe from crashing on the engine side.
+            hasSkip = m.list.hasField("skipFocusAnimations")
+            if hasSkip then m.list.skipFocusAnimations = true
+            if hasSkip
+                skipState = b(m.list.skipFocusAnimations)
+            else
+                skipState = "absent"
+            end if
+            p(m.scenario, "before", "skipFocusAnimations=" + skipState + " " + ls())
+            m.list.animateToItem = 3
+            p(m.scenario, "after-write", ls())
+
+        else if m.step = 19
+            m.scenario = "A7-settled"
+            p(m.scenario, "settled", ls())
+            if m.list.hasField("skipFocusAnimations") then m.list.skipFocusAnimations = false
+            m.stepTimer.control = "stop"
+            m.frameTimer.control = "stop"
+            p(m.scenario, "exit", "probe complete")
+            m.top.probeExit = true
+
+        end if
+    end sub
+
+    function onKeyEvent(key as string, press as boolean) as boolean
+        if key = "back" and press
+            p(m.scenario, "exit", "probe aborted by user")
+            m.top.probeExit = true
+            return true
+        end if
+        return false
+    end function
+    ]]></script>
+</component>

--- a/test/simulator/probes/grid-scroll-animation-probe/device-trace.txt
+++ b/test/simulator/probes/grid-scroll-animation-probe/device-trace.txt
@@ -1,0 +1,104 @@
+PROBE3|000|0ms|f0|boot|start|
+PROBE3|000|0ms|f0|boot|device|model=Roku Streaming Stick+ os=15.3
+PROBE3|001|3ms|f0|init|ready|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=-1 liveSS=F listInChain=F overlayFocus=F
+PROBE3|002|21ms|f0|init|OBS-currFocusRow|data=0 liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveSS=F listInChain=F overlayFocus=F
+PROBE3|003|1204ms|f73|A0-focus|before|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveSS=F listInChain=F overlayFocus=F
+PROBE3|004|1205ms|f73|A0-focus|OBS-itemFocused|data=0 liveRIF=[] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|005|1206ms|f73|A0-focus|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|006|1206ms|f73|A0-focus|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|007|2407ms|f148|A1-animate|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|008|2410ms|f148|A1-animate|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|009|2413ms|f148|A1-animate|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|010|2417ms|f148|A1-animate|after-write|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|011|2428ms|f149|A1-animate|OBS-currFocusRow|data=0.07916667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.07916667 liveSS=T listInChain=T overlayFocus=F
+PROBE3|012|2439ms|f150|A1-animate|OBS-currFocusRow|data=0.2 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.2 liveSS=T listInChain=T overlayFocus=F
+PROBE3|020|2545ms|f156|A1-animate|OBS-currFocusRow|data=1.016667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.016667 liveSS=T listInChain=T overlayFocus=F
+PROBE3|031|2728ms|f167|A1-animate|OBS-currFocusRow|data=2.020833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2.020833 liveSS=T listInChain=T overlayFocus=F
+PROBE3|065|3312ms|f201|A1-animate|OBS-currFocusRow|data=2.995833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2.995833 liveSS=T listInChain=T overlayFocus=F
+PROBE3|066|3412ms|f207|A1-animate|OBS-currFocusRow|data=3 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=3 liveSS=T listInChain=T overlayFocus=F
+PROBE3|067|3430ms|f207|A1-animate|OBS-itemFocused|data=3 liveRIF=[0,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=T listInChain=T overlayFocus=F
+PROBE3|068|3431ms|f207|A1-animate|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|069|3431ms|f207|A1-animate|OBS-rowItemFocused|data=[3,0] liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|070|3604ms|f219|A1-settled|settled|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|071|4805ms|f294|A2-jump|before|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|072|4805ms|f294|A2-jump|OBS-itemUnfocused|data=3 liveRIF=[3,0] liveIF=3 liveIU=3 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|073|4805ms|f294|A2-jump|OBS-currFocusRow|data=0 liveRIF=[3,0] liveIF=3 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|074|4806ms|f294|A2-jump|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=3 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|075|4808ms|f294|A2-jump|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|076|4808ms|f294|A2-jump|after-write|liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|077|6006ms|f369|A2-settled|settled|liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|078|7205ms|f444|A3-interrupt|before|liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|079|7205ms|f444|A3-interrupt|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|080|7206ms|f444|A3-interrupt|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|081|7206ms|f444|A3-interrupt|after-first-write|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|087|7266ms|f447|A3-interrupt|OBS-currFocusRow|data=0.5208333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5208333 liveSS=T listInChain=T overlayFocus=F
+PROBE3|088|7283ms|f448|A3-interrupt|INTERRUPT|retargeting animateToItem = 2 mid-flight liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5208333 liveSS=T listInChain=T overlayFocus=F
+PROBE3|089|7284ms|f448|A3-interrupt|INTERRUPT-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5208333 liveSS=T listInChain=T overlayFocus=F
+PROBE3|090|7285ms|f448|A3-interrupt|OBS-currFocusRow|data=0.6583334 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.6583334 liveSS=T listInChain=T overlayFocus=F
+PROBE3|113|7666ms|f470|A3-interrupt|OBS-currFocusRow|data=1.995833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.995833 liveSS=T listInChain=T overlayFocus=F
+PROBE3|114|7734ms|f474|A3-interrupt|OBS-currFocusRow|data=2 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2 liveSS=T listInChain=T overlayFocus=F
+PROBE3|115|7751ms|f474|A3-interrupt|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=T listInChain=T overlayFocus=F
+PROBE3|116|7752ms|f474|A3-interrupt|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|117|7753ms|f474|A3-interrupt|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|118|8406ms|f516|A3-settled|settled|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|119|9606ms|f591|A4-prep|before|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|124|9628ms|f591|A4-prep|after|liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|125|10806ms|f666|A4-steal-no-move|before|liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|126|10808ms|f666|A4-steal-no-move|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|127|10810ms|f666|A4-steal-no-move|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|128|10812ms|f666|A4-steal-no-move|after-write|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|148|11103ms|f684|A4-steal-no-move|OBS-currFocusRow|data=0.9958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9958333 liveSS=T listInChain=T overlayFocus=F
+PROBE3|149|11154ms|f687|A4-steal-no-move|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveSS=T listInChain=T overlayFocus=F
+PROBE3|150|11171ms|f687|A4-steal-no-move|OBS-itemFocused|data=1 liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=T listInChain=T overlayFocus=F
+PROBE3|151|11172ms|f687|A4-steal-no-move|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|152|11173ms|f687|A4-steal-no-move|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|153|11173ms|f687|A4-steal-no-move|STEAL|calling overlay.setFocus(true) liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|154|11174ms|f687|A4-steal-no-move|STEAL-done|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|155|12006ms|f740|A4-settled|settled|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|156|13206ms|f815|A5-prep|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|157|13208ms|f815|A5-prep|OBS-itemUnfocused|data=-1 liveRIF=[1,0] liveIF=1 liveIU=-1 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|158|13210ms|f815|A5-prep|OBS-currFocusRow|data=0 liveRIF=[1,0] liveIF=1 liveIU=-1 liveCFR=0 liveSS=F listInChain=F overlayFocus=T
+PROBE3|159|13216ms|f815|A5-prep|OBS-itemFocused|data=0 liveRIF=[1,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|160|13218ms|f815|A5-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|161|13220ms|f815|A5-prep|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|162|14405ms|f890|A5-steal-midflight|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|163|14407ms|f890|A5-steal-midflight|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|164|14409ms|f890|A5-steal-midflight|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|165|14411ms|f890|A5-steal-midflight|after-write|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|170|14456ms|f893|A5-steal-midflight|OBS-currFocusRow|data=0.3916667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3916667 liveSS=T listInChain=T overlayFocus=F
+PROBE3|171|14473ms|f894|A5-steal-midflight|MIDFLIGHT-STEAL|calling overlay.setFocus(true) mid-animation liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3916667 liveSS=T listInChain=T overlayFocus=F
+PROBE3|172|14475ms|f894|A5-steal-midflight|MIDFLIGHT-STEAL-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3916667 liveSS=T listInChain=F overlayFocus=T
+PROBE3|173|14476ms|f894|A5-steal-midflight|OBS-currFocusRow|data=0.5375 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5375 liveSS=T listInChain=F overlayFocus=T
+PROBE3|239|15575ms|f960|A5-steal-midflight|OBS-currFocusRow|data=3.991667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=3.991667 liveSS=T listInChain=F overlayFocus=T
+PROBE3|240|15607ms|f962|A5-settled|settled|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=3.991667 liveSS=T listInChain=F overlayFocus=T
+PROBE3|241|15625ms|f963|A5-settled|OBS-currFocusRow|data=3.995833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=3.995833 liveSS=T listInChain=F overlayFocus=T
+PROBE3|242|15741ms|f970|A5-settled|OBS-currFocusRow|data=4 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=4 liveSS=T listInChain=F overlayFocus=T
+PROBE3|243|15758ms|f970|A5-settled|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|244|16804ms|f1037|A6-prep|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|245|16805ms|f1037|A6-prep|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|246|18006ms|f1112|A6-unfocused-animate|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|247|18009ms|f1112|A6-unfocused-animate|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=4 liveSS=T listInChain=F overlayFocus=T
+PROBE3|248|18011ms|f1112|A6-unfocused-animate|OBS-itemUnfocused|data=-1 liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=4 liveSS=T listInChain=F overlayFocus=T
+PROBE3|249|18013ms|f1112|A6-unfocused-animate|after-write|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=4 liveSS=T listInChain=F overlayFocus=T
+PROBE3|250|18025ms|f1113|A6-unfocused-animate|OBS-currFocusRow|data=3.925 liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=3.925 liveSS=T listInChain=F overlayFocus=T
+PROBE3|286|18595ms|f1147|A6-unfocused-animate|OBS-currFocusRow|data=2 liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=2 liveSS=T listInChain=F overlayFocus=T
+PROBE3|287|18695ms|f1152|A6-unfocused-animate|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=2 liveSS=F listInChain=F overlayFocus=T
+PROBE3|288|19207ms|f1185|A6-settled|settled|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=2 liveSS=F listInChain=F overlayFocus=T
+PROBE3|289|20406ms|f1260|A7-prep|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=2 liveSS=F listInChain=F overlayFocus=T
+PROBE3|290|20412ms|f1260|A7-prep|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=2 liveIU=-1 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|291|20415ms|f1260|A7-prep|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=-1 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|296|20431ms|f1260|A7-prep|after|liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|297|21604ms|f1335|A7-skipFocusAnimations|before|skipFocusAnimations=T liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|298|21605ms|f1335|A7-skipFocusAnimations|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|299|21606ms|f1335|A7-skipFocusAnimations|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|300|21606ms|f1335|A7-skipFocusAnimations|after-write|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=T listInChain=T overlayFocus=F
+PROBE3|301|21608ms|f1335|A7-skipFocusAnimations|OBS-currFocusRow|data=0.008333334 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.008333334 liveSS=T listInChain=T overlayFocus=F
+PROBE3|355|22499ms|f1388|A7-skipFocusAnimations|OBS-currFocusRow|data=2.995833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2.995833 liveSS=T listInChain=T overlayFocus=F
+PROBE3|356|22615ms|f1395|A7-skipFocusAnimations|OBS-currFocusRow|data=3 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=3 liveSS=T listInChain=T overlayFocus=F
+PROBE3|357|22633ms|f1395|A7-skipFocusAnimations|OBS-itemFocused|data=3 liveRIF=[0,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=T listInChain=T overlayFocus=F
+PROBE3|358|22633ms|f1395|A7-skipFocusAnimations|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|359|22634ms|f1395|A7-skipFocusAnimations|OBS-rowItemFocused|data=[3,0] liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|360|22804ms|f1407|A7-settled|settled|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|361|22805ms|f1407|A7-settled|exit|probe complete
+PROBE3|999|0ms|f0|boot|end|
+PROBE3|999|capture-note|manual|Long fractional currFocusRow runs elided (A1 013-064, A3 082-112, A4 129-147, A5 174-238, A6 251-285, A7 302-354); every structural record and each ramp's endpoints are kept verbatim. Full log in the conversation that produced this file.

--- a/test/simulator/probes/grid-scroll-animation-probe/engine-trace.txt
+++ b/test/simulator/probes/grid-scroll-animation-probe/engine-trace.txt
@@ -1,0 +1,84 @@
+PROBE3|000|0ms|f0|boot|start|
+PROBE3|000|0ms|f0|boot|device|model=Roku TV os=15.0
+PROBE3|001|9ms|f0|init|ready|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveSS=F listInChain=F overlayFocus=F
+PROBE3|002|1210ms|f74|A0-focus|before|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveSS=F listInChain=F overlayFocus=F
+PROBE3|003|1211ms|f74|A0-focus|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|004|1211ms|f74|A0-focus|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|005|1212ms|f74|A0-focus|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|006|2410ms|f149|A1-animate|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|007|2410ms|f149|A1-animate|after-write|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|008|2411ms|f149|A1-animate|OBS-itemUnfocused|data=0 liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|009|2411ms|f149|A1-animate|OBS-currFocusRow|data=3 liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|010|2412ms|f149|A1-animate|OBS-itemFocused|data=3 liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|011|2412ms|f149|A1-animate|OBS-rowItemFocused|data=[3,0] liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|012|3610ms|f224|A1-settled|settled|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|013|4810ms|f299|A2-jump|before|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|014|4810ms|f299|A2-jump|after-write|liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|015|4811ms|f299|A2-jump|OBS-itemUnfocused|data=3 liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|016|4811ms|f299|A2-jump|OBS-currFocusRow|data=0 liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|017|4812ms|f299|A2-jump|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|018|4812ms|f299|A2-jump|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|019|6010ms|f374|A2-settled|settled|liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|020|7210ms|f449|A3-interrupt|before|liveRIF=[0,0] liveIF=0 liveIU=3 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|021|7211ms|f449|A3-interrupt|after-first-write|liveRIF=[5,0] liveIF=5 liveIU=0 liveCFR=5 liveSS=F listInChain=T overlayFocus=F
+PROBE3|022|7211ms|f449|A3-interrupt|OBS-itemUnfocused|data=0 liveRIF=[5,0] liveIF=5 liveIU=0 liveCFR=5 liveSS=F listInChain=T overlayFocus=F
+PROBE3|023|7212ms|f449|A3-interrupt|OBS-currFocusRow|data=5 liveRIF=[5,0] liveIF=5 liveIU=0 liveCFR=5 liveSS=F listInChain=T overlayFocus=F
+PROBE3|024|7212ms|f449|A3-interrupt|OBS-itemFocused|data=5 liveRIF=[5,0] liveIF=5 liveIU=0 liveCFR=5 liveSS=F listInChain=T overlayFocus=F
+PROBE3|025|7212ms|f449|A3-interrupt|OBS-rowItemFocused|data=[5,0] liveRIF=[5,0] liveIF=5 liveIU=0 liveCFR=5 liveSS=F listInChain=T overlayFocus=F
+PROBE3|026|7262ms|f453|A3-interrupt|INTERRUPT|retargeting animateToItem = 2 mid-flight liveRIF=[5,0] liveIF=5 liveIU=0 liveCFR=5 liveSS=F listInChain=T overlayFocus=F
+PROBE3|027|7262ms|f453|A3-interrupt|INTERRUPT-done|liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|028|7263ms|f453|A3-interrupt|OBS-itemUnfocused|data=5 liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|029|7263ms|f453|A3-interrupt|OBS-currFocusRow|data=2 liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|030|7264ms|f453|A3-interrupt|OBS-itemFocused|data=2 liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|031|7264ms|f453|A3-interrupt|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|032|8410ms|f524|A3-settled|settled|liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|033|9610ms|f599|A4-prep|before|liveRIF=[2,0] liveIF=2 liveIU=5 liveCFR=2 liveSS=F listInChain=T overlayFocus=F
+PROBE3|034|9610ms|f599|A4-prep|after|liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|035|9611ms|f599|A4-prep|OBS-itemUnfocused|data=2 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|036|9611ms|f599|A4-prep|OBS-currFocusRow|data=0 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|037|9612ms|f599|A4-prep|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|038|9612ms|f599|A4-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|039|10810ms|f674|A4-steal-no-move|before|liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|040|10810ms|f674|A4-steal-no-move|after-write|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|041|10810ms|f674|A4-steal-no-move|OBS-itemUnfocused|data=0 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|042|10811ms|f674|A4-steal-no-move|OBS-currFocusRow|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|043|10811ms|f674|A4-steal-no-move|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|044|10811ms|f674|A4-steal-no-move|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|045|10812ms|f674|A4-steal-no-move|STEAL|calling overlay.setFocus(true) liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=T overlayFocus=F
+PROBE3|046|10813ms|f674|A4-steal-no-move|STEAL-done|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|047|12010ms|f749|A4-settled|settled|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|048|13210ms|f824|A5-prep|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveSS=F listInChain=F overlayFocus=T
+PROBE3|049|13210ms|f824|A5-prep|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|050|13210ms|f824|A5-prep|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|051|13211ms|f824|A5-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|052|14410ms|f899|A5-steal-midflight|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|053|14410ms|f899|A5-steal-midflight|after-write|liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=T overlayFocus=F
+PROBE3|054|14411ms|f899|A5-steal-midflight|OBS-itemUnfocused|data=0 liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=T overlayFocus=F
+PROBE3|055|14411ms|f899|A5-steal-midflight|OBS-currFocusRow|data=4 liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=T overlayFocus=F
+PROBE3|056|14411ms|f899|A5-steal-midflight|OBS-itemFocused|data=4 liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=T overlayFocus=F
+PROBE3|057|14412ms|f899|A5-steal-midflight|OBS-rowItemFocused|data=[4,0] liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=T overlayFocus=F
+PROBE3|058|14463ms|f903|A5-steal-midflight|MIDFLIGHT-STEAL|calling overlay.setFocus(true) mid-animation liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=T overlayFocus=F
+PROBE3|059|14463ms|f903|A5-steal-midflight|MIDFLIGHT-STEAL-done|liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|060|15610ms|f974|A5-settled|settled|liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|061|16810ms|f1049|A6-prep|before|liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|062|16810ms|f1049|A6-prep|after|liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|063|18010ms|f1124|A6-unfocused-animate|before|liveRIF=[4,0] liveIF=4 liveIU=0 liveCFR=4 liveSS=F listInChain=F overlayFocus=T
+PROBE3|064|18010ms|f1124|A6-unfocused-animate|after-write|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=F overlayFocus=T
+PROBE3|065|19210ms|f1199|A6-settled|settled|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=F overlayFocus=T
+PROBE3|066|20410ms|f1274|A7-prep|before|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveSS=F listInChain=F overlayFocus=T
+PROBE3|067|20410ms|f1274|A7-prep|after|liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|068|20410ms|f1274|A7-prep|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|069|20411ms|f1274|A7-prep|OBS-rowItemFocused|data=[2,0] liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|070|20411ms|f1274|A7-prep|OBS-itemUnfocused|data=2 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|071|20411ms|f1274|A7-prep|OBS-currFocusRow|data=0 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|072|20411ms|f1274|A7-prep|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|073|20412ms|f1274|A7-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|074|21610ms|f1349|A7-skipFocusAnimations|before|skipFocusAnimations=absent liveRIF=[0,0] liveIF=0 liveIU=2 liveCFR=0 liveSS=F listInChain=T overlayFocus=F
+PROBE3|075|21610ms|f1349|A7-skipFocusAnimations|after-write|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|076|21610ms|f1349|A7-skipFocusAnimations|OBS-itemUnfocused|data=0 liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|077|21610ms|f1349|A7-skipFocusAnimations|OBS-currFocusRow|data=3 liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|078|21611ms|f1349|A7-skipFocusAnimations|OBS-itemFocused|data=3 liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|079|21611ms|f1349|A7-skipFocusAnimations|OBS-rowItemFocused|data=[3,0] liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|080|22810ms|f1424|A7-settled|settled|liveRIF=[3,0] liveIF=3 liveIU=0 liveCFR=3 liveSS=F listInChain=T overlayFocus=F
+PROBE3|081|22810ms|f1424|A7-settled|exit|probe complete
+PROBE3|999|0ms|f0|boot|end|

--- a/test/simulator/probes/grid-scroll-animation-probe/manifest
+++ b/test/simulator/probes/grid-scroll-animation-probe/manifest
@@ -1,0 +1,4 @@
+title=Grid Scroll Animation Probe
+major_version=1
+minor_version=0
+build_version=1

--- a/test/simulator/probes/grid-scroll-animation-probe/source/main.brs
+++ b/test/simulator/probes/grid-scroll-animation-probe/source/main.brs
@@ -1,0 +1,35 @@
+' Grid Scroll Animation Probe - entry point.
+'
+' Prints a machine-diffable trace of how a list/grid animates a focus move, so a real Roku and
+' brs-engine can be compared frame by frame. Every trace record has the shape:
+'
+'     PROBE3|<seq>|<ms>ms|f<frame>|<scenario>|<point>|<key=value ...>
+'
+' The millisecond stamp and frame counter are what make the ANIMATION measurable: a value sequence
+' alone cannot tell a 20-frame ramp from a 60-frame one sampled every third frame.
+'
+' Capture on device with:  telnet <roku-ip> 8085
+' Capture in the engine with:  brs-cli test/simulator/probes/grid-scroll-animation-probe
+sub Main()
+    print "PROBE3|000|0ms|f0|boot|start|"
+    di = CreateObject("roDeviceInfo")
+    print "PROBE3|000|0ms|f0|boot|device|model=" + di.GetModelDisplayName() + " os=" + di.GetOSVersion().major + "." + di.GetOSVersion().minor
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("ScrollAnimScene")
+    screen.show()
+
+    ' Pump the message loop. The scene drives every scenario from its own timers, so this loop only
+    ' has to stay alive and let the render thread run.
+    while true
+        msg = wait(500, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then exit while
+        end if
+        if scene.probeExit then exit while
+    end while
+
+    print "PROBE3|999|0ms|f0|boot|end|"
+end sub

--- a/test/simulator/probes/list-refocus-settle-probe/README.md
+++ b/test/simulator/probes/list-refocus-settle-probe/README.md
@@ -1,0 +1,265 @@
+# List Refocus Settle Probe
+
+Measures **whether** and **when** a `RowList` re-publishes its focus-settle fields (`itemFocused`,
+`itemUnfocused`, `currFocusRow`, `currFocusColumn`, `rowItemFocused`, `scrollingStatus`) when the list
+is handed focus **without its focused position having moved** — so brs-engine can be made to match.
+
+## Why this shape
+
+A common app pattern parents an overlay as a **sibling** of a list and re-shows that overlay from an
+observer on the list's `rowItemFocused`. Crucially, such an observer reads the field **live off the
+node**, not from `event.getData()`.
+
+A key handler that navigates *out of* the overlay must hand focus to the list **before** moving a row
+(a necessary ordering: the list's container may `jumpToItem` when focus changes). So the handler is:
+
+```brightscript
+row = list.currFocusRow
+container.setFocus(true)      ' (A) hand focus over FIRST
+list.animateToItem = row + 1  ' (B) then move a row
+hideOverlay()                 ' (C) fade the overlay out
+```
+
+Everything then hinges on **when** the focus-gain settle is delivered:
+
+| Delivery | Live read sees | Result |
+| --- | --- | --- |
+| synchronously, inside step (A) | the **outgoing** row | the observer re-shows the very overlay (C) is about to hide, and re-grabs focus with it |
+| from the message loop, after the handler | the **moved-to** row | the overlay is not re-shown |
+
+The app also focuses a **container**, never the list directly — the container's own `focusedChild`
+observer redirects focus inward. That intermediate observer turns out to matter (see Findings), so the
+probe measures both call shapes.
+
+## Run it on the Roku
+
+1. Zip the app:
+
+   ```
+   cd test/simulator/probes/list-refocus-settle-probe && zip -r ../list-refocus-settle-probe.zip manifest source components
+   ```
+
+2. Sideload: browse to `http://<roku-ip>` → Development Application Installer → upload
+   `list-refocus-settle-probe.zip` → **Replace**.
+
+3. Capture the trace **before the app finishes** — open a second terminal first:
+
+   ```
+   telnet <roku-ip> 8085 | tee device-trace.txt
+   ```
+
+   (or `nc <roku-ip> 8085 | tee device-trace.txt`)
+
+4. The app auto-runs R1–R5 over about 10 seconds. When it prints
+
+   ```
+   PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote.
+   ```
+
+   press **Down** once, then **Back**. Back exits the probe.
+
+5. Send back `device-trace.txt` (the `PROBE|` lines are enough).
+
+Capture the engine side with:
+
+```
+node packages/node/bin/brs.cli.js -r test/simulator/probes/list-refocus-settle-probe -c 0 -e
+```
+
+then `curl -X POST http://localhost:8060/keypress/Down` for the R6 press (and `.../Back` to exit).
+`engine-trace.txt` in this folder was captured that way.
+
+## What each scenario answers
+
+| Scenario | Question |
+|---|---|
+| `R1-first-focus` | Content loaded while unfocused, then the first `setFocus(true)`. Which fields fire? (The one case already pinned: focus genuinely moves onto item 0.) |
+| `R2-refocus-unchanged` | Move to row 1, park focus on a sibling, hand focus **back** with the position unchanged. **Does the settle re-fire at all?** And does its record land between `before`/`after` (synchronous) or after `after` (message loop)? |
+| `R3-focus-then-move` | The app's (A)→(B) sequence in one handler, via the **container**, driven from a Timer observer. Which row does the observer's **live** read see? |
+| `R4-refocus-after-horiz` | Same as R2 after a horizontal-only move (column changed, row did not). |
+| `R5-unfocused-jump` | `jumpToRowItem` written while unfocused — silent at the time, but is the recorded position published on the next focus-gain? |
+| `R6-key-down` | The same (A)→(B)→(C) sequence driven from **`onKeyEvent`** rather than a Timer observer. A key handler starts at observer depth zero, which can move where a deferred notification drains. |
+| `R7-key-down-regrab` | The **complete** app behavior: the re-show also **re-focuses** the overlay. That is a nested `setFocus` targeting a node *outside* the chain the in-flight `setFocus` just committed — a "backwards steal". `focus-probe2` established a device drops those. Is it dropped here, and if it is honored, does the (B) row move go silent? |
+
+`R2` + `R6` decide the fix; `R1`/`R5` guard rules that are already pinned
+(`test/cli/resources/list-initial-focus-app`).
+
+## Trace format
+
+```
+PROBE|<seq>|<scenario>|<point>|<key=value ...>
+```
+
+Live state accompanies every record — this read-back is the whole point, since it is what the app
+does:
+
+- `liveRIF` — `rowItemFocused` read live off the node, as `[row,col]`
+- `liveIF` / `liveIU` — `itemFocused` / `itemUnfocused`
+- `liveCFR` / `liveCFC` — `currFocusRow` / `currFocusColumn`
+- `listInChain` — `list.isInFocusChain()` (`T`/`F`)
+- `overlayFocus` — `overlay.hasFocus()`
+
+Special points:
+
+- `OBS-<field>` — that field's observer fired. `data=` is the event payload; compare it against
+  `liveRIF` on the same line — a disagreement means the notification arrived *after* a later move.
+- `OBS-containerFocus-redirect` / `-done` — the container's `focusedChild` observer handing focus down
+  to the list (the app's intermediate observer).
+- **`WOULD-RESHOW`** — the failure reproducing. The `rowItemFocused` observer's **live** read still
+  reports the overlay's row, so an app would re-show the overlay (and re-grab focus) at the exact
+  moment its handler is trying to hide it.
+
+Because each scenario is stepped from a repeating `Timer`, synchronous vs. deferred dispatch is
+directly visible: a synchronous notification prints **between** a scenario's `before` and `after`
+records; a message-loop one prints **after** `after`.
+
+## Engine findings (pre-fix baseline, `engine-trace.txt`)
+
+`engine-trace.txt` is captured **before** the fix on purpose: it is the record of the bug, so R7 there
+still shows the steal being honored (`listInChain=T` → `F`). Re-running the probe on a fixed build shows
+record 156 as `listInChain=T overlayFocus=F` instead.
+
+Captured against the engine as of this probe's commit. **The device trace is what decides the fix** —
+these are the numbers to diff against.
+
+1. **The settle re-fires for an unchanged position.** `R2-refocus-unchanged` (records 017-018) emits
+   `itemFocused=1` and `rowItemFocused=[1,0]` even though the focused row never moved. Same in
+   `R4` (039-040) and `R5` (056-057). Source: `ArrayGrid.setNodeFocus` unconditionally re-runs
+   `setFocusedItem(itemFocused)` on focus-gain.
+
+2. **The bug reproduces only on the key-driven path.** `R6-key-down` (064-076) is the failure:
+
+   ```
+   064 A-before-setFocus              row=0, overlay focused
+   065 OBS-containerFocus-redirect    container hands focus down to the list
+   067 OBS-itemFocused      data=0    <- settle fires INSIDE step (A)
+   068 OBS-rowItemFocused   data=[0,0]   liveRIF=[0,0]
+   069 WOULD-RESHOW         liveRow=0 <- overlay re-shown before the row ever moves
+   070 A-after-setFocus
+   071-074                            (B) finally moves the row to 1
+   076 C-hide-overlay                 too late: 069 already re-grabbed focus
+   ```
+
+3. **The Timer-driven path does *not* reproduce it** — `R3-focus-then-move` (032-033) shows a stale
+   payload (`data=[0,0]`) but a live read of `[2,0]`, so no `WOULD-RESHOW`.
+
+4. **Why the two differ — the drain boundary depends on the caller's observer depth.** The settle is
+   emitted under `Field.enterInternalUpdate()`, so a reentrant notification is queued and drained by
+   `Field.executeCallbacks`, which only drains when `observerDepth === 1`
+   (`src/extensions/scenegraph/nodes/Field.ts:761`):
+
+   - **R6** — `onKeyEvent` is not a field observer, so it starts at depth **0**. The container's
+     `focusedChild` observer becomes depth 1 and therefore drains the queue at *its own* boundary —
+     still inside step (A), before the row moves.
+   - **R3** — `onStepTimer` is a `fire` observer, so it starts at depth **1**. The container observer
+     becomes depth 2, no drain happens there, and the queue drains only when the outer Timer observer
+     unwinds — by which time (B) has moved the row.
+
+   The delivery point of a focus-gain settle should not depend on whether the caller happens to be
+   inside another observer. That depth-sensitivity is the engine artifact this probe pins.
+
+## Device findings (`device-trace.txt`, Roku Streaming Stick+ / OS 15.3)
+
+The device measurement **refutes both** candidate fixes that were on the table.
+
+1. **A refocus on an unchanged position DOES re-emit the settle.** `R2-refocus-unchanged` (038-039)
+   emits `itemFocused=1` and `rowItemFocused=[1,0]` with the row unmoved; same in `R4` (106-107) and
+   `R5` (116-117). So suppressing the re-emission would diverge from the device — and would break the
+   app pattern that relies on `setFocus(true)` firing `rowItemFocused`.
+
+2. **That re-emission is SYNCHRONOUS, and the engine wrongly defers it.** On device the records land
+   *between* `before` and `after`; in the engine they land *after* `after`:
+
+   | | device | engine |
+   | --- | --- | --- |
+   | `R1` | 004-005 before `after`(007) | 004-005 after `after`(003) |
+   | `R2` | 038-039 before `after`(040) | 017-018 after `after`(016) |
+   | `R4` | 106-107 before `after`(108) | 039-040 after `after`(038) |
+   | `R5` | 116-117 before `after`(119) | 048-049 after `after`(047) |
+
+   Consistent in all four. So deferring the settle to the message loop is the **wrong direction** —
+   the engine already defers it and should not.
+
+3. **`WOULD-RESHOW` fires on the device too** (`R6` record 128, matching engine 069). The overlay
+   being re-shown at step (A) is therefore **not** the divergence — it is what a real Roku does.
+
+4. **The real divergence is that `animateToItem` is instantaneous in the engine but animated on
+   device**, so the move's settle lands on opposite sides of the key handler:
+
+   | | device | engine |
+   | --- | --- | --- |
+   | (B) `animateToItem` | starts an animation; `scrollingStatus=T` (131), `itemUnfocused` (132) | completes instantly |
+   | `currFocusRow` | ~20 fractional steps (135-154), spanning frames | one jump to `1` (072) |
+   | settle for the NEW row | `itemFocused=1` (155), `rowItemFocused=[1,0]` (157) — **after** the handler returned at 134 | (073-074) — **inside** the handler, before (C) |
+
+   On device the whole move outlives the key handler; in the engine it finishes within it. That is
+   what changes the state the app's (C) fade-out and its `isInFocusChain()` completion guard observe.
+
+5. Minor, noted not fixed here: `currFocusColumn` defaults to `-1` on device, `0` in the engine
+   (record 001); and the device emits a `currFocusRow=0` at init (002) that the engine does not.
+
+### R7 — the actual failure, and the fix
+
+`R7` arms the half the earlier scenarios omitted: the app's re-show does not merely make the overlay
+visible, it calls `setFocus(true)` on it. That is a **backwards steal** — a nested focus request targeting
+a node outside the subtree the in-flight transaction just focused.
+
+Pre-fix engine trace:
+
+```
+150 A-before-setFocus              row=0  listInChain=F overlayFocus=T
+151 OBS-containerFocus-redirect     container hands focus down to the list
+152 OBS-itemFocused      data=0     the focus-gain settle (device-correct per finding 1)
+153 OBS-rowItemFocused   data=[0,0]
+155 RESHOW-regrab                   nested overlay.setFocus(true)   <-- BACKWARDS STEAL
+156 RESHOW-regrab-done              listInChain=T -> F               <-- HONORED
+158 A-after-setFocus                the list already lost focus, inside step (A)
+161 B-after-animateToItem           row moved but listInChain=F -> published SILENTLY
+162 C-hide-overlay                  overlay still holds focus
+```
+
+Because the steal is honored the list leaves the focus chain **inside step (A)**, so (B)'s row move takes
+the silent path and the app never learns the row changed; the overlay keeps focus, and an app whose
+fade-out completion guard is `isInFocusChain() = false` never passes it. That is the reported symptom:
+the overlay stays on screen, and left/right keeps operating the overlay instead of the list.
+
+**Why the drop rule missed it.** `Node.isFocusRequestDropped` exists to drop exactly this, but it asked
+whether the *notifying owner* was still in the focus chain. Here the owner is the container, which **is**
+still in the chain — focus went to its own child — so the steal read as a legal forward focus. The rule
+`focus-probe2` established is about the **target**: dropped only when the target lies outside the subtree
+just focused. Both conditions are needed, and "inside the owner's subtree" is the right forward test,
+because forward focus routinely targets a *sibling* of the focused leaf (how a dialog highlights its
+buttons).
+
+**Fix** (`Node.isFocusRequestDropped`, `ArrayGrid.setNodeFocus`): classify by owner **and** target, and
+dispatch the focus-gain settle synchronously while a `focusedChild` notification is on the stack — the
+only window in which the steal can be classified at all. Finding 2 above is what makes that second half
+necessary: a deferred settle escapes the rule entirely. It is scoped to that window, because forcing a
+plain app `setFocus`'s settle inline re-creates the reentrancy the deferral exists to prevent
+(`deferred-observer-app`).
+
+Post-fix, record 156 reads `listInChain=T overlayFocus=F`: the steal is dropped, the list keeps focus,
+(B) publishes normally, and the sequence settles on the new row.
+
+**R6 is deliberately unchanged.** Its steal is raised after the settle has already drained, with no focus
+transaction on the stack, so nothing can classify it. That shape is not what the app does.
+
+Regressions: two tests in `test/extensions/scenegraph/Focus.test.js` — the steal case (fails without the
+target-keyed rule) and a companion forward-focus case that passes both ways, pinning that the rule does
+not over-drop.
+
+### Corrections recorded, so the trail is not re-walked
+
+Two conclusions drawn from earlier captures in this probe were **wrong**, and both are worth knowing
+because each cost a deploy:
+
+1. *"The device does not evict the list from the focus chain."* R7's `listInChain=T` was the container's
+   `focusedChild` observer re-redirecting focus into the list one record later (record 174 in the device
+   capture), not the steal being softened. A follow-up probe (`grid-scroll-animation-probe`, added with the
+   scroll-animation work) measured the steal in isolation and the device **does** evict. Consequence: the `.claude/docs/scenegraph-invariants.md`
+   "two nodes reporting focus at once is deliberately not modeled" decision **stands** — no focus-chain
+   model change was needed.
+2. *"Implementing scroll animation fixes this."* Finding 4 is a real divergence and worth fixing on its
+   own, but it does **not** fix this bug: A4/A5 show a focus steal is honored regardless, and an in-flight
+   animation neither stops nor returns focus on completion. Deploying animation alone made the symptom
+   worse — the visuals moved while focus stayed on the overlay.

--- a/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeItem.xml
+++ b/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeItem.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Minimal RowList item component. The probe measures field emission, not rendering, so this only
+    needs to be a valid itemComponentName target that shows which cell is focused.
+-->
+<component name="RefocusProbeItem" extends="Group">
+    <children>
+        <Rectangle id="bg" width="300" height="200" color="0x223344FF" />
+        <Label id="label" translation="[12, 12]" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.bg = m.top.findNode("bg")
+        m.label = m.top.findNode("label")
+        m.top.observeField("itemContent", "onItemContent")
+        m.top.observeField("itemHasFocus", "onItemHasFocus")
+    end sub
+
+    sub onItemContent()
+        if m.top.itemContent <> invalid
+            m.label.text = m.top.itemContent.title
+        end if
+    end sub
+
+    sub onItemHasFocus()
+        if m.top.itemHasFocus
+            m.bg.color = "0x4488CCFF"
+        else
+            m.bg.color = "0x223344FF"
+        end if
+    end sub
+    ]]></script>
+</component>

--- a/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeScene.xml
+++ b/test/simulator/probes/list-refocus-settle-probe/components/RefocusProbeScene.xml
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    List Refocus Settle Probe.
+
+    Measures WHETHER and WHEN a RowList re-publishes its "focus settle" fields (itemFocused,
+    itemUnfocused, currFocusRow, currFocusColumn, rowItemFocused, scrollingStatus) when the list is
+    handed focus WITHOUT its focused position having moved.
+
+    Why this matters: a common app shape parents an overlay as a SIBLING of the list and re-shows it
+    from an observer on the list's `rowItemFocused`. That observer reads the field LIVE off the node
+    (not from event.getData()). A key handler that hands focus to the list BEFORE moving a row - a
+    necessary ordering, because a container may jumpToItem when focus changes - then depends entirely
+    on the delivery timing:
+
+      * settle dispatched SYNCHRONOUSLY inside setFocus() -> the live read sees the OUTGOING row, so
+        the observer re-shows the very overlay the handler is about to hide.
+      * settle dispatched from the MESSAGE LOOP -> by delivery time the row has moved, the live read
+        sees the new row, and the overlay is not re-shown.
+
+    Each scenario is stepped from a repeating Timer so the message loop drains in between. That is
+    what makes SYNCHRONOUS vs. DEFERRED dispatch visible: a synchronous notification prints BETWEEN
+    the "before" and "after" records of the call that caused it; a message-loop notification prints
+    AFTER "after".
+
+    TWO CALL SHAPES, and the difference is the point. The app never focuses the RowList directly: it
+    focuses a CONTAINER, whose own `focusedChild` observer redirects focus down to the inner list.
+    That intermediate observer changes where a deferred notification drains, so the probe measures
+    both:
+
+      * DIRECT   - `list.setFocus(true)`      (R2/R4/R5)
+      * INDIRECT - `container.setFocus(true)` -> container's focusedChild observer ->
+                   `list.setFocus(true)`      (R3, R6) - the real app's shape
+
+    Scenarios
+      R1  first focus-gain on a list whose content was loaded while unfocused
+      R2  DIRECT refocus after moving to row 1, focus parked on a sibling (does the settle re-fire?)
+      R3  INDIRECT, the app sequence in ONE handler: container.setFocus(true) then
+          animateToItem = row+1 (which row does an observer's LIVE read of rowItemFocused see?)
+      R4  DIRECT refocus after a horizontal-only move (column changed, row did not)
+      R5  jumpToRowItem written while unfocused, then focus (is the silent position published?)
+      R6  the same INDIRECT sequence driven from onKeyEvent instead of a Timer observer - the
+          genuine repro, since a key handler starts at observer depth zero
+-->
+<component name="RefocusProbeScene" extends="Scene">
+    <interface>
+        <field id="probeExit" type="boolean" value="false" />
+    </interface>
+    <children>
+        <!--
+            The container mirrors the real app: a Group that owns the list and redirects focus down
+            to it from its own focusedChild observer. Focusing the container - never the list - is
+            what the app's key handler does.
+        -->
+        <Group id="container">
+            <RowList
+                id="list"
+                itemComponentName="RefocusProbeItem"
+                itemSize="[1000, 240]"
+                rowItemSize="[[300, 200]]"
+                numRows="3"
+                translation="[100, 300]" />
+        </Group>
+        <!-- The overlay: a focusable SIBLING of the container, the shape the real failure has. -->
+        <Rectangle
+            id="overlay"
+            width="600"
+            height="160"
+            translation="[100, 100]"
+            color="0xCC7722FF"
+            focusable="true" />
+        <Timer id="stepTimer" duration="0.6" repeat="true" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.seq = 0
+        m.step = 0
+        m.scenario = "init"
+
+        m.list = m.top.findNode("list")
+        m.container = m.top.findNode("container")
+        m.overlay = m.top.findNode("overlay")
+        ' Tracks whether the overlay would be re-shown, i.e. whether a rowItemFocused observer that
+        ' reads the field LIVE decides the focused row is the overlay's row (row 0 here).
+        m.overlayRow = 0
+        ' Armed only for R7 - the re-focus half of the app's re-show. Left off for R1-R6 so those
+        ' scenarios measure emission/timing without focus churn confusing the picture.
+        m.regrabOnReshow = false
+
+        ' Content is loaded while the list is UNFOCUSED, as an async content Task does. Per the
+        ' documented rule this must NOT fire itemFocused - only the later focus-gain should.
+        content = createObject("roSGNode", "ContentNode")
+        for r = 0 to 2
+            row = content.createChild("ContentNode")
+            row.title = "Row" + str(r).trim()
+            for c = 0 to 1
+                item = row.createChild("ContentNode")
+                item.title = "R" + str(r).trim() + "C" + str(c).trim()
+            end for
+        end for
+        m.list.content = content
+
+        ' The container redirects focus inward, exactly as the real app's container does.
+        m.container.observeField("focusedChild", "onContainerFocusChange")
+
+        m.list.observeField("rowItemFocused", "onRowItemFocused")
+        m.list.observeField("itemFocused", "onItemFocused")
+        m.list.observeField("itemUnfocused", "onItemUnfocused")
+        m.list.observeField("currFocusRow", "onCurrFocusRow")
+        m.list.observeField("scrollingStatus", "onScrollingStatus")
+
+        p("init", "ready", ls())
+
+        m.stepTimer = m.top.findNode("stepTimer")
+        m.stepTimer.observeField("fire", "onStepTimer")
+        m.stepTimer.control = "start"
+    end sub
+
+    ' ---------------------------------------------------------------- trace helpers
+
+    sub p(scenario as string, point as string, detail = "" as string)
+        m.seq = m.seq + 1
+        num = "00" + str(m.seq).trim()
+        print "PROBE|" + Right(num, 3) + "|" + scenario + "|" + point + "|" + detail
+    end sub
+
+    function b(value as boolean) as string
+        if value then return "T"
+        return "F"
+    end function
+
+    ' Renders an int-array field (rowItemFocused) as [r,c], tolerating the empty default.
+    function arr(value as object) as string
+        if value = invalid then return "invalid"
+        if type(value) <> "roArray" then return "type:" + type(value)
+        if value.count() = 0 then return "[]"
+        out = "["
+        for i = 0 to value.count() - 1
+            if i > 0 then out = out + ","
+            out = out + str(value[i]).trim()
+        end for
+        return out + "]"
+    end function
+
+    ' The LIVE state read straight off the node - the whole point of this probe. An app's
+    ' rowItemFocused observer reads the field this way rather than from event.getData(), so this is
+    ' what decides whether it acts on the outgoing or the incoming row.
+    function ls() as string
+        return "liveRIF=" + arr(m.list.rowItemFocused) + " liveIF=" + str(m.list.itemFocused).trim() + " liveIU=" + str(m.list.itemUnfocused).trim() + " liveCFR=" + str(m.list.currFocusRow).trim() + " liveCFC=" + str(m.list.currFocusColumn).trim() + " listInChain=" + b(m.list.isInFocusChain()) + " overlayFocus=" + b(m.overlay.hasFocus())
+    end function
+
+    ' ---------------------------------------------------------------- observers
+    '
+    ' Every observer prints BOTH the event payload and the live read-back, so a payload/live
+    ' disagreement (the settle arriving after a subsequent move) is visible on one line.
+
+    ' The container's own focusedChild observer, redirecting focus down to the list. This is the
+    ' intermediate observer the real app has, and it matters: a notification raised inside it drains
+    ' at ITS boundary, not at the end of the outer key handler.
+    sub onContainerFocusChange()
+        if m.container.hasFocus()
+            p(m.scenario, "OBS-containerFocus-redirect", "calling list.setFocus(true) " + ls())
+            m.list.setFocus(true)
+            p(m.scenario, "OBS-containerFocus-done", ls())
+        end if
+    end sub
+
+    ' Models the app's decision precisely: read rowItemFocused LIVE off the node (NOT from
+    ' event.getData()) and re-show the overlay when the focused row is the overlay's row. A
+    ' "WOULD-RESHOW" record is the bug reproducing - the overlay being re-shown (and re-grabbing
+    ' focus) at the very moment the handler is trying to hide it.
+    sub onRowItemFocused(event as object)
+        p(m.scenario, "OBS-rowItemFocused", "data=" + arr(event.getData()) + " " + ls())
+        live = m.list.rowItemFocused
+        if live <> invalid and live.count() = 2 and live[0] = m.overlayRow
+            p(m.scenario, "WOULD-RESHOW", "liveRow=" + str(live[0]).trim() + " (overlay re-shown from a LIVE read)")
+            ' The app does not merely re-SHOW the overlay here - it also re-FOCUSES it. That is a
+            ' nested setFocus targeting a node OUTSIDE the chain just committed by the setFocus we
+            ' are currently notifying for, i.e. a "backwards steal". focus-probe2 established that a
+            ' real Roku DROPS such a request (while honoring a forward focus into the committed
+            ' chain). If it is honored instead, the list loses focus again and the (B) row move that
+            ' follows goes silent - which is what leaves the overlay stuck on screen.
+            if m.regrabOnReshow
+                p(m.scenario, "RESHOW-regrab", "calling overlay.setFocus(true) " + ls())
+                m.overlay.setFocus(true)
+                p(m.scenario, "RESHOW-regrab-done", ls())
+            end if
+        end if
+    end sub
+
+    sub onItemFocused(event as object)
+        p(m.scenario, "OBS-itemFocused", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onItemUnfocused(event as object)
+        p(m.scenario, "OBS-itemUnfocused", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onCurrFocusRow(event as object)
+        p(m.scenario, "OBS-currFocusRow", "data=" + str(event.getData()).trim() + " " + ls())
+    end sub
+
+    sub onScrollingStatus(event as object)
+        p(m.scenario, "OBS-scrollingStatus", "data=" + b(event.getData()) + " " + ls())
+    end sub
+
+    ' ---------------------------------------------------------------- scenario driver
+
+    sub onStepTimer()
+        m.step = m.step + 1
+
+        if m.step = 1
+            ' R1: content was loaded while unfocused (in init). The first focus-gain is the one case
+            ' the docs and existing regressions DO pin: focus genuinely moves onto item 0.
+            m.scenario = "R1-first-focus"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 2
+            ' Move down one row so the remembered position is row 1, not the default 0.
+            m.scenario = "R2-prep-move"
+            p(m.scenario, "before", ls())
+            m.list.animateToItem = 1
+            p(m.scenario, "after", ls())
+
+        else if m.step = 3
+            ' Park focus on the sibling overlay - the list leaves the focus chain.
+            m.scenario = "R2-park"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 4
+            ' THE question: hand focus back with the position unchanged (still row 1).
+            ' Any OBS- record here means the settle re-fires for an unchanged position; whether it
+            ' lands before or after "after" answers the timing half.
+            m.scenario = "R2-refocus-unchanged"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 5
+            ' One settled frame later: anything arriving here was dispatched from the message loop.
+            m.scenario = "R2-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 6
+            ' Re-park for R3, with the remembered row set to the OVERLAY's row (0) - the state the
+            ' app is in when the user presses down out of the overlay. A stale settle then describes
+            ' row 0 and trips WOULD-RESHOW; a correctly-timed one describes the moved-to row.
+            m.scenario = "R3-park"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [m.overlayRow, 0]
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 7
+            ' R3: the exact app sequence, all inside ONE handler, via the CONTAINER (not the list) -
+            ' focus first, THEN move the row. If the settle dispatches while still inside step (A),
+            ' an observer's live read sees the OLD row. If it defers past the handler, by delivery
+            ' time (B) has moved it. Park the position on the overlay's row first so a stale read
+            ' trips WOULD-RESHOW.
+            m.scenario = "R3-focus-then-move"
+            p(m.scenario, "before", ls())
+            m.container.setFocus(true)
+            p(m.scenario, "mid-after-setFocus", ls())
+            m.list.animateToItem = 2
+            p(m.scenario, "after-animateToItem", ls())
+
+        else if m.step = 8
+            m.scenario = "R3-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 9
+            ' R4: a horizontal-only move - column changes, row does not.
+            m.scenario = "R4-prep-horiz"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [2, 1]
+            p(m.scenario, "after", ls())
+
+        else if m.step = 10
+            m.scenario = "R4-park"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 11
+            m.scenario = "R4-refocus-after-horiz"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 12
+            m.scenario = "R4-settled"
+            p(m.scenario, "settled", ls())
+
+        else if m.step = 13
+            ' R5: park, then write a position while UNFOCUSED. The write itself should be silent;
+            ' the question is whether the focus-gain that follows publishes it.
+            m.scenario = "R5-park"
+            p(m.scenario, "before", ls())
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 14
+            m.scenario = "R5-unfocused-jump"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [0, 0]
+            p(m.scenario, "after", ls())
+
+        else if m.step = 15
+            m.scenario = "R5-refocus-after-jump"
+            p(m.scenario, "before", ls())
+            m.list.setFocus(true)
+            p(m.scenario, "after", ls())
+
+        else if m.step = 16
+            ' R6 setup: put the remembered position back on the overlay's row and park focus on the
+            ' overlay, so the next DOWN press is the genuine repro.
+            m.scenario = "R6-prep"
+            p(m.scenario, "before", ls())
+            m.list.jumpToRowItem = [m.overlayRow, 0]
+            m.overlay.setFocus(true)
+            p(m.scenario, "after", ls())
+            m.stepTimer.control = "stop"
+            print "PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote."
+
+        end if
+    end sub
+
+    ' ---------------------------------------------------------------- key-driven repro (R6)
+    '
+    ' R1-R5 are driven from a Timer observer, which already sits at observer depth >= 1. A real key
+    ' handler starts at depth ZERO, which can move where a deferred notification drains - so the
+    ' genuine repro has to come through onKeyEvent. This mirrors the app's handler exactly:
+    '   (A) hand focus to the container   (B) move a row   (C) hide the overlay
+    function onKeyEvent(key as string, press as boolean) as boolean
+        if key = "back" and press
+            p(m.scenario, "exit", "probe complete")
+            m.top.probeExit = true
+            return true
+        end if
+
+        if key = "down" and press and m.overlay.hasFocus()
+            ' First DOWN = R6 (re-show only). Second DOWN = R7, with the re-focus armed: the FULL app
+            ' behavior, where the re-show also grabs focus back. R7 is the one that decides whether a
+            ' nested backwards steal is honored (engine) or dropped (device, per focus-probe2).
+            if m.regrabOnReshow
+                m.scenario = "R7-key-down-regrab"
+            else
+                m.scenario = "R6-key-down"
+            end if
+            row = m.list.currFocusRow
+            p(m.scenario, "A-before-setFocus", "row=" + str(row).trim() + " " + ls())
+            m.container.setFocus(true)
+            p(m.scenario, "A-after-setFocus", ls())
+            m.list.animateToItem = row + 1
+            p(m.scenario, "B-after-animateToItem", ls())
+            p(m.scenario, "C-hide-overlay", "overlay would be faded out here " + ls())
+
+            if not m.regrabOnReshow
+                ' Arm R7 and put the state back so a second DOWN reruns the same sequence.
+                m.regrabOnReshow = true
+                m.list.jumpToRowItem = [m.overlayRow, 0]
+                m.overlay.setFocus(true)
+                print "PROBE|---|R7-key|MANUAL|Now press DOWN once more, then BACK."
+            end if
+            return true
+        end if
+
+        return false
+    end function
+    ]]></script>
+</component>

--- a/test/simulator/probes/list-refocus-settle-probe/device-trace.txt
+++ b/test/simulator/probes/list-refocus-settle-probe/device-trace.txt
@@ -1,0 +1,171 @@
+PROBE|000|boot|start|
+PROBE|000|boot|device|model=Roku Streaming Stick+ os=15.3
+PROBE|001|init|ready|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=-1 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|002|init|OBS-currFocusRow|data=0 liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|003|R1-first-focus|before|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|004|R1-first-focus|OBS-itemFocused|data=0 liveRIF=[] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|005|R1-first-focus|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|006|R1-first-focus|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|007|R1-first-focus|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|008|R2-prep-move|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|009|R2-prep-move|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|010|R2-prep-move|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|011|R2-prep-move|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|012|R2-prep-move|OBS-currFocusRow|data=0.1041667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1041667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|013|R2-prep-move|OBS-currFocusRow|data=0.1333333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1333333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|014|R2-prep-move|OBS-currFocusRow|data=0.175 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.175 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|015|R2-prep-move|OBS-currFocusRow|data=0.25 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.25 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|016|R2-prep-move|OBS-currFocusRow|data=0.3791667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3791667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|017|R2-prep-move|OBS-currFocusRow|data=0.475 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.475 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|018|R2-prep-move|OBS-currFocusRow|data=0.5708333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5708333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|019|R2-prep-move|OBS-currFocusRow|data=0.65 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.65 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|020|R2-prep-move|OBS-currFocusRow|data=0.7166666 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.7166666 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|021|R2-prep-move|OBS-currFocusRow|data=0.7791666 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.7791666 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|022|R2-prep-move|OBS-currFocusRow|data=0.8291667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.8291667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|023|R2-prep-move|OBS-currFocusRow|data=0.8666667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.8666667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|024|R2-prep-move|OBS-currFocusRow|data=0.9041666 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9041666 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|025|R2-prep-move|OBS-currFocusRow|data=0.9333333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9333333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|026|R2-prep-move|OBS-currFocusRow|data=0.9541667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9541667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|027|R2-prep-move|OBS-currFocusRow|data=0.9708334 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9708334 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|028|R2-prep-move|OBS-currFocusRow|data=0.9833333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9833333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|029|R2-prep-move|OBS-currFocusRow|data=0.9875 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9875 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|030|R2-prep-move|OBS-currFocusRow|data=0.9958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9958333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|031|R2-prep-move|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|032|R2-prep-move|OBS-itemFocused|data=1 liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|033|R2-prep-move|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|034|R2-prep-move|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|035|R2-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|036|R2-park|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|037|R2-refocus-unchanged|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|038|R2-refocus-unchanged|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|039|R2-refocus-unchanged|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|040|R2-refocus-unchanged|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|041|R2-settled|settled|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|042|R3-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|043|R3-park|OBS-currFocusRow|data=0 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|044|R3-park|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|045|R3-park|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|046|R3-park|after|liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|047|R3-focus-then-move|before|liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=T
+PROBE|048|R3-focus-then-move|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=F overlayFocus=F
+PROBE|049|R3-focus-then-move|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|050|R3-focus-then-move|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|051|R3-focus-then-move|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|052|R3-focus-then-move|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|053|R3-focus-then-move|mid-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|054|R3-focus-then-move|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|055|R3-focus-then-move|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|056|R3-focus-then-move|after-animateToItem|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|057|R3-focus-then-move|OBS-currFocusRow|data=0.01666667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.01666667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|058|R3-focus-then-move|OBS-currFocusRow|data=0.04166667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.04166667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|059|R3-focus-then-move|OBS-currFocusRow|data=0.1125 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1125 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|060|R3-focus-then-move|OBS-currFocusRow|data=0.1916667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.1916667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|061|R3-focus-then-move|OBS-currFocusRow|data=0.3208333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.3208333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|062|R3-focus-then-move|OBS-currFocusRow|data=0.4541667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.4541667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|063|R3-focus-then-move|OBS-currFocusRow|data=0.5791667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.5791667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|064|R3-focus-then-move|OBS-currFocusRow|data=0.6833333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.6833333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|065|R3-focus-then-move|OBS-currFocusRow|data=0.7958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.7958333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|066|R3-focus-then-move|OBS-currFocusRow|data=0.9 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.9 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|067|R3-focus-then-move|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|068|R3-focus-then-move|OBS-currFocusRow|data=1.095833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.095833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|069|R3-focus-then-move|OBS-currFocusRow|data=1.183333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.183333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|070|R3-focus-then-move|OBS-currFocusRow|data=1.258333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.258333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|071|R3-focus-then-move|OBS-currFocusRow|data=1.333333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.333333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|072|R3-focus-then-move|OBS-currFocusRow|data=1.404167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.404167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|073|R3-focus-then-move|OBS-currFocusRow|data=1.4625 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.4625 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|074|R3-focus-then-move|OBS-currFocusRow|data=1.525 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.525 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|075|R3-focus-then-move|OBS-currFocusRow|data=1.579167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.579167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|076|R3-focus-then-move|OBS-currFocusRow|data=1.633333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.633333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|077|R3-focus-then-move|OBS-currFocusRow|data=1.679167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.679167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|078|R3-focus-then-move|OBS-currFocusRow|data=1.720833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.720833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|079|R3-focus-then-move|OBS-currFocusRow|data=1.7625 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.7625 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|080|R3-focus-then-move|OBS-currFocusRow|data=1.795833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.795833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|081|R3-focus-then-move|OBS-currFocusRow|data=1.825 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.825 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|082|R3-focus-then-move|OBS-currFocusRow|data=1.854167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.854167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|083|R3-focus-then-move|OBS-currFocusRow|data=1.879167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.879167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|084|R3-focus-then-move|OBS-currFocusRow|data=1.9 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.9 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|085|R3-focus-then-move|OBS-currFocusRow|data=1.916667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.916667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|086|R3-focus-then-move|OBS-currFocusRow|data=1.933333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.933333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|087|R3-focus-then-move|OBS-currFocusRow|data=1.945833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.945833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|088|R3-focus-then-move|OBS-currFocusRow|data=1.958333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.958333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|089|R3-focus-then-move|OBS-currFocusRow|data=1.970833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.970833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|090|R3-focus-then-move|OBS-currFocusRow|data=1.979167 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.979167 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|091|R3-focus-then-move|OBS-currFocusRow|data=1.983333 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.983333 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|092|R3-focus-then-move|OBS-currFocusRow|data=1.9875 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.9875 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|093|R3-focus-then-move|OBS-currFocusRow|data=1.991667 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.991667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|094|R3-settled|settled|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.991667 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|095|R3-settled|OBS-currFocusRow|data=1.995833 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.995833 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|096|R3-settled|OBS-currFocusRow|data=2 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|097|R3-settled|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|098|R3-settled|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|099|R3-settled|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|100|R4-prep-horiz|before|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=-1 listInChain=T overlayFocus=F
+PROBE|101|R4-prep-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|102|R4-prep-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|103|R4-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|104|R4-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|105|R4-refocus-after-horiz|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|106|R4-refocus-after-horiz|OBS-itemFocused|data=2 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|107|R4-refocus-after-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|108|R4-refocus-after-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|109|R4-settled|settled|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|110|R5-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|111|R5-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|112|R5-unfocused-jump|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|113|R5-unfocused-jump|OBS-currFocusRow|data=0 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|114|R5-unfocused-jump|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|115|R5-refocus-after-jump|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|116|R5-refocus-after-jump|OBS-itemFocused|data=0 liveRIF=[2,1] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|117|R5-refocus-after-jump|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|118|R5-refocus-after-jump|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|119|R5-refocus-after-jump|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|121|R6-prep|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|122|R6-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|123|R6-prep|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|124|R6-prep|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote.
+PROBE|125|R6-key-down|A-before-setFocus|row=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|126|R6-key-down|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=F overlayFocus=F
+PROBE|127|R6-key-down|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|128|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|129|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|130|R6-key-down|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|131|R6-key-down|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|132|R6-key-down|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|133|R6-key-down|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|134|R6-key-down|B-after-animateToItem|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|135|R6-key-down|C-hide-overlay|overlay would be faded out here liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|136|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|137|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|138|R6-key-down|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|139|R6-key-down|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|---|R7-key|MANUAL|Now press DOWN once more, then BACK.
+PROBE|140|R6-key-down|OBS-currFocusRow|data=0.075 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0.075 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|160|R6-key-down|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|161|R6-key-down|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|162|R6-key-down|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|163|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|164|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|165|R6-key-down|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|166|R6-key-down|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|167|R7-key-down-regrab|A-before-setFocus|row=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|168|R7-key-down-regrab|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=F overlayFocus=F
+PROBE|169|R7-key-down-regrab|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|170|R7-key-down-regrab|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|171|R7-key-down-regrab|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|172|R7-key-down-regrab|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|173|R7-key-down-regrab|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|174|R7-key-down-regrab|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|175|R7-key-down-regrab|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|176|R7-key-down-regrab|OBS-scrollingStatus|data=T liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|177|R7-key-down-regrab|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|178|R7-key-down-regrab|B-after-animateToItem|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|179|R7-key-down-regrab|C-hide-overlay|overlay would be faded out here liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|180|R7-key-down-regrab|OBS-currFocusRow|data=1.05 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1.05 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|200|R7-key-down-regrab|OBS-currFocusRow|data=2 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=T
+PROBE|201|R7-key-down-regrab|OBS-itemFocused|data=2 liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|202|R7-key-down-regrab|OBS-scrollingStatus|data=F liveRIF=[0,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|203|R7-key-down-regrab|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|204|R7-key-down-regrab|exit|probe complete
+PROBE|999|boot|end|
+PROBE|999|capture-note|manual|Second capture (DOWN pressed twice) adds R7. R2-prep-move record 031 and R6-key-down 141-159 / R7 181-199 fractional currFocusRow steps elided for brevity; the endpoints are kept.

--- a/test/simulator/probes/list-refocus-settle-probe/engine-trace.txt
+++ b/test/simulator/probes/list-refocus-settle-probe/engine-trace.txt
@@ -1,0 +1,100 @@
+PROBE|000|boot|start|
+PROBE|000|boot|device|model=Roku TV os=15.0
+PROBE|001|init|ready|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|002|R1-first-focus|before|liveRIF=[] liveIF=-1 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|003|R1-first-focus|after|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|004|R1-first-focus|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|005|R1-first-focus|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|006|R1-first-focus|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|007|R2-prep-move|before|liveRIF=[0,0] liveIF=0 liveIU=-1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|008|R2-prep-move|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|009|R2-prep-move|OBS-itemUnfocused|data=0 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|010|R2-prep-move|OBS-currFocusRow|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|011|R2-prep-move|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|012|R2-prep-move|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|013|R2-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|014|R2-park|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|015|R2-refocus-unchanged|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|016|R2-refocus-unchanged|after|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|017|R2-refocus-unchanged|OBS-itemFocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|018|R2-refocus-unchanged|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|019|R2-settled|settled|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|020|R3-park|before|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|021|R3-park|after|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|022|R3-park|OBS-itemUnfocused|data=1 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|023|R3-park|OBS-currFocusRow|data=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|024|R3-park|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|025|R3-park|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|026|R3-park|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|027|R3-focus-then-move|before|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|028|R3-focus-then-move|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|029|R3-focus-then-move|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|030|R3-focus-then-move|mid-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|031|R3-focus-then-move|after-animateToItem|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|032|R3-focus-then-move|OBS-itemFocused|data=0 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|033|R3-focus-then-move|OBS-rowItemFocused|data=[0,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|034|R3-focus-then-move|OBS-itemUnfocused|data=0 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|035|R3-focus-then-move|OBS-currFocusRow|data=2 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|036|R3-focus-then-move|OBS-itemFocused|data=2 liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|037|R3-focus-then-move|OBS-rowItemFocused|data=[2,0] liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|038|R3-settled|settled|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|039|R4-prep-horiz|before|liveRIF=[2,0] liveIF=2 liveIU=0 liveCFR=2 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|040|R4-prep-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|041|R4-prep-horiz|OBS-itemFocused|data=2 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|042|R4-prep-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|043|R4-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|044|R4-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|045|R4-refocus-after-horiz|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|046|R4-refocus-after-horiz|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|047|R4-refocus-after-horiz|OBS-itemFocused|data=2 liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|048|R4-refocus-after-horiz|OBS-rowItemFocused|data=[2,1] liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|049|R4-settled|settled|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|050|R5-park|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=T overlayFocus=F
+PROBE|051|R5-park|after|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|052|R5-unfocused-jump|before|liveRIF=[2,1] liveIF=2 liveIU=0 liveCFR=2 liveCFC=1 listInChain=F overlayFocus=T
+PROBE|053|R5-unfocused-jump|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|054|R5-refocus-after-jump|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|055|R5-refocus-after-jump|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|056|R5-refocus-after-jump|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|057|R5-refocus-after-jump|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|058|R5-refocus-after-jump|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|059|R6-prep|before|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|060|R6-prep|after|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|---|R6-key|MANUAL|Now press DOWN once, then BACK on the remote.
+PROBE|061|R6-prep|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|062|R6-prep|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|063|R6-prep|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|064|R6-key-down|A-before-setFocus|row=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|065|R6-key-down|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|066|R6-key-down|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|067|R6-key-down|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|068|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|069|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|070|R6-key-down|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|071|R6-key-down|OBS-itemUnfocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|072|R6-key-down|OBS-currFocusRow|data=1 liveRIF=[0,0] liveIF=0 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|073|R6-key-down|OBS-itemFocused|data=1 liveRIF=[0,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|074|R6-key-down|OBS-rowItemFocused|data=[1,0] liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|075|R6-key-down|B-after-animateToItem|liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|076|R6-key-down|C-hide-overlay|overlay would be faded out here liveRIF=[1,0] liveIF=1 liveIU=0 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|077|R6-key-down|OBS-itemUnfocused|data=1 liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=1 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|078|R6-key-down|OBS-currFocusRow|data=0 liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|079|R6-key-down|OBS-itemFocused|data=0 liveRIF=[1,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|080|R6-key-down|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|081|R6-key-down|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|082|R6-key-down|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|083|R6-key-down|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|---|R7-key|MANUAL|Now press DOWN once more, then BACK.
+PROBE|084|R7-key-down-regrab|A-before-setFocus|row=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|085|R7-key-down-regrab|OBS-containerFocus-redirect|calling list.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=F
+PROBE|086|R7-key-down-regrab|OBS-containerFocus-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|087|R7-key-down-regrab|OBS-itemFocused|data=0 liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|088|R7-key-down-regrab|OBS-rowItemFocused|data=[0,0] liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|089|R7-key-down-regrab|WOULD-RESHOW|liveRow=0 (overlay re-shown from a LIVE read)
+PROBE|090|R7-key-down-regrab|RESHOW-regrab|calling overlay.setFocus(true) liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=T overlayFocus=F
+PROBE|091|R7-key-down-regrab|RESHOW-regrab-done|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|092|R7-key-down-regrab|A-after-setFocus|liveRIF=[0,0] liveIF=0 liveIU=1 liveCFR=0 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|093|R7-key-down-regrab|B-after-animateToItem|liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|094|R7-key-down-regrab|C-hide-overlay|overlay would be faded out here liveRIF=[1,0] liveIF=1 liveIU=1 liveCFR=1 liveCFC=0 listInChain=F overlayFocus=T
+PROBE|095|R7-key-down-regrab|exit|probe complete
+PROBE|999|boot|end|

--- a/test/simulator/probes/list-refocus-settle-probe/manifest
+++ b/test/simulator/probes/list-refocus-settle-probe/manifest
@@ -1,0 +1,4 @@
+title=List Refocus Settle Probe
+major_version=1
+minor_version=0
+build_version=1

--- a/test/simulator/probes/list-refocus-settle-probe/source/main.brs
+++ b/test/simulator/probes/list-refocus-settle-probe/source/main.brs
@@ -1,0 +1,33 @@
+' List Refocus Settle Probe - entry point.
+'
+' Prints a machine-diffable trace of WHETHER and WHEN a RowList re-publishes its focus-settle fields
+' when the list is handed focus without its focused position having moved. Every trace record has
+' the shape:
+'
+'     PROBE|<seq>|<scenario>|<point>|<key=value ...>
+'
+' Capture on device with:  telnet <roku-ip> 8085
+' Capture in the engine with:  brs-cli test/simulator/probes/list-refocus-settle-probe
+sub Main()
+    print "PROBE|000|boot|start|"
+    di = CreateObject("roDeviceInfo")
+    print "PROBE|000|boot|device|model=" + di.GetModelDisplayName() + " os=" + di.GetOSVersion().major + "." + di.GetOSVersion().minor
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("RefocusProbeScene")
+    screen.show()
+
+    ' Pump the message loop. The scene drives the scenarios from a repeating Timer, so this loop only
+    ' has to stay alive and let the render thread run.
+    while true
+        msg = wait(500, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then exit while
+        end if
+        if scene.probeExit then exit while
+    end while
+
+    print "PROBE|999|boot|end|"
+end sub


### PR DESCRIPTION
> **Stacked on #1177.** Base is `fix/focus-steal-container-redirect`; retarget to `master` once that
> merges. #1177 is the fix for the reported focus bug — this PR is an independent device-accuracy
> improvement that came out of the same investigation.

## Problem

`animateToItem` is documented as "quickly scroll so that the item at the specified index moves into
focus", and a real Roku animates it across many frames. The engine completed it **instantly**, routing
both `animateToItem` and `jumpToItem` through the same `setFocusedItem`. Two consequences:

1. **Visual:** the rows snapped instead of sliding.
2. **Behavioral:** the whole move — including its settle — landed *inside* the key handler that wrote it.
   On device the move outlives the handler by ~340 ms per row, so an app's `(A) setFocus → (B)
   animateToItem → (C) hide` sequence observes a move still in flight where we gave it a settled one.

## Measurements

All from `test/simulator/probes/grid-scroll-animation-probe` on a Roku Streaming Stick+ (OS 15.3),
committed with device + engine traces:

| | measured |
| --- | --- |
| duration | **~340 ms per row traversed** (364 / 686 / 1021 ms for 1 / 2 / 3 rows), ease-in-out |
| start | `scrollingStatus = true` **and** `itemUnfocused` fire before the assignment returns |
| in flight | ~20 fractional `currFocusRow` steps per row; no `currFocusColumn` on a vertical scroll |
| completion | `itemFocused` → `scrollingStatus = false` → `rowItemFocused` last |
| `jumpToItem` | does **not** animate at all — genuinely separate paths |
| retarget | a mid-flight write continues from the current fractional position; no restart, no second pulse |
| unfocused list | still pulses and still ramps, but publishes **no** settled focus fields |

## Commits

1. **`Emit animated scroll fields`** — the per-frame eased scroll, driven from the render loop via
   `sgRoot.processScrollAnimations` and the injectable `sgClock` (so tests are deterministic). Scoped
   honestly: this animates the *fields*, not yet the pixels.
2. **`Interleave the scroll falling edge into the settle`** — the falling edge belongs *between*
   `itemFocused` and `rowItemFocused`, not after the whole settle. **Load-bearing, not cosmetic:** an app
   tears transient scroll state down on the rising edge and *rebuilds* its focused-item overlay on the
   falling edge, while treating `rowItemFocused` as the authoritative settle. With the edge last the
   rebuild ran first and the settle handler overwrote it — the overlay stayed hidden until a later
   navigation re-triggered it.
3. **`Slide the rows during an animated scroll`** — wires the fractional position into rendering.
   `scrollRowOffset`/`scrollAnchorRow` split it into "which row is on top" and "how far past it";
   `RowList.renderContent` re-anchors the window and shifts the layout by the remainder, and draws one
   extra row to fill the gap that opens at the bottom.

## Deliberately scoped out

**Key navigation stays instant.** A device animates it too, but `MarkupGrid.handleUpDown` writes
`animateToItem` as an internal move shortcut, and animating it would rewrite the key-driven emission
order pinned by `ArrayGridFields.test.js` and read synchronously by several CLI fixtures. `keyNavMove`
keeps that path instant; animating it deserves its own PR and regression pass.

**`skipFocusAnimations`** is now declared (it was documented but absent, so reading it returned `invalid`
and crashed a strongly-typed BrightScript helper) but intentionally **not** wired to the scroll: the probe
measured that setting it `true` on a device does *not* suppress the animation.

## Verification

- `test/extensions/scenegraph/ArrayGridScrollAnimation.test.js` — 11 tests driving the fake clock: field
  ordering, duration scaling, `jumpToItem` staying instant, retarget-from-position, the unfocused case,
  the falling-edge interleave, the no-settle backstop, and **the visual slide** (records each row's drawn
  y-origin: `{R0:0, R1:120, R2:240}` settled → smoothly shifted mid-flight → `{R2:0, R3:120, R4:240}` at
  the target). Each of the three load-bearing tests was verified failing with its fix disabled.
- `list-refocus-overlay-app` in `test/cli/cli-scenegraph.test.js` — end-to-end, with an `inflight:` line
  an instant move cannot produce.
- **Full suite:** 210 files, 2678 tests, 0 failures.

## Note on expectations

The focused-item overlay now rebuilds ~340 ms after the key press, when the scroll settles — matching the
device, where the same delay exists. If that reads as sluggish in a way it doesn't on hardware, it's a
duration question rather than an ordering one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)