### PR TITLE
fix(brs): optional chaining for boxed `roInvalid` failing on indexed access

### DIFF
--- a/src/core/brsTypes/BrsType.ts
+++ b/src/core/brsTypes/BrsType.ts
@@ -400,7 +400,7 @@ export class BrsInvalid implements BrsValue, Comparable, Boxable {
      * @returns True if other is also invalid, false otherwise
      */
     equalTo(other: BrsType): BrsBoolean {
-        if (other.kind === ValueKind.Invalid || other instanceof RoInvalid) {
+        if (isInvalid(other)) {
             return BrsBoolean.True;
         }
         return BrsBoolean.False;
@@ -491,4 +491,13 @@ export class Uninitialized implements BrsValue, Comparable {
     toString(parent?: BrsType) {
         return "<UNINITIALIZED>";
     }
+}
+
+/**
+ * Checks if a value is invalid.
+ * @param value BrightScript value to check
+ * @returns True if value is invalid, false otherwise
+ */
+export function isInvalid(value: BrsType): boolean {
+    return value.kind === ValueKind.Invalid || value instanceof RoInvalid;
 }

--- a/src/core/brsTypes/components/RoInvalid.ts
+++ b/src/core/brsTypes/components/RoInvalid.ts
@@ -1,5 +1,5 @@
 import { BrsComponent } from "./BrsComponent";
-import { BrsValue, ValueKind, BrsBoolean, BrsInvalid } from "../BrsType";
+import { BrsValue, ValueKind, BrsBoolean, BrsInvalid, isInvalid } from "../BrsType";
 import { BrsType } from "..";
 import { Unboxable } from "../Boxing";
 import { IfToStr } from "../interfaces/IfToStr";
@@ -30,14 +30,9 @@ export class RoInvalid extends BrsComponent implements BrsValue, Unboxable {
     }
 
     equalTo(other: BrsType): BrsBoolean {
-        if (other instanceof BrsInvalid) {
+        if (isInvalid(other)) {
             return BrsBoolean.True;
         }
-
-        if (other instanceof RoInvalid) {
-            return BrsBoolean.True;
-        }
-
         return BrsBoolean.False;
     }
 

--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -1,6 +1,6 @@
-import { BrsValue, ValueKind, BrsInvalid, BrsBoolean } from "../BrsType";
+import { BrsValue, ValueKind, BrsInvalid, BrsBoolean, isInvalid } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
-import { BrsEvent, BrsType, isInvalid } from "..";
+import { BrsEvent, BrsType } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { DebugMode, Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -462,15 +462,6 @@ export function jsValueOf(value: BrsType, deep: boolean = true, visitedNodes?: W
 }
 
 /**
- * Checks if a BrsType value is invalid.
- * @param value The BrsType value to check.
- * @returns True if the value is invalid, false otherwise.
- */
-export function isInvalid(value: BrsType): boolean {
-    return value.equalTo(BrsInvalid.Instance).toBoolean();
-}
-
-/**
  * Checks if a string represents a number and returns its precision.
  * The precision is equivalent to the Number.toPrecision() parameter (total significant digits).
  * @param {string} str - The string to check

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -12,6 +12,7 @@ import {
     isBrsBoolean,
     isBrsCallable,
     isIterable,
+    isInvalid,
     isComparable,
     isBoxable,
     isUnboxable,
@@ -1209,7 +1210,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     const foundErr = findErrorDetail(element.getValue());
                     errDetail.message = foundErr ? foundErr.message : "UNKNOWN ERROR";
                 }
-            } else if (!(element instanceof BrsInvalid)) {
+            } else if (!isInvalid(element)) {
                 return {
                     errno: RuntimeErrorDetail.MalformedThrow.errno,
                     message: `Thrown "number" is not an integer.`,
@@ -1220,7 +1221,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         function validateErrorMessage(element: BrsType, errDetail: ErrorDetail): ErrorDetail {
             if (element instanceof BrsString) {
                 errDetail.message = element.toString();
-            } else if (!(element instanceof BrsInvalid)) {
+            } else if (!isInvalid(element)) {
                 return {
                     errno: RuntimeErrorDetail.MalformedThrow.errno,
                     message: `Thrown "message" is not a string.`,
@@ -1272,8 +1273,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         let args = expression.args.map(this.evaluate, this);
 
         if (!isBrsCallable(callee)) {
-            const invalidCallee = BrsInvalid.Instance.equalTo(callee).toBoolean();
-            if (invalidCallee && expression.optional) {
+            if (isInvalid(callee) && expression.optional) {
                 return callee;
             }
             this.addError(new RuntimeError(RuntimeErrorDetail.NotAFunction, expression.closingParen.location));
@@ -1288,7 +1288,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     visitAtSignGet(expression: Expr.AtSignGet) {
         let source = this.evaluate(expression.obj);
-        if (source instanceof BrsInvalid && expression.optional) {
+        if (isInvalid(source) && expression.optional) {
             return source;
         }
         if (source instanceof RoXMLElement || source instanceof RoXMLList) {
@@ -1364,11 +1364,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 // An AA member read never yields an interface method on Roku (`aa.items` with no
                 // such key is invalid); the method resolves only at a call site (`aa.items()`),
                 // where a stored element still shadows it (the classic `aa.count` gotcha).
-                if (
-                    target instanceof BrsInvalid &&
-                    this._activeCallee === expression &&
-                    source instanceof RoAssociativeArray
-                ) {
+                if (isInvalid(target) && this._activeCallee === expression && source instanceof RoAssociativeArray) {
                     const method = source.getMethod(expression.name.text);
                     if (method) {
                         return method;
@@ -1382,7 +1378,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
         let errorDetail = RuntimeErrorDetail.DotOnNonObject;
         if (boxedSource instanceof BrsComponent) {
-            const invalidSource = BrsInvalid.Instance.equalTo(source).toBoolean();
+            const invalidSource = isInvalid(source);
             // This check is supposed to be placed after method check,
             // but it's here to mimic the behavior of Roku, if they fix, we move it.
             if (invalidSource && expression.optional) {
@@ -1401,7 +1397,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     visitIndexedGet(expression: Expr.IndexedGet): BrsType {
         let source = this.evaluate(expression.obj);
         if (!isCollection(source)) {
-            if (source instanceof BrsInvalid && expression.optional) {
+            if (isInvalid(source) && expression.optional) {
                 return source;
             }
             this.addError(new RuntimeError(RuntimeErrorDetail.UndimmedArray, expression.location));

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1878,7 +1878,7 @@ export class Node extends RoSGNode implements BrsValue {
         value: RoAssociativeArray,
         createFields: boolean
     ): boolean {
-        if (value.get(new BrsString("subtype")) instanceof BrsInvalid) {
+        if (isInvalid(value.get(new BrsString("subtype")))) {
             return false;
         }
         const field = node.resolveField(fieldName);

--- a/src/extensions/scenegraph/nodes/Scene.ts
+++ b/src/extensions/scenegraph/nodes/Scene.ts
@@ -12,6 +12,7 @@ import {
     RuntimeError,
     DebugMode,
     BrsDevice,
+    isInvalid,
 } from "brs-engine";
 import { toAssociativeArray } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
@@ -84,7 +85,7 @@ export class Scene extends Group {
                     value.setNodeParent(this);
                 }
                 this.dialog = value;
-            } else if (value instanceof BrsInvalid) {
+            } else if (isInvalid(value)) {
                 this.dialog?.removeParent();
                 this.dialog?.setValue("close", BrsBoolean.True);
             } else {

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -2,7 +2,6 @@ import {
     AAMember,
     Interpreter,
     BrsBoolean,
-    BrsInvalid,
     isBrsString,
     BrsType,
     Float,
@@ -10,6 +9,7 @@ import {
     RoBitmap,
     RoFont,
     Rect,
+    isInvalid,
 } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
@@ -90,7 +90,7 @@ export class ScrollableText extends Group {
 
         if (fieldName === "focusedchild") {
             // Track focus state: focusedChild is set to `this` when focused, BrsInvalid when unfocused
-            this.focused = !(value instanceof BrsInvalid) && value !== null && value !== undefined;
+            this.focused = !isInvalid(value) && value !== null && value !== undefined;
         } else if (fieldName === "scrollbartrackbitmapuri") {
             const uri = isBrsString(value) ? value.getValue() : "";
             this.customTrackBitmap = uri ? this.loadBitmap(uri) : undefined;

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -428,6 +428,8 @@ describe("end to end syntax", () => {
             "optional chaining works",
             "param test result was: success",
             "literal test result was: success",
+            "checking indexed access, unboxed:invalid",
+            "checking indexed access, boxed:<Component: roInvalid>",
         ]);
     });
 

--- a/test/e2e/resources/dot-chaining.brs
+++ b/test/e2e/resources/dot-chaining.brs
@@ -16,6 +16,10 @@ sub main()
         print createLevel2().testResult("literal test result was: ")
     end sub
     level1.run()
+    invalidVar = invalid
+    print "checking indexed access, unboxed:"; invalidVar?.options?[0]
+    boxedVar = box(invalidVar)
+    print "checking indexed access, boxed:"; boxedVar?.options?[0]
 end sub
 
 function createLevel2()


### PR DESCRIPTION
The following code was crashing the app in the second print:

```brs
settings = invalid
print settings?.options?[0]
settings = box(settings)
print settings?.options?[0]
```

