### PR TITLE
fix(api): read Video.captionRenderArea sub-fields case-insensitively

### DIFF
--- a/src/api/display.ts
+++ b/src/api/display.ts
@@ -56,7 +56,7 @@ let trickPlayBar = false;
 let supportCaptions = false;
 
 /** OS 15.3 `Video.captionRenderArea` — where/how captions are rendered on screen. */
-interface CaptionRenderArea {
+export interface CaptionRenderArea {
     mode: "fullscreen" | "auto" | "override";
     overridePlacement: boolean;
     scaleFonts: "off" | "by-width" | "by-height";
@@ -874,25 +874,41 @@ function getCaptionArea(canvasW: number, canvasH: number) {
 
 /**
  * Sets the OS 15.3 `Video.captionRenderArea`, normalizing its attributes with the documented
- * per-mode defaults. Keys arrive lowercased from the SceneGraph associative-array serializer.
+ * per-mode defaults. `RoAssociativeArray` literals are case-preserving (see
+ * `fromAssociativeArray`), so an app writing the documented camelCase keys (`scaleFonts`,
+ * `overridePlacement`, `keepSafeMargins`) arrives here with that exact casing — keys are
+ * looked up case-insensitively below rather than assumed lowercase.
  * @param area Render-area object posted from the worker (or a bare `{ mode }` reset)
  */
 export function setCaptionRenderArea(area: { [key: string]: any }) {
-    const rawMode = typeof area?.mode === "string" ? area.mode.toLowerCase() : "fullscreen";
+    const normalized: { [key: string]: any } = {};
+    for (const key of Object.keys(area ?? {})) {
+        normalized[key.toLowerCase()] = area[key];
+    }
+    const rawMode = typeof normalized.mode === "string" ? normalized.mode.toLowerCase() : "fullscreen";
     const mode = rawMode === "auto" || rawMode === "override" ? rawMode : "fullscreen";
     const isOverride = mode === "override";
-    const rawScale = typeof area?.scalefonts === "string" ? area.scalefonts.toLowerCase() : "by-width";
+    const rawScale = typeof normalized.scalefonts === "string" ? normalized.scalefonts.toLowerCase() : "by-width";
     const scaleFonts = rawScale === "off" || rawScale === "by-height" ? rawScale : "by-width";
     captionRenderArea = {
         mode,
-        overridePlacement: typeof area?.overrideplacement === "boolean" ? area.overrideplacement : isOverride,
+        overridePlacement:
+            typeof normalized.overrideplacement === "boolean" ? normalized.overrideplacement : isOverride,
         scaleFonts,
-        keepSafeMargins: typeof area?.keepsafemargins === "boolean" ? area.keepsafemargins : !isOverride,
-        x: Math.trunc(area?.x ?? 0),
-        y: Math.trunc(area?.y ?? 0),
-        width: Math.trunc(area?.width ?? 0),
-        height: Math.trunc(area?.height ?? 0),
+        keepSafeMargins: typeof normalized.keepsafemargins === "boolean" ? normalized.keepsafemargins : !isOverride,
+        x: Math.trunc(normalized.x ?? 0),
+        y: Math.trunc(normalized.y ?? 0),
+        width: Math.trunc(normalized.width ?? 0),
+        height: Math.trunc(normalized.height ?? 0),
     };
+}
+
+/**
+ * Gets the current OS 15.3 `Video.captionRenderArea` state.
+ * @returns A copy of the current caption render area
+ */
+export function getCaptionRenderArea(): CaptionRenderArea {
+    return { ...captionRenderArea };
 }
 
 /**

--- a/test/api/display.test.js
+++ b/test/api/display.test.js
@@ -1,0 +1,112 @@
+// Exercises `src/api/display.ts` directly (not a compiled bundle) because this module's
+// caption-render logic has no other automated coverage: it lives on the browser/main-thread
+// side of the API and is never reached by the `packages/*/bin` or `packages/*/lib` bundles
+// that the rest of the suite imports (those only cover the worker/interpreter side).
+import { setCaptionRenderArea, getCaptionRenderArea } from "../../src/api/display.ts";
+
+function expectArea(input, expected) {
+    setCaptionRenderArea(input);
+    expect(getCaptionRenderArea()).toEqual(expected);
+}
+
+describe("Video.captionRenderArea normalization (Roku OS 15.3)", () => {
+    test("reads the documented camelCase sub-field keys (overridePlacement, scaleFonts, keepSafeMargins)", () => {
+        // `RoAssociativeArray` literals preserve the app's original key case, so an app using
+        // the exact field names from Roku's docs must not have them silently dropped.
+        expectArea(
+            {
+                mode: "override",
+                overridePlacement: false,
+                scaleFonts: "by-height",
+                keepSafeMargins: true,
+                x: 10,
+                y: 20,
+                width: 300,
+                height: 100,
+            },
+            {
+                mode: "override",
+                overridePlacement: false,
+                scaleFonts: "by-height",
+                keepSafeMargins: true,
+                x: 10,
+                y: 20,
+                width: 300,
+                height: 100,
+            }
+        );
+    });
+
+    test("still accepts all-lowercase keys", () => {
+        expectArea(
+            {
+                mode: "override",
+                overrideplacement: false,
+                scalefonts: "by-height",
+                keepsafemargins: true,
+                x: 1,
+                y: 2,
+                width: 3,
+                height: 4,
+            },
+            {
+                mode: "override",
+                overridePlacement: false,
+                scaleFonts: "by-height",
+                keepSafeMargins: true,
+                x: 1,
+                y: 2,
+                width: 3,
+                height: 4,
+            }
+        );
+    });
+
+    test("defaults overridePlacement=true and keepSafeMargins=false for override mode when unset", () => {
+        expectArea(
+            { mode: "override", width: 640, height: 200 },
+            {
+                mode: "override",
+                overridePlacement: true,
+                scaleFonts: "by-width",
+                keepSafeMargins: false,
+                x: 0,
+                y: 0,
+                width: 640,
+                height: 200,
+            }
+        );
+    });
+
+    test("defaults overridePlacement=false and keepSafeMargins=true for auto/fullscreen mode when unset", () => {
+        expectArea(
+            { mode: "auto" },
+            {
+                mode: "auto",
+                overridePlacement: false,
+                scaleFonts: "by-width",
+                keepSafeMargins: true,
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0,
+            }
+        );
+    });
+
+    test("falls back to fullscreen mode and by-width scaling for unrecognized values", () => {
+        expectArea(
+            { mode: "bogus", scaleFonts: "bogus" },
+            {
+                mode: "fullscreen",
+                overridePlacement: false,
+                scaleFonts: "by-width",
+                keepSafeMargins: true,
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0,
+            }
+        );
+    });
+});

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -109,6 +109,33 @@ describe("Video bufferingBar and retrievingBar fields", () => {
         });
     });
 
+    test("captionRenderArea forwards the documented camelCase keys with their original case (Roku OS 15.3)", () => {
+        const video = SGNodeFactory.createNode("Video");
+        // Ignore the messages posted during construction (control/caption defaults).
+        global.postMessage.mockClear();
+
+        // Roku's docs name these sub-fields `overridePlacement`, `scaleFonts`, and
+        // `keepSafeMargins` (camelCase). RoAssociativeArray literals are case-preserving, so
+        // the render thread must receive (and read) those exact keys, not a lowercased form.
+        const area = new RoAssociativeArray([
+            { name: new BrsString("mode"), value: new BrsString("override") },
+            { name: new BrsString("overridePlacement"), value: BrsBoolean.False },
+            { name: new BrsString("scaleFonts"), value: new BrsString("by-height") },
+            { name: new BrsString("keepSafeMargins"), value: BrsBoolean.True },
+        ]);
+
+        video.setValue("captionRenderArea", area);
+
+        expect(global.postMessage).toHaveBeenCalledWith({
+            captionRenderArea: {
+                mode: "override",
+                overridePlacement: false,
+                scaleFonts: "by-height",
+                keepSafeMargins: true,
+            },
+        });
+    });
+
     afterAll(() => {
         sgRoot.setVideo();
     });


### PR DESCRIPTION
## Summary
- Roku's OS 15.3 spec (now vendored in `external/dev-doc`) documents `Video.captionRenderArea`'s sub-fields as camelCase (`scaleFonts`, `overridePlacement`, `keepSafeMargins`). `RoAssociativeArray` literals preserve the app's original key case, but `setCaptionRenderArea` in `src/api/display.ts` read them via all-lowercase property access, so those three sub-fields were silently dropped to their per-mode defaults whenever an app used the documented field names.
- Normalize the incoming object's keys to lowercase before reading them, matching the case-insensitive-read pattern already used elsewhere for AA-sourced data. Added `getCaptionRenderArea()` (mirroring the existing `getCaptionMode()`) so the fix is unit-testable without touching DOM/canvas internals.
- All other aspects of the field (types, the 8 sub-keys, and every per-mode default) already matched the newly-published spec exactly — no other discrepancies found.

## Test plan
- [x] `npm run lint` / `npx prettier --check` — clean
- [x] `npx vitest run test/api/display.test.js test/extensions/scenegraph/Video.test.js` — new/updated tests pass
- [x] `npm test` (full suite) — 216 files / 2763 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)