### PR TITLE
fix(scenegraph): apply the scale field to drawn content, bounding rect, and remaining text nodes

### DIFF
--- a/src/core/brsTypes/interfaces/IfDraw2D.ts
+++ b/src/core/brsTypes/interfaces/IfDraw2D.ts
@@ -121,7 +121,15 @@ export class IfDraw2D {
         this.component.makeDirty();
     }
 
-    doDrawRotatedRect(rect: Rect, rgba: number, rotation: number, center?: number[], opacity: number = 1) {
+    doDrawRotatedRect(
+        rect: Rect,
+        rgba: number,
+        rotation: number,
+        center?: number[],
+        opacity: number = 1,
+        scaleX: number = 1,
+        scaleY: number = 1
+    ) {
         const baseX = this.component.x;
         const baseY = this.component.y;
         const ctx = this.component.getContext();
@@ -129,6 +137,17 @@ export class IfDraw2D {
         // Default to top-left corner if centerX and centerY are not provided
         const rotationCenterX = center === undefined ? 0 : center[0];
         const rotationCenterY = center === undefined ? 0 : center[1];
+        if (scaleX !== 1 || scaleY !== 1) {
+            // Division-free scale-around-pivot bracket: exactly a no-op at scale [1,1] for any
+            // pivot, and collapses to a single point at scale [0,0] instead of the NaN/Infinity
+            // risk a fused rotate+scale transform (see doDrawRotatedBitmap) would hit there.
+            // Pivot is rect.x/y as-is, NOT + rotationCenterX/Y: rect.x/y already bakes in
+            // scaleRotateCenter's position compensation via Group.getTranslation(), so adding the
+            // center again here would double-count it (see Group.applyScale for the derivation).
+            // Composed onto the ctx.save() already opened above (this method restores it below);
+            // pushScale (used by text drawing) does the same composition with its own save/restore.
+            this.composeScalePivot(ctx, baseX + rect.x, baseY + rect.y, scaleX, scaleY);
+        }
         if (rotation === 0) {
             ctx.translate(baseX + rect.x, baseY + rect.y);
         } else {
@@ -247,6 +266,49 @@ export class IfDraw2D {
     /** Depth of the active clip stack. Exposed for the frame-level balance check and tests. */
     getClipDepth(): number {
         return this.clipDepth;
+    }
+
+    /**
+     * Applies a division-free scale-around-pivot bracket: translate(pivot) -> scale -> translate(-pivot).
+     * `pivotX`/`pivotY` are in the node's local (pre-canvas-origin) coordinate space - the same
+     * convention every doDrawRotated* method uses - so this adds `this.component.x/y` internally.
+     *
+     * Mathematically an exact no-op at scale [1,1] for any pivot, so callers may compute the pivot
+     * from whatever origin/scaleRotateCenter is convenient without perturbing the common, unscaled
+     * case. Never divides by scale, so scale [0,0] just collapses everything drawn inside the
+     * bracket to the pivot point rather than risking a NaN/Infinity translate.
+     *
+     * Kept independent of the clip stack: this only ever brackets a synchronous, JS-only draw call
+     * with a try/finally around it (no BrightScript runs in between), so there's no equivalent of
+     * the cross-frame clip leak that `resetClips()` guards against.
+     *
+     * @returns Whether a transform was pushed (false at scale [1,1] - caller can skip popScale()).
+     */
+    pushScale(pivotX: number, pivotY: number, scaleX: number, scaleY: number): boolean {
+        if (scaleX === 1 && scaleY === 1) {
+            return false;
+        }
+        const ctx = this.component.getContext();
+        ctx.save();
+        this.composeScalePivot(ctx, this.component.x + pivotX, this.component.y + pivotY, scaleX, scaleY);
+        return true;
+    }
+
+    /**
+     * Composes `translate(pivot) -> scale -> translate(-pivot)` onto the canvas's CURRENT
+     * transform. Caller owns `ctx.save()`/`ctx.restore()` — shared by `doDrawRotatedRect` (which
+     * composes onto its own already-open save, alongside rotation) and `pushScale` (which opens
+     * its own save for text drawing, since `doDrawRotatedText` never takes a scale param).
+     */
+    private composeScalePivot(ctx: BrsCanvasContext2D, pivotX: number, pivotY: number, scaleX: number, scaleY: number) {
+        ctx.translate(pivotX, pivotY);
+        ctx.scale(scaleX, scaleY);
+        ctx.translate(-pivotX, -pivotY);
+    }
+
+    /** Pairs with a `pushScale()` call that returned true. */
+    popScale(): void {
+        this.component.getContext().restore();
     }
 
     drawNinePatch(bitmap: RoBitmap, rect: Rect, rgba?: number, opacity?: number) {

--- a/src/extensions/scenegraph/SGUtil.ts
+++ b/src/extensions/scenegraph/SGUtil.ts
@@ -124,6 +124,19 @@ export function unionRect(rectChild: Rect, rectParent: Rect) {
 }
 
 /**
+ * Applies a node's scale factor to a measured extent (width or height), normalizing a mirrored
+ * (negative) scale to a non-negative magnitude — callers that assume a non-negative extent
+ * (`unionRect`'s `x + width` far-edge math, a `width > 0` gate) need this rather than the raw,
+ * possibly-negative product.
+ * @param extent The unscaled width or height.
+ * @param scale The matching scale component (`scale[0]` for width, `scale[1]` for height).
+ * @returns The scaled, non-negative extent.
+ */
+export function scaledExtent(extent: number, scale: number): number {
+    return Math.abs(extent * scale);
+}
+
+/**
  * Converts a string representation of a number to a numeric value.
  * @param strNumber String representation of the number
  * @returns Numeric value of the string

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -272,10 +272,15 @@ export class Group extends Node {
         return rectangle;
     }
 
-    protected getTranslation() {
+    /**
+     * @param scale This node's own scale field, if the caller already fetched it (avoids a second
+     * `getValueJS` lookup on this hot render-path method, e.g. a caller that also needs `scale` for
+     * `applyScale`/`withScale`); fetched here when omitted.
+     */
+    protected getTranslation(scale?: number[]) {
         const translation = this.getValueJS("translation") as number[];
         // Adjust translation based on scale and rotation center
-        const scale = this.getValueJS("scale") as number[];
+        scale ??= this.getValueJS("scale") as number[];
         const scaleRotateCenter = this.getScaleRotateCenter();
         const scaleDiffX = scaleRotateCenter[0] * (scale[0] - 1);
         const scaleDiffY = scaleRotateCenter[1] * (scale[1] - 1);
@@ -699,8 +704,9 @@ export class Group extends Node {
         this.rectToScene = { x: trans[0], y: trans[1], width, height };
     }
 
-    protected updateBoundingRects(drawRect: Rect, origin: number[], rotation: number) {
-        const nodeTrans = this.getTranslation();
+    /** @param scale See `getTranslation`'s `scale` param — threaded through to avoid a re-fetch. */
+    protected updateBoundingRects(drawRect: Rect, origin: number[], rotation: number, scale?: number[]) {
+        const nodeTrans = this.getTranslation(scale);
         this.rectLocal = { x: 0, y: 0, width: drawRect.width, height: drawRect.height };
         if (rotation === 0) {
             // Local space must agree with the parent/scene rects below: a grid's drawRect is outset
@@ -857,8 +863,9 @@ export class Group extends Node {
      * looked accidental (#1133 preserved it pending exactly this measurement) and placed a container's
      * children 100px off under a rotated ancestor.
      */
-    protected getDrawTranslation(origin: number[], angle: number): number[] {
-        const nodeTrans = this.getTranslation();
+    /** @param scale See `getTranslation`'s `scale` param — threaded through to avoid a re-fetch. */
+    protected getDrawTranslation(origin: number[], angle: number, scale?: number[]): number[] {
+        const nodeTrans = this.getTranslation(scale);
         const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
         drawTrans[0] += origin[0];
         drawTrans[1] += origin[1];

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -33,6 +33,7 @@ import {
     rectContainsRect,
     rotateRect,
     rotateTranslation,
+    scaledExtent,
     unionRect,
 } from "../SGUtil";
 import { SGNodeFactory } from "../factory/NodeFactory";
@@ -329,6 +330,66 @@ export class Group extends Node {
         return opacity ?? 1;
     }
 
+    /**
+     * Returns `rect` shrunk/grown by this node's own scale, WITHOUT touching x/y: `rect.x`/`rect.y`
+     * already come from `getDrawTranslation`/`getTranslation`, which bakes `scaleRotateCenter`'s
+     * pivot compensation into the position (`translation + center*(1-scale)`, Group.ts:274-284) —
+     * so the pivot-corrected anchor is already there; only width/height need the scale factor.
+     * Reapplying the center offset here would double-count it (verified against a device-spec
+     * derivation of the affine `C(-1) S C T` composition — the same reasoning fixed a matching
+     * double-count in the draw-time scale bracket, see IfDraw2D.doDrawRotatedRect/pushScale).
+     *
+     * Makes a node's reported bounding rect (what a parent LayoutGroup measures for spacing) agree
+     * with what it actually paints. Exact no-op at scale [1,1]. Returns a NEW rect; never mutates
+     * the input (callers still need the unscaled rect for the draw call itself, which applies its
+     * own scale bracket independently).
+     *
+     * Composed BEFORE any rotation in the caller's subsequent updateBoundingRects, unlike the
+     * scale-outside-rotation order used at draw time: a node combining non-zero rotation with a
+     * non-default scale can therefore report a bounding rect that doesn't quite match its drawn
+     * extent. Left unaddressed (no known caller hits it) rather than reworking the rotation
+     * composition in updateBoundingRects.
+     *
+     * A negative scale (a mirror, e.g. [-1,1]) flips which edge is "first": `width`/`height` are
+     * normalized back to non-negative extents (with x/y shifted to the new left/top edge) so callers
+     * downstream that assume a non-negative rect — `SGUtil.unionRect`'s `x+width` far-edge math,
+     * `chooseActiveRect`'s `width>0` gate — keep working instead of computing a backwards box.
+     *
+     * @param scale This node's own scale field, if the caller already fetched it (avoids a second
+     * `getValueJS` lookup on this hot render-path method); fetched here when omitted.
+     */
+    protected applyScale(rect: Rect, scale?: number[]): Rect {
+        scale ??= this.getValueJS("scale") as number[];
+        if (scale[0] === 1 && scale[1] === 1) {
+            return rect;
+        }
+        const width = rect.width * scale[0];
+        const height = rect.height * scale[1];
+        return {
+            x: width < 0 ? rect.x + width : rect.x,
+            y: height < 0 ? rect.y + height : rect.y,
+            width: scaledExtent(rect.width, scale[0]),
+            height: scaledExtent(rect.height, scale[1]),
+        };
+    }
+
+    /**
+     * Brackets `draw` with `IfDraw2D.pushScale`/`popScale` around `rect.x`/`rect.y` when `scale`
+     * isn't the default `[1,1]` — the shared shape behind `drawText`'s single draw call and
+     * `drawTextWrap`'s per-line loop (pushed once for the whole block, not per line).
+     */
+    private withScale(draw2D: IfDraw2D | undefined, rect: Rect, scale: number[], draw: () => void) {
+        const scaled =
+            (scale[0] !== 1 || scale[1] !== 1) && (draw2D?.pushScale(rect.x, rect.y, scale[0], scale[1]) ?? false);
+        try {
+            draw();
+        } finally {
+            if (scaled) {
+                draw2D?.popScale();
+            }
+        }
+    }
+
     protected drawText(
         fullText: string,
         font: Font,
@@ -340,7 +401,8 @@ export class Group extends Node {
         rotation: number,
         draw2D?: IfDraw2D,
         ellipsis: string = "...",
-        index: number = 0
+        index: number = 0,
+        scale?: number[]
     ) {
         const drawFont = font.createDrawFont();
         if (!(drawFont instanceof RoFont)) {
@@ -385,7 +447,10 @@ export class Group extends Node {
                 textY += rect.height - measured.height;
             }
         }
-        draw2D?.doDrawRotatedText(text, textX, textY, color, opacity, drawFont, rotation);
+        scale ??= this.getValueJS("scale") as number[];
+        this.withScale(draw2D, rect, scale, () => {
+            draw2D?.doDrawRotatedText(text, textX, textY, color, opacity, drawFont, rotation);
+        });
         return measured;
     }
 
@@ -403,7 +468,8 @@ export class Group extends Node {
         maxLines: number = 0,
         lineSpacing: number = 0,
         displayPartialLines: boolean = false,
-        draw2D?: IfDraw2D
+        draw2D?: IfDraw2D,
+        scale?: number[]
     ): MeasuredText {
         const drawFont = font.createDrawFont();
         if (!(drawFont instanceof RoFont)) {
@@ -420,18 +486,21 @@ export class Group extends Node {
                 y += rect.height - this.cachedHeight;
             }
         }
+        scale ??= this.getValueJS("scale") as number[];
         let ellipsized = false;
-        for (const line of this.cachedLines) {
-            let x = rect.x;
-            if (horizAlign === "center") {
-                x += (rect.width - line.width) / 2;
-            } else if (horizAlign === "right") {
-                x += rect.width - line.width;
+        this.withScale(draw2D, rect, scale, () => {
+            for (const line of this.cachedLines) {
+                let x = rect.x;
+                if (horizAlign === "center") {
+                    x += (rect.width - line.width) / 2;
+                } else if (horizAlign === "right") {
+                    x += rect.width - line.width;
+                }
+                draw2D?.doDrawRotatedText(line.text, x, y, color, opacity, drawFont, rotation);
+                y += line.height + lineSpacing;
+                ellipsized = line.ellipsized;
             }
-            draw2D?.doDrawRotatedText(line.text, x, y, color, opacity, drawFont, rotation);
-            y += line.height + lineSpacing;
-            ellipsized = line.ellipsized;
-        }
+        });
 
         return {
             text,

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -374,13 +374,15 @@ export class Group extends Node {
     }
 
     /**
-     * Brackets `draw` with `IfDraw2D.pushScale`/`popScale` around `rect.x`/`rect.y` when `scale`
+     * Brackets `draw` with `IfDraw2D.pushScale`/`popScale` around the pivot `(x, y)` when `scale`
      * isn't the default `[1,1]` — the shared shape behind `drawText`'s single draw call and
-     * `drawTextWrap`'s per-line loop (pushed once for the whole block, not per line).
+     * `drawTextWrap`'s per-line loop (pushed once for the whole block, not per line). Takes raw
+     * coordinates rather than a `Rect` since only the pivot position is ever needed: a caller whose
+     * own rect gets mutated before drawing (SimpleLabel's horizOrigin/vertOrigin alignment) can pass
+     * its captured pivot directly instead of packaging a throwaway `Rect` around it.
      */
-    private withScale(draw2D: IfDraw2D | undefined, rect: Rect, scale: number[], draw: () => void) {
-        const scaled =
-            (scale[0] !== 1 || scale[1] !== 1) && (draw2D?.pushScale(rect.x, rect.y, scale[0], scale[1]) ?? false);
+    protected withScale(draw2D: IfDraw2D | undefined, x: number, y: number, scale: number[], draw: () => void) {
+        const scaled = (scale[0] !== 1 || scale[1] !== 1) && (draw2D?.pushScale(x, y, scale[0], scale[1]) ?? false);
         try {
             draw();
         } finally {
@@ -448,7 +450,7 @@ export class Group extends Node {
             }
         }
         scale ??= this.getValueJS("scale") as number[];
-        this.withScale(draw2D, rect, scale, () => {
+        this.withScale(draw2D, rect.x, rect.y, scale, () => {
             draw2D?.doDrawRotatedText(text, textX, textY, color, opacity, drawFont, rotation);
         });
         return measured;
@@ -488,7 +490,7 @@ export class Group extends Node {
         }
         scale ??= this.getValueJS("scale") as number[];
         let ellipsized = false;
-        this.withScale(draw2D, rect, scale, () => {
+        this.withScale(draw2D, rect.x, rect.y, scale, () => {
             for (const line of this.cachedLines) {
                 let x = rect.x;
                 if (horizAlign === "center") {

--- a/src/extensions/scenegraph/nodes/Label.ts
+++ b/src/extensions/scenegraph/nodes/Label.ts
@@ -80,16 +80,16 @@ export class Label extends Group {
             this.updateRenderTracking(true);
             return;
         }
-        const drawTrans = this.getDrawTranslation(origin, angle);
+        const scale = this.getValueJS("scale") as number[];
+        const drawTrans = this.getDrawTranslation(origin, angle, scale);
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
-        const scale = this.getValueJS("scale") as number[];
         this.measured = this.renderLabel(rect, rotation, opacity, draw2D, scale);
         rect.width = Math.max(this.measured.width, size.width);
         rect.height = Math.max(this.measured.height, size.height);
-        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation, scale);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }

--- a/src/extensions/scenegraph/nodes/Label.ts
+++ b/src/extensions/scenegraph/nodes/Label.ts
@@ -85,15 +85,16 @@ export class Label extends Group {
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
-        this.measured = this.renderLabel(rect, rotation, opacity, draw2D);
+        const scale = this.getValueJS("scale") as number[];
+        this.measured = this.renderLabel(rect, rotation, opacity, draw2D, scale);
         rect.width = Math.max(this.measured.width, size.width);
         rect.height = Math.max(this.measured.height, size.height);
-        this.updateBoundingRects(rect, origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 
-    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D) {
+    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D, scale?: number[]) {
         const font = this.getValue("font") as Font;
         const color = this.getValueJS("color") as number;
         const textField = this.getValueJS("text") as string;
@@ -123,7 +124,8 @@ export class Label extends Group {
                     maxLines,
                     lineSpacing,
                     displayPartialLines,
-                    draw2D
+                    draw2D,
+                    scale
                 );
             } else {
                 measured = { text: "", width: 0, height: 0, ellipsized: false };
@@ -139,7 +141,9 @@ export class Label extends Group {
                 vertAlign,
                 rotation,
                 draw2D,
-                ellipsis
+                ellipsis,
+                0,
+                scale
             );
         }
         this.setEllipsized(measured.ellipsized);

--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -13,6 +13,7 @@ import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
+import { scaledExtent } from "../SGUtil";
 import { Group } from "./Group";
 import { Node } from "./Node";
 
@@ -560,11 +561,25 @@ export class LayoutGroup extends Group {
         const dims = child.getDimensions();
         const cached = this.childSizes.get(child);
 
+        // A child scaled all the way to [0,0] legitimately renders a zero-size rect (Group.applyScale),
+        // which fails the cached-rect gate above and lands here. getDimensions() reads the child's raw,
+        // scale-unaware width/height field, so fold the child's own scale in before using it (via the
+        // same scaledExtent normalization Group.applyScale uses) — otherwise a fully collapsed child
+        // (e.g. hidden via scale rather than the visible field) is measured at its pre-collapse size
+        // and the LayoutGroup spaces siblings as if it were still full size.
+        const scale = child.getValueJS("scale") as number[] | undefined;
+
         const rect = {
             x: translation[0],
             y: translation[1],
-            width: typeof dims.width === "number" && dims.width > 0 ? dims.width : cached?.width ?? 0,
-            height: typeof dims.height === "number" && dims.height > 0 ? dims.height : cached?.height ?? 0,
+            width:
+                typeof dims.width === "number" && dims.width > 0
+                    ? scaledExtent(dims.width, scale?.[0] ?? 1)
+                    : cached?.width ?? 0,
+            height:
+                typeof dims.height === "number" && dims.height > 0
+                    ? scaledExtent(dims.height, scale?.[1] ?? 1)
+                    : cached?.height ?? 0,
         };
         return { rect, cached: false };
     }

--- a/src/extensions/scenegraph/nodes/MonospaceLabel.ts
+++ b/src/extensions/scenegraph/nodes/MonospaceLabel.ts
@@ -35,7 +35,13 @@ export class MonospaceLabel extends Label {
         }
     }
 
-    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D): MeasuredText {
+    protected renderLabel(
+        rect: Rect,
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D,
+        scale?: number[]
+    ): MeasuredText {
         const font = this.getValue("font") as Font;
         const drawFont = font.createDrawFont();
         const fullText = (this.getValueJS("text") as string) ?? "";
@@ -93,23 +99,26 @@ export class MonospaceLabel extends Label {
         }
 
         if (draw2D) {
+            scale ??= this.getValueJS("scale") as number[];
             const chars = [...text];
-            for (let i = 0; i < chars.length; i++) {
-                const char = chars[i];
-                const centerOffset =
-                    i === 0 && firstCharTrueLeftAlign ? 0 : (cellWidth - drawFont.measureTextWidth(char).width) / 2;
-                const local = [startX + i * cellWidth + centerOffset, startY];
-                const screen = rotation === 0 ? local : rotateTranslation(local, rotation);
-                draw2D.doDrawRotatedText(
-                    char,
-                    rect.x + screen[0],
-                    rect.y + screen[1],
-                    color,
-                    opacity,
-                    drawFont,
-                    rotation
-                );
-            }
+            this.withScale(draw2D, rect.x, rect.y, scale, () => {
+                for (let i = 0; i < chars.length; i++) {
+                    const char = chars[i];
+                    const centerOffset =
+                        i === 0 && firstCharTrueLeftAlign ? 0 : (cellWidth - drawFont.measureTextWidth(char).width) / 2;
+                    const local = [startX + i * cellWidth + centerOffset, startY];
+                    const screen = rotation === 0 ? local : rotateTranslation(local, rotation);
+                    draw2D.doDrawRotatedText(
+                        char,
+                        rect.x + screen[0],
+                        rect.y + screen[1],
+                        color,
+                        opacity,
+                        drawFont,
+                        rotation
+                    );
+                }
+            });
         }
 
         this.setEllipsized(ellipsized);

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -157,16 +157,16 @@ export class MultiStyleLabel extends Group {
             this.updateRenderTracking(true);
             return;
         }
-        const drawTrans = this.getDrawTranslation(origin, angle);
+        const scale = this.getValueJS("scale") as number[];
+        const drawTrans = this.getDrawTranslation(origin, angle, scale);
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
-        const scale = this.getValueJS("scale") as number[];
         this.measured = this.renderLabel(rect, rotation, opacity, draw2D, scale);
         rect.width = Math.max(this.measured.width, size.width);
         rect.height = Math.max(this.measured.height, size.height);
-        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation, scale);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -162,10 +162,11 @@ export class MultiStyleLabel extends Group {
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
-        this.measured = this.renderLabel(rect, rotation, opacity, draw2D);
+        const scale = this.getValueJS("scale") as number[];
+        this.measured = this.renderLabel(rect, rotation, opacity, draw2D, scale);
         rect.width = Math.max(this.measured.width, size.width);
         rect.height = Math.max(this.measured.height, size.height);
-        this.updateBoundingRects(rect, origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
@@ -175,7 +176,13 @@ export class MultiStyleLabel extends Group {
      * `width`/`height` field values (the computed bounding box); the returned
      * MeasuredText carries the rendered block size for bounding-rect tracking.
      */
-    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D): MeasuredText {
+    protected renderLabel(
+        rect: Rect,
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D,
+        scale?: number[]
+    ): MeasuredText {
         this.buildStyles();
         const fullText = (this.getValueJS("text") as string) ?? "";
         const horizAlign = (this.getValueJS("horizAlign") as string) || "left";
@@ -258,31 +265,34 @@ export class MultiStyleLabel extends Group {
                 y += rect.height - blockHeight;
             }
         }
-        for (let i = 0; i < rendered.length; i++) {
-            const line = rendered[i];
-            const { ascent, descent } = lineMetrics[i];
-            const baseline = y + ascent;
-            maxWidth = Math.max(maxWidth, line.width);
-            ellipsized ||= line.ellipsized;
-            let x = rect.x;
-            if (rect.width > line.width) {
-                if (horizAlign === "center") {
-                    x += (rect.width - line.width) / 2;
-                } else if (horizAlign === "right") {
-                    x += rect.width - line.width;
+        scale ??= this.getValueJS("scale") as number[];
+        this.withScale(draw2D, rect.x, rect.y, scale, () => {
+            for (let i = 0; i < rendered.length; i++) {
+                const line = rendered[i];
+                const { ascent, descent } = lineMetrics[i];
+                const baseline = y + ascent;
+                maxWidth = Math.max(maxWidth, line.width);
+                ellipsized ||= line.ellipsized;
+                let x = rect.x;
+                if (rect.width > line.width) {
+                    if (horizAlign === "center") {
+                        x += (rect.width - line.width) / 2;
+                    } else if (horizAlign === "right") {
+                        x += rect.width - line.width;
+                    }
                 }
-            }
-            for (const token of line.tokens) {
-                if (token.text.length > 0) {
-                    // Place this span's baseline on the line baseline.
-                    const topAdjust = token.font.getTopAdjust();
-                    const drawY = baseline - (token.height - 2 * topAdjust) - topAdjust;
-                    draw2D?.doDrawRotatedText(token.text, x, drawY, token.color, opacity, token.font, rotation);
+                for (const token of line.tokens) {
+                    if (token.text.length > 0) {
+                        // Place this span's baseline on the line baseline.
+                        const topAdjust = token.font.getTopAdjust();
+                        const drawY = baseline - (token.height - 2 * topAdjust) - topAdjust;
+                        draw2D?.doDrawRotatedText(token.text, x, drawY, token.color, opacity, token.font, rotation);
+                    }
+                    x += token.width;
                 }
-                x += token.width;
+                y += ascent + descent;
             }
-            y += ascent + descent;
-        }
+        });
         this.setEllipsized(ellipsized);
         return { text: fullText, width: maxWidth, height: blockHeight, ellipsized };
     }

--- a/src/extensions/scenegraph/nodes/Rectangle.ts
+++ b/src/extensions/scenegraph/nodes/Rectangle.ts
@@ -30,16 +30,16 @@ export class Rectangle extends Group {
             this.updateRenderTracking(true);
             return;
         }
-        const drawTrans = this.getDrawTranslation(origin, angle);
+        const scale = this.getValueJS("scale") as number[];
+        const drawTrans = this.getDrawTranslation(origin, angle, scale);
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         const color = this.getValueJS("color") as number;
         opacity = opacity * this.getOpacity();
         const center = this.getScaleRotateCenter();
-        const scale = this.getValueJS("scale") as number[];
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         draw2D?.doDrawRotatedRect(rect, color, rotation, center, opacity, scale[0], scale[1]);
-        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation, scale);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }

--- a/src/extensions/scenegraph/nodes/Rectangle.ts
+++ b/src/extensions/scenegraph/nodes/Rectangle.ts
@@ -36,9 +36,10 @@ export class Rectangle extends Group {
         const color = this.getValueJS("color") as number;
         opacity = opacity * this.getOpacity();
         const center = this.getScaleRotateCenter();
+        const scale = this.getValueJS("scale") as number[];
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
-        draw2D?.doDrawRotatedRect(rect, color, rotation, center, opacity);
-        this.updateBoundingRects(rect, origin, rotation);
+        draw2D?.doDrawRotatedRect(rect, color, rotation, center, opacity, scale[0], scale[1]);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -161,17 +161,18 @@ export class ScrollableText extends Group {
 
         const size = this.getDimensions();
         const rect: Rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
+        const scale = this.getValueJS("scale") as number[];
 
         if (draw2D && size.width > 0 && size.height > 0) {
-            this.renderContent(draw2D, rect, rotation, opacity);
+            this.renderContent(draw2D, rect, rotation, opacity, scale);
         }
 
-        this.updateBoundingRects(rect, origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 
-    private renderContent(draw2D: IfDraw2D, rect: Rect, rotation: number, opacity: number) {
+    private renderContent(draw2D: IfDraw2D, rect: Rect, rotation: number, opacity: number, scale: number[]) {
         const font = this.getValue("font") as Font;
         const drawFont = font?.createDrawFont();
         if (!(drawFont instanceof RoFont)) {
@@ -225,28 +226,33 @@ export class ScrollableText extends Group {
         // Draw visible lines with clipping to prevent overflow
         const clipWidth = showScrollbar ? nodeWidth - this.scrollbarWidth : nodeWidth;
         const clipRect: Rect = { x: rect.x, y: rect.y, width: clipWidth, height: nodeHeight };
-        draw2D.pushClip(clipRect);
-        try {
-            const endLine = Math.min(this.scrollTopLine + this.visibleLines, this.totalLines);
-            let y = startY;
-            for (let i = this.scrollTopLine; i < endLine; i++) {
-                const line = finalLines[i];
-                let x = rect.x;
-                if (horizAlign === "center" && textWidth > line.width) {
-                    x += (textWidth - line.width) / 2;
-                } else if (horizAlign === "right" && textWidth > line.width) {
-                    x += textWidth - line.width;
+        this.withScale(draw2D, rect.x, rect.y, scale, () => {
+            draw2D.pushClip(clipRect);
+            try {
+                const endLine = Math.min(this.scrollTopLine + this.visibleLines, this.totalLines);
+                let y = startY;
+                for (let i = this.scrollTopLine; i < endLine; i++) {
+                    const line = finalLines[i];
+                    let x = rect.x;
+                    if (horizAlign === "center" && textWidth > line.width) {
+                        x += (textWidth - line.width) / 2;
+                    } else if (horizAlign === "right" && textWidth > line.width) {
+                        x += textWidth - line.width;
+                    }
+                    draw2D.doDrawRotatedText(line.text, x, y, color, opacity, drawFont, rotation);
+                    y += this.lineHeight + lineSpacing;
                 }
-                draw2D.doDrawRotatedText(line.text, x, y, color, opacity, drawFont, rotation);
-                y += this.lineHeight + lineSpacing;
+            } finally {
+                draw2D.popClip();
             }
-        } finally {
-            draw2D.popClip();
-        }
+        });
 
-        // Draw scrollbar if needed
+        // Draw scrollbar if needed. Not wrapped in the scale bracket above: drawImage (used for the
+        // track/thumb bitmaps below) already applies this node's own scale to the bitmap dimensions
+        // directly (Group.drawImage) — nesting it inside another canvas-transform bracket would
+        // double-apply the scale.
         if (showScrollbar) {
-            this.renderScrollbar(draw2D, rect, nodeWidth, nodeHeight, rotation, opacity, maxScroll);
+            this.renderScrollbar(draw2D, rect, nodeWidth, nodeHeight, rotation, opacity, maxScroll, scale);
         }
     }
 
@@ -278,7 +284,8 @@ export class ScrollableText extends Group {
         nodeHeight: number,
         rotation: number,
         opacity: number,
-        maxScroll: number
+        maxScroll: number,
+        scale: number[]
     ) {
         const sbX = rect.x + nodeWidth - this.scrollbarWidth;
         const sbY = rect.y;
@@ -290,13 +297,17 @@ export class ScrollableText extends Group {
             const trackRect: Rect = { x: sbX, y: sbY, width: this.scrollbarWidth, height: nodeHeight };
             this.drawImage(trackBmp, trackRect, rotation, opacity, draw2D, trackBlend);
         } else {
-            // Fallback: draw a semi-transparent rectangle as track
+            // Fallback: draw a semi-transparent rectangle as track. Passed scale directly (not the
+            // canvas-transform withScale bracket) since doDrawRotatedRect already applies scale to a
+            // single rect draw the same way Rectangle.renderNodeContent does.
             draw2D.doDrawRotatedRect(
                 { x: sbX, y: sbY, width: this.scrollbarWidth, height: nodeHeight },
                 0x333333aa,
                 rotation,
                 undefined,
-                opacity
+                opacity,
+                scale[0],
+                scale[1]
             );
         }
 

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -155,19 +155,19 @@ export class ScrollableText extends Group {
             return;
         }
 
-        const drawTrans = this.getDrawTranslation(origin, angle);
+        const scale = this.getValueJS("scale") as number[];
+        const drawTrans = this.getDrawTranslation(origin, angle, scale);
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
 
         const size = this.getDimensions();
         const rect: Rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
-        const scale = this.getValueJS("scale") as number[];
 
         if (draw2D && size.width > 0 && size.height > 0) {
             this.renderContent(draw2D, rect, rotation, opacity, scale);
         }
 
-        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation, scale);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }

--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -165,7 +165,13 @@ export class ScrollingLabel extends Label {
     }
 
     // Override renderLabel to implement scrolling logic
-    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D): MeasuredText {
+    protected renderLabel(
+        rect: Rect,
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D,
+        scale?: number[]
+    ): MeasuredText {
         const text = this.getValueJS("text") as string;
         if (this.isDirty || (this.fullTextWidth === 0 && text)) {
             this.checkForScrolling();
@@ -238,12 +244,15 @@ export class ScrollingLabel extends Label {
                 }
             }
         }
-        draw2D?.pushClip(clipRect);
-        try {
-            draw2D?.doDrawRotatedText(textToDraw, drawX, drawY, color, opacity, drawFont, rotation);
-        } finally {
-            draw2D?.popClip();
-        }
+        scale ??= this.getValueJS("scale") as number[];
+        this.withScale(draw2D, rect.x, rect.y, scale, () => {
+            draw2D?.pushClip(clipRect);
+            try {
+                draw2D?.doDrawRotatedText(textToDraw, drawX, drawY, color, opacity, drawFont, rotation);
+            } finally {
+                draw2D?.popClip();
+            }
+        });
         // Safe on layout passes too (matching the base Label): with the scroll state frozen
         // during layout, the value derives purely from stored state, and setValue only notifies
         // on a genuine change — idempotent.

--- a/src/extensions/scenegraph/nodes/SimpleLabel.ts
+++ b/src/extensions/scenegraph/nodes/SimpleLabel.ts
@@ -87,16 +87,16 @@ export class SimpleLabel extends Group {
             this.updateRenderTracking(true);
             return;
         }
-        const drawTrans = this.getDrawTranslation(origin, angle);
+        const scale = this.getValueJS("scale") as number[];
+        const drawTrans = this.getDrawTranslation(origin, angle, scale);
         const rect = { x: drawTrans[0], y: drawTrans[1], width: 0, height: 0 };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
-        const scale = this.getValueJS("scale") as number[];
         // renderLabel offsets rect.x/rect.y to the drawn top-left so bounding rects are accurate.
         this.measured = this.renderLabel(rect, rotation, opacity, draw2D, scale);
         rect.width = this.measured.width;
         rect.height = this.measured.height;
-        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation, scale);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }

--- a/src/extensions/scenegraph/nodes/SimpleLabel.ts
+++ b/src/extensions/scenegraph/nodes/SimpleLabel.ts
@@ -91,11 +91,12 @@ export class SimpleLabel extends Group {
         const rect = { x: drawTrans[0], y: drawTrans[1], width: 0, height: 0 };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
+        const scale = this.getValueJS("scale") as number[];
         // renderLabel offsets rect.x/rect.y to the drawn top-left so bounding rects are accurate.
-        this.measured = this.renderLabel(rect, rotation, opacity, draw2D);
+        this.measured = this.renderLabel(rect, rotation, opacity, draw2D, scale);
         rect.width = this.measured.width;
         rect.height = this.measured.height;
-        this.updateBoundingRects(rect, origin, rotation);
+        this.updateBoundingRects(this.applyScale(rect, scale), origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
@@ -105,7 +106,13 @@ export class SimpleLabel extends Group {
      * position according to `horizOrigin`/`vertOrigin`. On return, `rect.x`/`rect.y`
      * are moved to the actual top-left of the drawn text.
      */
-    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D): MeasuredText {
+    protected renderLabel(
+        rect: Rect,
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D,
+        scale?: number[]
+    ): MeasuredText {
         const color = this.getValueJS("color") as number;
         const fullText = (this.getValueJS("text") as string) ?? "";
         const horizOrigin = (this.getValueJS("horizOrigin") as string) || "left";
@@ -120,6 +127,11 @@ export class SimpleLabel extends Group {
         const text = newlineIndex === -1 ? fullText : fullText.substring(0, newlineIndex);
         const measured = drawFont.measureText(text);
 
+        // Captured BEFORE the horizOrigin/vertOrigin adjustments below mutate rect.x/y: the scale
+        // pivot is the node's own local origin, not wherever the text ends up anchored.
+        const pivotX = rect.x;
+        const pivotY = rect.y;
+
         if (horizOrigin === "center") {
             rect.x -= measured.width / 2;
         } else if (horizOrigin === "right") {
@@ -133,7 +145,10 @@ export class SimpleLabel extends Group {
             const ascent = measured.height - 2 * drawFont.getTopAdjust();
             rect.y -= ascent;
         }
-        draw2D?.doDrawRotatedText(text, rect.x, rect.y, color, opacity, drawFont, rotation);
+        scale ??= this.getValueJS("scale") as number[];
+        this.withScale(draw2D, pivotX, pivotY, scale, () => {
+            draw2D?.doDrawRotatedText(text, rect.x, rect.y, color, opacity, drawFont, rotation);
+        });
         return measured;
     }
 }

--- a/test/extensions/scenegraph/Label.test.js
+++ b/test/extensions/scenegraph/Label.test.js
@@ -202,3 +202,155 @@ describe("Label node wrap/vertAlign", () => {
         }
     });
 });
+
+/**
+ * Regression: `scale` used to be a no-op on drawn text (it was only ever applied to Poster-style
+ * bitmap drawing), so a component hiding a Label via `scale=[0,0]` when unfocused — the idiomatic
+ * Roku show/hide pattern used by many apps' focus-driven buttons — rendered the label at full size
+ * regardless of scale. Fixed by wrapping the (unmodified) draw call in a division-free
+ * translate/scale/translate-back bracket (IfDraw2D.pushScale/popScale).
+ */
+describe("Label node scale", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function textLabel({ scale, translation = [0, 0], text = "hello", horizAlign = "left" } = {}) {
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("font", new BrsString("font:MediumSystemFont"));
+        label.setValue("translation", vector(translation));
+        label.setValue("horizAlign", new BrsString(horizAlign));
+        if (scale !== undefined) label.setValue("scale", vector(scale));
+        label.setValue("text", new BrsString(text));
+        return label;
+    }
+
+    test("scale=[0,0] pushes a scale bracket (around the node's translated origin) before drawing, then pops it", () => {
+        const label = textLabel({ scale: [0, 0], translation: [10, 20] });
+        const calls = [];
+        const draw2D = {
+            pushScale(pivotX, pivotY, scaleX, scaleY) {
+                calls.push(["push", pivotX, pivotY, scaleX, scaleY]);
+                return true;
+            },
+            popScale() {
+                calls.push(["pop"]);
+            },
+            doDrawRotatedText(text) {
+                calls.push(["draw", text]);
+            },
+        };
+        label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls[0]).toEqual(["push", 10, 20, 0, 0]);
+        expect(calls[1][0]).toBe("draw");
+        expect(calls[2]).toEqual(["pop"]);
+    });
+
+    test("scale=[1,1] (default) never calls pushScale/popScale", () => {
+        const label = textLabel();
+        // Deliberately omits pushScale/popScale, mirroring existing minimal draw2D stubs
+        // elsewhere in this file (e.g. captureLineYs) — a default-scale node must not call them.
+        const draw2D = { doDrawRotatedText() {} };
+        expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+    });
+
+    test("a wrapping multi-line Label pushes the scale bracket once for the whole block, not per line", () => {
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("font", new BrsString("font:MediumSystemFont"));
+        label.setValue("width", new Float(400));
+        label.setValue("wrap", BrsBoolean.True);
+        label.setValue("scale", vector([2, 2]));
+        label.setValue("text", new BrsString(LONG_TEXT));
+
+        let pushCount = 0;
+        let popCount = 0;
+        let drawCount = 0;
+        const draw2D = {
+            pushScale() {
+                pushCount++;
+                return true;
+            },
+            popScale() {
+                popCount++;
+            },
+            doDrawRotatedText(text) {
+                if (text.trim() !== "") drawCount++;
+            },
+        };
+        label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(drawCount).toBeGreaterThan(1); // actually wrapped into multiple lines
+        expect(pushCount).toBe(1);
+        expect(popCount).toBe(1);
+    });
+
+    test("scale does not affect measured size (getMeasured)", () => {
+        const unscaled = textLabel().getMeasured();
+        const shrunk = textLabel({ scale: [0, 0] }).getMeasured();
+        const grown = textLabel({ scale: [2, 2] }).getMeasured();
+
+        expect(shrunk.width).toBeCloseTo(unscaled.width, 5);
+        expect(shrunk.height).toBeCloseTo(unscaled.height, 5);
+        expect(grown.width).toBeCloseTo(unscaled.width, 5);
+        expect(grown.height).toBeCloseTo(unscaled.height, 5);
+    });
+});
+
+/**
+ * Integration regression, reproducing the reported shape: a custom "button" component (a Group
+ * wrapping a fixed-width Rectangle background that stays present, plus a Label collapsed via
+ * `scale=[0,0]` — TextIconButton's exact pattern, with a Rectangle standing in for its Poster
+ * background) placed inside an outer horizontal LayoutGroup (TransportButtons). Before this fix,
+ * the collapsed Label still contributed its full unscaled text width to the button's own reported
+ * footprint, so the outer LayoutGroup spaced buttons as if every label were shown even when none
+ * had focus.
+ */
+describe("LayoutGroup spacing reflects a button whose label is collapsed via scale", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function button({ bgWidth, labelScale, text = "Feedback" }) {
+        const group = SGNodeFactory.createNode("Group");
+        const bg = SGNodeFactory.createNode("Rectangle");
+        bg.setValue("width", new Float(bgWidth));
+        bg.setValue("height", new Float(60));
+        group.appendChildToParent(bg);
+
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("font", new BrsString("font:MediumSystemFont"));
+        label.setValue("translation", vector([10, 20]));
+        label.setValue("scale", vector(labelScale));
+        label.setValue("text", new BrsString(text));
+        group.appendChildToParent(label);
+
+        return group;
+    }
+
+    test("a button with its label collapsed reports a footprint close to its background, not its label text", () => {
+        const focusedButton = button({ bgWidth: 160, labelScale: [1, 1] });
+        const collapsedButton = button({ bgWidth: 40, labelScale: [0, 0] });
+
+        const row = SGNodeFactory.createNode("LayoutGroup");
+        row.setValue("layoutDirection", new BrsString("horiz"));
+        row.setValue("itemSpacings", vector([20]));
+        row.appendChildToParent(focusedButton);
+        row.appendChildToParent(collapsedButton);
+
+        const draw2D = {
+            doDrawRotatedText() {},
+            doDrawRotatedRect() {},
+            pushScale() {
+                return true;
+            },
+            popScale() {},
+        };
+        row.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        // The collapsed button must be packed right after the focused one's background width
+        // (160) plus the item spacing (20) — NOT pushed out by "Feedback"'s full text width,
+        // which is comfortably wider than the 40px background alone.
+        expect(collapsedButton.getValueJS("translation")[0]).toBeCloseTo(180, 5);
+    });
+});

--- a/test/extensions/scenegraph/MonospaceLabel.test.js
+++ b/test/extensions/scenegraph/MonospaceLabel.test.js
@@ -4,10 +4,15 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, BrsBoolean, Float } = core;
+const { BrsDevice, BrsString, BrsBoolean, Float, RoArray } = core;
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
+
+/** A float vector for translation/scale-style fields. */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
 
 /** Renders the label with a stub draw surface, capturing each drawn glyph (text + position + color). */
 function captureGlyphs(label, origin = [0, 0]) {
@@ -171,5 +176,66 @@ describe("MonospaceLabel node", () => {
                 expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1)).not.toThrow();
             }
         }
+    });
+
+    /**
+     * Regression: `scale` used to be a no-op on MonospaceLabel (it overrides Label.renderLabel
+     * with its own per-character draw loop, bypassing Group.drawText's scale bracket entirely).
+     * Fixed via Group.withScale, pushed ONCE around the whole per-character loop (not once per
+     * glyph) so every character shares the same pivot/scale.
+     */
+    describe("scale", () => {
+        function monoLabel({ scale, translation = [0, 0] } = {}) {
+            const label = SGNodeFactory.createNode("MonospaceLabel");
+            label.setValue("font", new BrsString("font:MediumSystemFont"));
+            label.setValue("translation", vector(translation));
+            if (scale) label.setValue("scale", vector(scale));
+            label.setValue("text", new BrsString("hi"));
+            return label;
+        }
+
+        test("scale=[0,0] pushes a scale bracket once for the whole run, around the node's own translation", () => {
+            const label = monoLabel({ scale: [0, 0], translation: [10, 20] });
+            const calls = [];
+            const draw2D = {
+                pushScale(pivotX, pivotY, scaleX, scaleY) {
+                    calls.push(["push", pivotX, pivotY, scaleX, scaleY]);
+                    return true;
+                },
+                popScale() {
+                    calls.push(["pop"]);
+                },
+                doDrawRotatedText(text) {
+                    calls.push(["draw", text]);
+                },
+            };
+            label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+            expect(calls[0]).toEqual(["push", 10, 20, 0, 0]);
+            expect(calls.filter((c) => c[0] === "draw").length).toBe(2); // "h" and "i"
+            expect(calls.at(-1)).toEqual(["pop"]);
+        });
+
+        test("scale=[1,1] (default) never calls pushScale/popScale", () => {
+            const label = monoLabel();
+            const draw2D = { doDrawRotatedText() {} };
+            expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+        });
+
+        test("scale=[0,0] collapses the reported boundingRect", () => {
+            const label = monoLabel({ scale: [0, 0], translation: [10, 20] });
+            const draw2D = {
+                doDrawRotatedText() {},
+                pushScale() {
+                    return true;
+                },
+                popScale() {},
+            };
+            label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+            const rect = label.getBoundingRect("toParent", { environment: {}, inSubEnv: () => {} });
+            expect(rect.width).toBe(0);
+            expect(rect.height).toBe(0);
+        });
     });
 });

--- a/test/extensions/scenegraph/MultiStyleLabel.test.js
+++ b/test/extensions/scenegraph/MultiStyleLabel.test.js
@@ -4,7 +4,12 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, BrsBoolean, Int32, RoAssociativeArray } = core;
+const { BrsDevice, BrsString, BrsBoolean, Int32, Float, RoArray, RoAssociativeArray } = core;
+
+/** A float vector for translation/scale-style fields. */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
@@ -227,5 +232,71 @@ describe("MultiStyleLabel node", () => {
         } finally {
             sgRoot.rendering = false;
         }
+    });
+});
+
+/**
+ * Regression: `scale` used to be a no-op on MultiStyleLabel (it extends Group directly with its
+ * own renderNodeContent/renderLabel, bypassing Group.drawText's scale bracket and never calling
+ * Group.applyScale for its bounding rect). Fixed the same way as Label: Group.withScale pushed
+ * once around the whole multi-line/multi-token draw loop, and Group.applyScale folded into the
+ * rect passed to updateBoundingRects.
+ */
+describe("MultiStyleLabel scale", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function styledLabel({ scale, translation = [0, 0] } = {}) {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
+        label.setValue("translation", vector(translation));
+        if (scale) label.setValue("scale", vector(scale));
+        label.setValue("text", new BrsString("hello <b>world</b>"));
+        return label;
+    }
+
+    test("scale=[0,0] pushes a scale bracket once for the whole block, around the node's own translation", () => {
+        const label = styledLabel({ scale: [0, 0], translation: [10, 20] });
+        const calls = [];
+        const draw2D = {
+            pushScale(pivotX, pivotY, scaleX, scaleY) {
+                calls.push(["push", pivotX, pivotY, scaleX, scaleY]);
+                return true;
+            },
+            popScale() {
+                calls.push(["pop"]);
+            },
+            doDrawRotatedText(text) {
+                if (text.length > 0) calls.push(["draw", text]);
+            },
+        };
+        label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls[0]).toEqual(["push", 10, 20, 0, 0]);
+        expect(calls.filter((c) => c[0] === "draw").length).toBeGreaterThan(1); // multiple tokens
+        expect(calls.at(-1)).toEqual(["pop"]);
+    });
+
+    test("scale=[1,1] (default) never calls pushScale/popScale", () => {
+        const label = styledLabel();
+        const draw2D = { doDrawRotatedText() {} };
+        expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+    });
+
+    test("scale=[0,0] collapses the reported boundingRect", () => {
+        const label = styledLabel({ scale: [0, 0], translation: [10, 20] });
+        const draw2D = {
+            doDrawRotatedText() {},
+            pushScale() {
+                return true;
+            },
+            popScale() {},
+        };
+        label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        const rect = label.getBoundingRect("toParent", fakeObserverInterpreter);
+        expect(rect.width).toBe(0);
+        expect(rect.height).toBe(0);
     });
 });

--- a/test/extensions/scenegraph/Rectangle.test.js
+++ b/test/extensions/scenegraph/Rectangle.test.js
@@ -1,0 +1,178 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { Float, RoArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+/** Minimal fake interpreter accepted by getBoundingRect (mirrors Label.test.js). */
+const fakeObserverInterpreter = { environment: {}, inSubEnv: () => {} };
+
+/** A float vector for translation/scale-style fields. */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
+
+function rectangle({ width = 100, height = 50, translation = [0, 0], scale, scaleRotateCenter } = {}) {
+    const rect = SGNodeFactory.createNode("Rectangle");
+    rect.setValue("width", new Float(width));
+    rect.setValue("height", new Float(height));
+    rect.setValue("translation", vector(translation));
+    if (scale !== undefined) rect.setValue("scale", vector(scale));
+    if (scaleRotateCenter !== undefined) rect.setValue("scaleRotateCenter", vector(scaleRotateCenter));
+    return rect;
+}
+
+/**
+ * Regression: `scale` used to be a no-op on a Rectangle's own fill (it was only ever applied to
+ * Poster-style bitmap drawing), so `scale=[0,0]` never visually collapsed a Rectangle, AND its
+ * reported boundingRect() never shrank either — so a parent LayoutGroup kept spacing a collapsed
+ * Rectangle as if it were full size (the exact symptom reported against TextIconButton's Label,
+ * reproduced here for Rectangle since it shares the same underlying gap). Fixed by (1) threading
+ * the node's own scale field through to `doDrawRotatedRect`'s new trailing scaleX/scaleY params
+ * for drawing, and (2) folding scale into the rect passed to `updateBoundingRects` via the new
+ * `Group.applyScale` helper, so a rendered node's own reported footprint agrees with what it paints.
+ */
+describe("Rectangle node scale", () => {
+    test("scale=[1,1] (default) draws with scaleX=1/scaleY=1 and the node's plain unscaled rect", () => {
+        const rect = rectangle({ translation: [10, 20] });
+        const calls = [];
+        const draw2D = {
+            doDrawRotatedRect(r, rgba, rotation, center, opacity, scaleX, scaleY) {
+                calls.push({ r, scaleX, scaleY });
+            },
+        };
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls.length).toBe(1);
+        expect(calls[0].scaleX).toBe(1);
+        expect(calls[0].scaleY).toBe(1);
+        expect(calls[0].r).toEqual({ x: 10, y: 20, width: 100, height: 50 });
+        expect(rect.getBoundingRect("toParent", fakeObserverInterpreter)).toEqual({
+            x: 10,
+            y: 20,
+            width: 100,
+            height: 50,
+        });
+    });
+
+    test("scale=[0,0] passes scaleX=0/scaleY=0 to the draw call (unscaled rect - it applies its own bracket)", () => {
+        const rect = rectangle({ translation: [10, 20], scale: [0, 0] });
+        const calls = [];
+        const draw2D = {
+            doDrawRotatedRect(r, rgba, rotation, center, opacity, scaleX, scaleY) {
+                calls.push({ r, scaleX, scaleY });
+            },
+        };
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls.length).toBe(1);
+        expect(calls[0].scaleX).toBe(0);
+        expect(calls[0].scaleY).toBe(0);
+        expect(calls[0].r).toEqual({ x: 10, y: 20, width: 100, height: 50 });
+    });
+
+    test("scale=[0,0] collapses the REPORTED boundingRect (default scaleRotateCenter [0,0]: top-left anchored)", () => {
+        const rect = rectangle({ translation: [10, 20], scale: [0, 0] });
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, { doDrawRotatedRect() {} });
+
+        expect(rect.getBoundingRect("toParent", fakeObserverInterpreter)).toEqual({
+            x: 10,
+            y: 20,
+            width: 0,
+            height: 0,
+        });
+    });
+
+    test("scale=[0.5,0.5] with a non-default scaleRotateCenter shrinks the boundingRect around that pivot", () => {
+        const rect = rectangle({
+            translation: [10, 20],
+            width: 100,
+            height: 50,
+            scale: [0.5, 0.5],
+            scaleRotateCenter: [20, 10],
+        });
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, { doDrawRotatedRect() {} });
+
+        // x = rect.x + center.x*(1-scaleX) = 10 + 20*0.5 = 20; width = 100*0.5 = 50 (symmetric for y/height).
+        expect(rect.getBoundingRect("toParent", fakeObserverInterpreter)).toEqual({
+            x: 20,
+            y: 25,
+            width: 50,
+            height: 25,
+        });
+    });
+
+    test("a mirrored (negative) scale reports a non-negative boundingRect, not a backwards one", () => {
+        const rect = rectangle({ translation: [10, 20], width: 100, height: 50, scale: [-1, 1] });
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, { doDrawRotatedRect() {} });
+
+        // x=10, width=100*-1=-100 -> normalized to x=10-100=-90, width=abs(-100)=100 (unionRect
+        // assumes non-negative width when computing the far edge as x+width).
+        expect(rect.getBoundingRect("toParent", fakeObserverInterpreter)).toEqual({
+            x: -90,
+            y: 20,
+            width: 100,
+            height: 50,
+        });
+    });
+
+    test("getDimensions() (the raw width/height fields) is unaffected by scale", () => {
+        const rect = rectangle({ scale: [0, 0] });
+        expect(rect.getDimensions()).toEqual({ width: 100, height: 50 });
+    });
+
+    test("scale is not propagated to children", () => {
+        const rect = rectangle({ translation: [10, 20], scale: [0, 0] });
+        const child = rectangle({ width: 5, height: 5 });
+        rect.appendChildToParent(child);
+
+        const calls = [];
+        const draw2D = {
+            doDrawRotatedRect(r, rgba, rotation, center, opacity, scaleX, scaleY) {
+                calls.push({ r, scaleX, scaleY });
+            },
+        };
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls.length).toBe(2);
+        // Second call is the child: it must not inherit the parent's [0,0] scale, and must render
+        // at the parent's unscaled translation (renderChildren receives unscaled drawTrans).
+        const childCall = calls[1];
+        expect(childCall.scaleX).toBe(1);
+        expect(childCall.scaleY).toBe(1);
+        expect(childCall.r.x).toBe(10);
+        expect(childCall.r.y).toBe(20);
+    });
+});
+
+/**
+ * Integration regression, reproducing the exact reported scenario: a Rectangle inside a
+ * LayoutGroup must contribute its SCALED (not natural) size to the LayoutGroup's item spacing,
+ * matching TextIconButton's Label shrinking inside VideoPlayerScreen's TransportButtons LayoutGroup.
+ */
+describe("LayoutGroup spacing reflects a scaled child's collapsed size", () => {
+    test("a horizontal LayoutGroup packs a scaled-to-zero Rectangle at zero width, not its natural width", () => {
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new core.BrsString("horiz"));
+        layout.setValue("itemSpacings", vector([10]));
+
+        const first = rectangle({ width: 100, height: 50 });
+        const collapsed = rectangle({ width: 100, height: 50, scale: [0, 0] });
+        const third = rectangle({ width: 100, height: 50 });
+        layout.appendChildToParent(first);
+        layout.appendChildToParent(collapsed);
+        layout.appendChildToParent(third);
+
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1, { doDrawRotatedRect() {} });
+
+        // first at x=0 (width 100), collapsed at x=110 (width 0), third packed right after it at
+        // x=120 (110 + 0 + itemSpacing) — NOT x=210, which is what the pre-fix natural-width-100
+        // collapsed rect would have produced.
+        expect(first.getValueJS("translation")[0]).toBeCloseTo(0, 5);
+        expect(collapsed.getValueJS("translation")[0]).toBeCloseTo(110, 5);
+        expect(third.getValueJS("translation")[0]).toBeCloseTo(120, 5);
+    });
+});

--- a/test/extensions/scenegraph/Rectangle.test.js
+++ b/test/extensions/scenegraph/Rectangle.test.js
@@ -1,7 +1,7 @@
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { SGNodeFactory } = scenegraph;
+const { SGNodeFactory, Node } = scenegraph;
 const { Float, RoArray } = core;
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
@@ -145,6 +145,24 @@ describe("Rectangle node scale", () => {
         expect(childCall.scaleY).toBe(1);
         expect(childCall.r.x).toBe(10);
         expect(childCall.r.y).toBe(20);
+    });
+
+    /**
+     * Efficiency regression: `getTranslation()` already reads the `scale` field internally (to
+     * compensate the drawn position for `scaleRotateCenter`), so `renderNodeContent` must fetch
+     * `scale` ONCE and thread it into `getDrawTranslation(origin, angle, scale)` rather than
+     * reading the field a second time for `applyScale`/`doDrawRotatedRect` — a real, avoidable
+     * double allocation (getValueJS on a vector2d field allocates a WeakSet + a fresh array) that
+     * slipped in when scale support was first wired into these node types.
+     */
+    test("reads the scale field exactly once per render pass", () => {
+        const rect = rectangle({ translation: [10, 20], scale: [0.5, 0.5] });
+        const spy = vi.spyOn(Node.prototype, "getValueJS");
+        rect.renderNode(fakeInterpreter, [0, 0], 0, 1, { doDrawRotatedRect() {} });
+
+        const scaleCalls = spy.mock.calls.filter(([field]) => field === "scale");
+        expect(scaleCalls.length).toBe(1);
+        spy.mockRestore();
     });
 });
 

--- a/test/extensions/scenegraph/ScrollableText.test.js
+++ b/test/extensions/scenegraph/ScrollableText.test.js
@@ -1,0 +1,125 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float, RoArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+/** Minimal fake interpreter accepted by getBoundingRect (mirrors Label.test.js). */
+const fakeObserverInterpreter = { environment: {}, inSubEnv: () => {} };
+
+/** A float vector for translation/scale-style fields. */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
+
+/**
+ * Regression: `scale` used to be a no-op on ScrollableText (it extends Group directly with its
+ * own renderNodeContent/renderContent, bypassing Group.drawText's scale bracket and never calling
+ * Group.applyScale for its bounding rect). Fixed by wrapping its text-line draw loop in
+ * Group.withScale and folding scale into the rect passed to updateBoundingRects. The scrollbar
+ * itself is deliberately NOT wrapped in the same bracket — its track/thumb bitmaps already go
+ * through Group.drawImage, which independently applies this node's own scale to the bitmap
+ * dimensions; nesting that inside another canvas-transform bracket would double-apply it.
+ */
+describe("ScrollableText node scale", () => {
+    beforeAll(() => {
+        // Fonts and the default scrollbar 9-patches are resolved from the common: volume.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function scrollableText({ scale, translation = [0, 0], width = 200, height = 100 } = {}) {
+        const node = SGNodeFactory.createNode("ScrollableText");
+        node.setValue("font", new BrsString("font:MediumSystemFont"));
+        node.setValue("translation", vector(translation));
+        node.setValue("width", new Float(width));
+        node.setValue("height", new Float(height));
+        if (scale) node.setValue("scale", vector(scale));
+        node.setValue("text", new BrsString("hello world, this is some scrollable text"));
+        return node;
+    }
+
+    test("scale=[0,0] pushes a scale bracket once for the text block, around the node's own translation", () => {
+        const node = scrollableText({ scale: [0, 0], translation: [10, 20] });
+        const calls = [];
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            pushScale(pivotX, pivotY, scaleX, scaleY) {
+                calls.push(["push", pivotX, pivotY, scaleX, scaleY]);
+                return true;
+            },
+            popScale() {
+                calls.push(["pop"]);
+            },
+            doDrawRotatedText(text) {
+                if (text.trim() !== "") calls.push(["draw", text]);
+            },
+            doDrawRotatedRect() {},
+        };
+        node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls[0]).toEqual(["push", 10, 20, 0, 0]);
+        expect(calls.some((c) => c[0] === "draw")).toBe(true);
+        // The push/pop bracket around the text block closes before anything else runs.
+        expect(calls[calls.findIndex((c) => c[0] === "pop")]).toEqual(["pop"]);
+    });
+
+    test("scale=[1,1] (default) never calls pushScale/popScale", () => {
+        const node = scrollableText();
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            doDrawRotatedText() {},
+            doDrawRotatedRect() {},
+        };
+        expect(() => node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+    });
+
+    test("scale=[0,0] collapses the reported boundingRect", () => {
+        const node = scrollableText({ scale: [0, 0], translation: [10, 20] });
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            doDrawRotatedText() {},
+            doDrawRotatedRect() {},
+            pushScale() {
+                return true;
+            },
+            popScale() {},
+        };
+        node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        const rect = node.getBoundingRect("toParent", fakeObserverInterpreter);
+        expect(rect.width).toBe(0);
+        expect(rect.height).toBe(0);
+    });
+
+    test("a narrow width that triggers the scrollbar still renders without throwing at scale=[0,0]", () => {
+        // Wide enough text + narrow width forces computeLines/showScrollbar down the scrollbar path,
+        // which calls Group.drawImage (its own, independent scale handling) — must not conflict with
+        // the text block's withScale bracket.
+        const node = scrollableText({ scale: [0, 0], width: 80, height: 40 });
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            doDrawRotatedText() {},
+            doDrawRotatedRect() {},
+            drawNinePatch() {},
+            pushScale() {
+                return true;
+            },
+            popScale() {},
+        };
+        expect(() => node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+    });
+});

--- a/test/extensions/scenegraph/ScrollingLabel.test.js
+++ b/test/extensions/scenegraph/ScrollingLabel.test.js
@@ -4,10 +4,15 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, Float } = core;
+const { BrsDevice, BrsString, Float, RoArray } = core;
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
+
+/** A float vector for translation/scale-style fields. */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
 
 /** Renders the label with a stub draw surface, capturing the y of the drawn text. */
 function captureTextY(label) {
@@ -87,5 +92,74 @@ describe("ScrollingLabel node vertAlign", () => {
 
         expect(centerYs).toBeCloseTo(0, 5);
         expect(bottomYs).toBeCloseTo(0, 5);
+    });
+});
+
+/**
+ * Regression: `scale` used to be a no-op on ScrollingLabel (it overrides Label.renderLabel with
+ * its own marquee draw path, bypassing Group.drawText's scale bracket entirely), so
+ * `scale=[0,0]` never visually collapsed it. Fixed via the same Group.withScale mechanism, pushed
+ * around the existing pushClip/popClip bracket. The bounding-rect fix comes for free: ScrollingLabel
+ * doesn't override Label.renderNodeContent, which already applies Group.applyScale.
+ */
+describe("ScrollingLabel node scale", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function scrollingLabel({ scale, translation = [0, 0] } = {}) {
+        const label = SGNodeFactory.createNode("ScrollingLabel");
+        label.setValue("font", new BrsString("font:MediumSystemFont"));
+        label.setValue("translation", vector(translation));
+        if (scale) label.setValue("scale", vector(scale));
+        label.setValue("text", new BrsString("Search"));
+        return label;
+    }
+
+    test("scale=[0,0] pushes a scale bracket around the node's own translation before drawing", () => {
+        const label = scrollingLabel({ scale: [0, 0], translation: [10, 20] });
+        const calls = [];
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            pushScale(pivotX, pivotY, scaleX, scaleY) {
+                calls.push(["push", pivotX, pivotY, scaleX, scaleY]);
+                return true;
+            },
+            popScale() {
+                calls.push(["pop"]);
+            },
+            doDrawRotatedText(text) {
+                if (text.trim() !== "") calls.push(["draw", text]);
+            },
+        };
+        label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        expect(calls[0]).toEqual(["push", 10, 20, 0, 0]);
+        expect(calls.at(-1)).toEqual(["pop"]);
+    });
+
+    test("scale=[1,1] (default) never calls pushScale/popScale", () => {
+        const label = scrollingLabel();
+        const draw2D = { pushClip() {}, popClip() {}, doDrawRotatedText() {} };
+        expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+    });
+
+    test("scale=[0,0] collapses the reported boundingRect", () => {
+        const label = scrollingLabel({ scale: [0, 0], translation: [10, 20] });
+        const draw2D = {
+            pushClip() {},
+            popClip() {},
+            doDrawRotatedText() {},
+            pushScale() {
+                return true;
+            },
+            popScale() {},
+        };
+        label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+        const rect = label.getBoundingRect("toParent", { environment: {}, inSubEnv: () => {} });
+        expect(rect.width).toBe(0);
+        expect(rect.height).toBe(0);
     });
 });

--- a/test/extensions/scenegraph/SimpleLabel.test.js
+++ b/test/extensions/scenegraph/SimpleLabel.test.js
@@ -4,13 +4,18 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, Int32 } = core;
+const { BrsDevice, BrsString, Int32, Float, RoArray } = core;
 
 /** Minimal fake interpreter accepted by getBoundingRect (mirrors Poster.test.js). */
 const fakeObserverInterpreter = { environment: {}, inSubEnv: () => {} };
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
+
+/** A float vector for translation/scale-style fields. */
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
 
 describe("SimpleLabel node", () => {
     beforeAll(() => {
@@ -122,5 +127,78 @@ describe("SimpleLabel node", () => {
                 expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1)).not.toThrow();
             }
         }
+    });
+
+    /**
+     * Regression: `scale` used to be a no-op on SimpleLabel (only Label ever wired the draw-time
+     * and bounding-rect scale bracket), so `scale=[0,0]` never visually collapsed it. Fixed by the
+     * same Group.withScale/applyScale mechanism Label uses. SimpleLabel's own renderLabel mutates
+     * rect.x/y in place for horizOrigin/vertOrigin alignment BEFORE drawing, so the scale pivot must
+     * be captured up front — otherwise a centered/right/bottom-anchored label would scale around its
+     * post-alignment position instead of its own translation.
+     */
+    describe("scale", () => {
+        function scaledLabel({ scale, translation, horizOrigin = "left", vertOrigin = "top" } = {}) {
+            const label = SGNodeFactory.createNode("SimpleLabel");
+            label.setValue("fontUri", new BrsString("font:MediumSystemFont"));
+            label.setValue("text", new BrsString("hello"));
+            if (translation) label.setValue("translation", vector(translation));
+            label.setValue("horizOrigin", new BrsString(horizOrigin));
+            label.setValue("vertOrigin", new BrsString(vertOrigin));
+            if (scale) label.setValue("scale", vector(scale));
+            return label;
+        }
+
+        test("scale=[0,0] pushes a scale bracket around the node's own translation, not the aligned draw position", () => {
+            const label = scaledLabel({
+                scale: [0, 0],
+                translation: [10, 20],
+                horizOrigin: "center",
+                vertOrigin: "bottom",
+            });
+            const calls = [];
+            const draw2D = {
+                pushScale(pivotX, pivotY, scaleX, scaleY) {
+                    calls.push(["push", pivotX, pivotY, scaleX, scaleY]);
+                    return true;
+                },
+                popScale() {
+                    calls.push(["pop"]);
+                },
+                doDrawRotatedText(text, x, y) {
+                    calls.push(["draw", x, y]);
+                },
+            };
+            label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+            // Pivot is the node's own (10,20) translation, NOT wherever center/bottom alignment
+            // shifted the actual draw position to.
+            expect(calls[0]).toEqual(["push", 10, 20, 0, 0]);
+            expect(calls[1][0]).toBe("draw");
+            expect(calls[1][1]).not.toBe(10); // the draw itself IS shifted by horizOrigin/vertOrigin
+            expect(calls[2]).toEqual(["pop"]);
+        });
+
+        test("scale=[1,1] (default) never calls pushScale/popScale", () => {
+            const label = scaledLabel();
+            const draw2D = { doDrawRotatedText() {} };
+            expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+        });
+
+        test("scale=[0,0] collapses the reported boundingRect", () => {
+            const label = scaledLabel({ scale: [0, 0], translation: [10, 20] });
+            const draw2D = {
+                doDrawRotatedText() {},
+                pushScale() {
+                    return true;
+                },
+                popScale() {},
+            };
+            label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+
+            const rect = label.getBoundingRect("toParent", fakeObserverInterpreter);
+            expect(rect.width).toBe(0);
+            expect(rect.height).toBe(0);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- The SceneGraph `scale` field was only ever honored when drawing a Poster-style background bitmap — text (Label and everything sharing `Group.drawText`/`drawTextWrap`) and Rectangle fills ignored it entirely, so scaling a node to shrink or hide it had no visual effect, and a scaled node's reported bounding rect stayed unscaled, so a `LayoutGroup` measuring a scaled-down child still spaced its siblings as if the child were full size.
- Adds a division-free scale-around-pivot canvas bracket (`IfDraw2D.pushScale`/`popScale`, and inline in `doDrawRotatedRect`) and folds the same scale into the rect passed to `updateBoundingRects` (`Group.applyScale`), so a scaled node's reported footprint agrees with what it actually paints. Normalizes a negative (mirrored) scale to a non-negative extent throughout, matching what downstream rect math assumes.
- Extends the same mechanism to five more node types that each draw text through their own path instead of the shared `Group.drawText`/`drawTextWrap`: `SimpleLabel`, `ScrollingLabel`, `MonospaceLabel`, `MultiStyleLabel`, and `ScrollableText` — all confirmed against the Roku SceneGraph reference to extend `Group` and inherit its `scale`/`scaleRotateCenter` fields. `RowList`'s row-counter/divider text was checked and confirmed out of scope (drawn directly from `RowList`'s own fields, not a separate scale-bearing node).

## Test plan
- [x] `npm run lint` / `npm run prettier:write` clean
- [x] Full suite green: 211 files, 2693 tests passing
- [x] New regression tests per node type: `scale=[0,0]` collapses the drawn content and reported `boundingRect()`, `scale=[1,1]` is a byte-identical no-op, multi-line/multi-token/multi-character draws push the scale bracket once per block (not once per line/glyph)
- [x] New `LayoutGroup`-shaped integration test reproducing the original report: a sibling packs tightly against a scale-collapsed node instead of the old inflated spacing
- [x] Manually verified via a throwaway probe app rendered through `brs-cli -i` (real `Timer`/`setFocus`/`scale` toggling): a focused element shows full content, an unfocused/collapsed one correctly renders nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)