### PR TITLE
fix(scenegraph): implement Poster loadDisplayMode="limitSize"

### DIFF
--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -192,7 +192,13 @@ export class Poster extends Group {
                 const loadWidth = this.getValueJS("loadWidth") as number;
                 const loadHeight = this.getValueJS("loadHeight") as number;
                 if (loadWidth > 0 && loadHeight > 0) {
-                    this.bitmap = getTextureManager().resizeTexture(this.bitmap, loadWidth, loadHeight);
+                    const mode = (this.getValueJS("loadDisplayMode") as string).trim().toLowerCase();
+                    if (mode === "limitsize") {
+                        const size = this.clampLoadSize(this.bitmap.width, this.bitmap.height, loadWidth, loadHeight);
+                        this.bitmap = getTextureManager().resizeTexture(this.bitmap, size.width, size.height);
+                    } else {
+                        this.bitmap = getTextureManager().resizeTexture(this.bitmap, loadWidth, loadHeight);
+                    }
                 }
             }
             const subSearch = sgRoot.autoSub.search.toLowerCase();
@@ -210,6 +216,14 @@ export class Poster extends Group {
             loadStatus = "ready";
         }
         return loadStatus;
+    }
+
+    private clampLoadSize(width: number, height: number, maxWidth: number, maxHeight: number) {
+        if (width <= maxWidth && height <= maxHeight) {
+            return { width, height };
+        }
+        const scale = Math.min(maxWidth / width, maxHeight / height);
+        return { width: width * scale, height: height * scale };
     }
 
     private scaleToFit(rect: Rect): Rect {

--- a/test/extensions/scenegraph/Poster.test.js
+++ b/test/extensions/scenegraph/Poster.test.js
@@ -196,3 +196,71 @@ describe("Poster 9-patch display modes", () => {
         expect(scaledRects[0].x).toBeCloseTo(80);
     });
 });
+
+/**
+ * loadDisplayMode="limitSize" is the only mode whose spec text governs loadWidth/loadHeight directly:
+ * it clamps the LOADED texture (not the render rect) to a max box, only shrinking, and preserving aspect
+ * ratio. Before this fix it fell through to the same code path as noScale — an unconditional distort
+ * stretch to exactly loadWidth x loadHeight, even when the source was already smaller.
+ */
+describe("Poster loadDisplayMode limitSize", () => {
+    beforeAll(mountCommonVolume);
+
+    // A plain (non 9-patch) 853x480 asset — landscape aspect ratio, distinct from a square source so a
+    // stretch-to-box bug is distinguishable from a correctly clamped, aspect-preserved result.
+    const wideUri = "common:/images/video_overlay_top.png";
+
+    function loadedSize(poster) {
+        return { width: poster.getValueJS("bitmapWidth"), height: poster.getValueJS("bitmapHeight") };
+    }
+
+    test("shrinks to fit the box, preserving aspect ratio, when the source exceeds both dimensions", () => {
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("loadDisplayMode", new BrsString("limitSize"));
+        poster.setValue("loadWidth", new Float(200));
+        poster.setValue("loadHeight", new Float(200));
+        poster.setValue("uri", new BrsString(wideUri));
+        expect(poster.getValueJS("loadStatus")).toBe("ready");
+
+        const { width, height } = loadedSize(poster);
+        // Width is the binding axis (853/480 is wider than the 200x200 box). RoBitmap truncates
+        // fractional pixel sizes, so compare against the same truncation rather than the raw float.
+        expect(width).toBe(200);
+        expect(height).toBe(Math.trunc(200 * (480 / 853)));
+        expect(width / height).toBeCloseTo(853 / 480, 1);
+    });
+
+    test("leaves the source at its regular size when it is already smaller than the box", () => {
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("loadDisplayMode", new BrsString("limitSize"));
+        poster.setValue("loadWidth", new Float(2000));
+        poster.setValue("loadHeight", new Float(2000));
+        poster.setValue("uri", new BrsString(wideUri));
+        expect(poster.getValueJS("loadStatus")).toBe("ready");
+
+        expect(loadedSize(poster)).toEqual({ width: 853, height: 480 });
+    });
+
+    test("clamps by whichever axis actually exceeds the box", () => {
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("loadDisplayMode", new BrsString("limitSize"));
+        poster.setValue("loadWidth", new Float(400));
+        poster.setValue("loadHeight", new Float(1000));
+        poster.setValue("uri", new BrsString(wideUri));
+        expect(poster.getValueJS("loadStatus")).toBe("ready");
+
+        const { width, height } = loadedSize(poster);
+        expect(width).toBeCloseTo(400, 0);
+        expect(height).toBeCloseTo(400 * (480 / 853), 0);
+    });
+
+    test("differs from the noScale distort-stretch at the same loadWidth/loadHeight", () => {
+        const stretched = SGNodeFactory.createNode("Poster");
+        stretched.setValue("loadDisplayMode", new BrsString("noScale"));
+        stretched.setValue("loadWidth", new Float(200));
+        stretched.setValue("loadHeight", new Float(200));
+        stretched.setValue("uri", new BrsString(wideUri));
+
+        expect(loadedSize(stretched)).toEqual({ width: 200, height: 200 });
+    });
+});


### PR DESCRIPTION
## Summary
- `loadDisplayMode="limitSize"` on the Poster node was entirely unimplemented — it silently fell through to the same code path as `noScale`, distort-stretching the loaded texture to exactly `loadWidth`x`loadHeight` even when the source was already smaller
- Now clamps the loaded texture to `loadWidth`/`loadHeight`, only shrinking (never upscaling) and preserving aspect ratio, matching the Roku spec

## Test plan
- [x] `npx vitest run test/extensions/scenegraph/Poster.test.js` — new `limitSize` cases (shrink-to-fit, already-smaller-than-box, single-axis clamp, differs from `noScale`) plus existing cases pass
- [x] `npx vitest run test/extensions/scenegraph/ test/cli/cli-scenegraph.test.js` — full suite (85 files / 979 tests) passes
- [x] `npm run lint` / `npm run prettier:write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)