### PR TITLE
feat(api): add MPEG-DASH streaming support via dash.js

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -31,8 +31,8 @@ The **BrightScript Engine** implements the BrightScript language specification u
   * The following `roVideoPlayer` methods are not supported, implemented as mock: `setCGMS`, `setMaxVideoDecodeResolution`, `setTimedMetadataForKeys`, `getCaptionRenderer`
   * Check what formats (container and codec) can be used on each browser, using `roDeviceInfo.canDecodeVideo()`, to make sure your video can be played.
   * Under **Node.js/CLI** there is no audio or video output: `autoPlayEnabled` is forced off and media events are only simulated, so apps behave as if playback never starts.
-  * Subtitles are only supported for HLS streams and only in `Video` node, the `roVideoPlayer` does not support subtitles until `roCaptionRenderer` is implemented.
-  * DASH streams and BIF (Base Index Frames) thumbnails are not yet supported.
+  * Subtitles are only supported for HLS and DASH streams and only in `Video` node, the `roVideoPlayer` does not support subtitles until `roCaptionRenderer` is implemented.
+  * BIF (Base Index Frames) thumbnails are not yet supported.
 * The component `roUrlTransfer` is implemented with basic functionality but with the following limitations:
   * To make a **web app** access urls from domains other than the one it is hosted, the Cross-Origin Resource Sharing (CORS) browser policy requires the server called to respond with the header `Access-Control-Allow-Origin`, [read more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS).
     * A simple way to overcome this limitation is to use a CORS proxy like the [cors-anywhere](https://github.com/Rob--W/cors-anywhere), see [customization documentation](./customization.md) to learn how to configure `brs-engine` to use it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "chalk": "^4.1.2",
         "commander": "^2.12.2",
         "crc": "^3.8.0",
+        "dashjs": "^5.2.1",
         "dayjs": "^1.11.10",
         "decode-bmp": "^0.1.0",
         "default-gateway": "^7.2.2",
@@ -2377,6 +2378,129 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@svta/cml-608": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-608/-/cml-608-1.0.2.tgz",
+      "integrity": "sha512-ZEJ68330gcLKfvVv6Qifr1HR7+GldDUxzkjqSbqRK7jHtHSLSV1JAyDwlYe8+C7ABuY1bp8MpgJ4/Gg+jl+pLQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@svta/cml-cmcd": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cmcd/-/cml-cmcd-2.3.2.tgz",
+      "integrity": "sha512-SKBBjLmci0WK8HMjuv+36tVIMktonoOoxsXblOFZmB+ePPV2zjRMTD+2ZmE/1VEPJkKHENyhSjSHgJyeOlvZ1A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-cmsd": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cmsd/-/cml-cmsd-1.0.6.tgz",
+      "integrity": "sha512-LUORV6bb0TbU4rSC2HoPqUCix1igLrXkRQXWiIyJo2OMzb14kAK/1jsW0mzY6up6w1GrjKQcjc6OwqJdo/zd/g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-cta": "1.0.6",
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-cta": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-cta/-/cml-cta-1.0.6.tgz",
+      "integrity": "sha512-l13/4myTX1EbRd38nY8J1umVY5UdR/nZO6CeKqVLXnMMIayg7/fu0TueZckjTA9Loal55MGK1xbHnXVjz7OUUw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-structured-field-values": "1.1.3",
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-dash": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-dash/-/cml-dash-1.0.6.tgz",
+      "integrity": "sha512-4XtHYlPrzL/dRe/8XmRQoLnTo9S86tISgrl67eUqKl5MtNTpZBYTncuPrspslPZPZROBBWNrBuepYfYUtU9CKA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-id3": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@svta/cml-id3/-/cml-id3-1.0.6.tgz",
+      "integrity": "sha512-63j8gkAnPOmOBWlp0hIZPvsIioZttdbg6/TgwITqMYbSLYVJ+6QGa/UtIP0I84NsfstANw6QdCn7i8SS08kn1A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-request": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@svta/cml-request/-/cml-request-1.0.12.tgz",
+      "integrity": "sha512-4sJvnnoNpq58j2mCGP8k+MF6wVy/qa4gbt6kfT1dPIKmn3mPxw+JVfilhcWsUi+peK2yCZxOJJYyHj1cAcQE1w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-cmcd": "2.3.2",
+        "@svta/cml-utils": "1.5.0",
+        "@svta/cml-xml": "1.1.4"
+      }
+    },
+    "node_modules/@svta/cml-structured-field-values": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@svta/cml-structured-field-values/-/cml-structured-field-values-1.1.3.tgz",
+      "integrity": "sha512-XqLzQOTznz6kh/nsSh8dy1kV7GQjL4csG+2U5EvLGhAqNuNUczbVg5EAsDobKDVg8xhdthdXx2UuwM+ZHQCxSg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
+    "node_modules/@svta/cml-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@svta/cml-utils/-/cml-utils-1.5.0.tgz",
+      "integrity": "sha512-JMqclD7Akd+GSJiuaYNUHOP2wNtf/nauKeszlYeivSHfi0Lp3pmSW5PXDvJ2dO4aPmmSOQbF0ztTsW9Vcs2Whw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@svta/cml-xml": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@svta/cml-xml/-/cml-xml-1.1.4.tgz",
+      "integrity": "sha512-jbixqjiJIc16SGxylHwiOzO+DuhkGfuP+fJ9AHeVJKdFDKnabgfCDpnp6dvZpZnjMj4nHvzVtuUV7RISPIwYXw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@svta/cml-utils": "1.5.0"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -3985,6 +4109,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "dev": true,
@@ -4824,6 +4958,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/codem-isoboxer": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/codem-isoboxer/-/codem-isoboxer-0.3.10.tgz",
+      "integrity": "sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==",
+      "license": "MIT"
+    },
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "license": "MIT",
@@ -5181,6 +5321,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dashjs": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-5.2.1.tgz",
+      "integrity": "sha512-axcJmLeJCTJMLUfQRErUJB1KOiU5iHF+DMLBc3FKeox1HPYtGUQlC6Xm5Mm6vhBUR3CHHLIPOqw0JDIqMtP+Dw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@svta/cml-608": "1.0.2",
+        "@svta/cml-cmcd": "2.3.2",
+        "@svta/cml-cmsd": "1.0.6",
+        "@svta/cml-dash": "1.0.6",
+        "@svta/cml-id3": "1.0.6",
+        "@svta/cml-request": "1.0.12",
+        "@svta/cml-xml": "1.1.4",
+        "bcp-47-match": "^2.0.3",
+        "codem-isoboxer": "0.3.10",
+        "fast-deep-equal": "3.1.3",
+        "html-entities": "^2.6.0",
+        "imsc": "^1.1.5",
+        "localforage": "^1.10.0",
+        "path-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/data-view-buffer": {
@@ -6514,7 +6679,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -7185,6 +7349,22 @@
       "version": "2.2.4",
       "license": "MIT"
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "dev": true,
@@ -7351,6 +7531,12 @@
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "license": "MIT"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "dev": true,
@@ -7383,6 +7569,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/imsc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.5.tgz",
+      "integrity": "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "sax": "1.2.1"
+      }
+    },
+    "node_modules/imsc/node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -8330,6 +8531,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.0.5",
       "dev": true,
@@ -8617,6 +8827,15 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -9676,7 +9895,6 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -14004,6 +14222,7 @@
         "@msgpack/msgpack": "^2.8.0",
         "@zenfs/core": "^2.5.0",
         "crc": "^3.8.0",
+        "dashjs": "^5.2.1",
         "dayjs": "^1.11.10",
         "decode-bmp": "^0.1.0",
         "esm-gamecontroller.js": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "chalk": "^4.1.2",
     "commander": "^2.12.2",
     "crc": "^3.8.0",
+    "dashjs": "^5.2.1",
     "dayjs": "^1.11.10",
     "decode-bmp": "^0.1.0",
     "default-gateway": "^7.2.2",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -56,6 +56,7 @@
     "@msgpack/msgpack": "^2.8.0",
     "@zenfs/core": "^2.5.0",
     "crc": "^3.8.0",
+    "dashjs": "^5.2.1",
     "dayjs": "^1.11.10",
     "decode-bmp": "^0.1.0",
     "esm-gamecontroller.js": "^1.0.2",

--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -17,10 +17,23 @@ import {
     DrmInfoEntry,
 } from "../core/common";
 import Hls from "hls.js";
+import type { MediaPlayerClass, MediaInfo } from "dashjs";
+
+// dash.js touches `window` at module-load time (imsc/TTML dependency), which breaks a static
+// import outside a browser (e.g. the Node test suite). Deferred to a dynamic import instead.
+// `webpackMode: "eager"` keeps it in the main bundle rather than a separate chunk, since
+// brs-engine's deployment contract is exactly `brs.api.js` + `brs.worker.js` (docs/integrating.md).
+async function loadDashjs() {
+    return import(/* webpackMode: "eager" */ "dashjs");
+}
 
 // Video Objects
 export let player: HTMLVideoElement;
 let hls: Hls | undefined;
+let dash: MediaPlayerClass | undefined;
+// Bumped by loadVideo()/stopVideo() so a loadDash() suspended on the dashjs import can detect
+// it was superseded and must not attach a stale instance.
+let dashLoadToken = 0;
 let deviceData: DeviceInfo;
 let packageVideos = new Map();
 let currentFrame = 0;
@@ -47,6 +60,10 @@ let playFloorTimer: ReturnType<typeof setTimeout> | undefined; // pending deferr
 let priming = false; // HLS audio-track priming play in flight; suppress its "playing" side effects
 const audioTracks: MediaTrack[] = [];
 const textTracks: MediaTrack[] = [];
+// dash.js MediaInfo objects backing audioTracks/textTracks (same index); dash.setCurrentTrack()
+// takes the track object itself, not an index.
+const dashAudioTrackInfos: MediaInfo[] = [];
+const dashTextTrackInfos: MediaInfo[] = [];
 
 // Initialize Video Module
 if (typeof document !== "undefined") {
@@ -131,7 +148,7 @@ export function initVideoModule(array: Int32Array, deviceInfo: DeviceInfo, mute:
  * @param e Progress event from video player
  */
 function calculateBandwidth(e: Event) {
-    if (hls === undefined && player && player.buffered.length > 0) {
+    if (hls === undefined && dash === undefined && player && player.buffered.length > 0) {
         let totalBuffered = 0;
         for (let i = 0; i < player.buffered.length; i++) {
             totalBuffered += player.buffered.end(i) - player.buffered.start(i);
@@ -305,6 +322,10 @@ export function videoFormats() {
         if (player.canPlayType("application/vnd.apple.mpegurl") || Hls.isSupported()) {
             containers.push("hls");
         }
+        if (typeof MediaSource !== "undefined") {
+            // Equivalent to dash.js's supportsMediaSource(), checked natively to avoid loading it here.
+            containers.push("dash");
+        }
         if (player.canPlayType("video/mp2t") !== "") {
             containers.push("ts");
         }
@@ -339,6 +360,12 @@ export function addVideoPlaylist(newList: any[]) {
     playIndex = 0;
     playNext = -1;
     startPosition = 0;
+    if (newList.some((item) => item.streamFormat === "dash")) {
+        // Warm the dash.js import ahead of the play/prebuffer command that triggers loadDash(),
+        // shortening the delay before it attaches to the video element. Failure is reported later
+        // when loadDash() retries the same import.
+        loadDashjs().catch(() => {});
+    }
 }
 
 /**
@@ -351,9 +378,7 @@ export function resetVideo() {
         // (playerState === "stop"), which leaves the previous video's source, buffered
         // frames and text tracks attached to the shared player element. Release them
         // unconditionally here so nothing bleeds into the next app that gets loaded.
-        if (hls) {
-            destroyHls();
-        }
+        destroyActiveEngine();
         if (player.src.startsWith("blob:")) {
             revokeVideoURL(player.src);
         }
@@ -419,18 +444,62 @@ function setDuration(e: Event) {
 }
 
 /**
- * Loads audio tracks from HLS stream and selects preferred track.
- * Prioritizes: audio language > device locale > English.
+ * Picks the best-matching track id/index by priority: preferred locale > device locale > English.
+ * Shared by the HLS/DASH audio and subtitle track loaders, which differ only in how they build
+ * their candidate list and what id/index they key selection by.
+ * @param langs Formatted (via formatLocale) language code per candidate track, in source order
+ * @param preferredLocale Two-letter locale to prioritize (audio or caption language)
+ * @param idOf Maps a candidate's index to the id/index value the caller selects by
+ * @returns The selected id/index, or 0 if no candidate matched any priority
+ */
+function selectPreferredTrack(langs: string[], preferredLocale: string, idOf: (index: number) => number): number {
+    let preferredTrackId = -1;
+    let deviceTrackId = -1;
+    let englishTrackId = -1;
+    const deviceLocale = deviceData.locale.toLowerCase().slice(0, 2);
+    for (const [index, lang] of langs.entries()) {
+        if (preferredTrackId === -1 && lang === preferredLocale) {
+            preferredTrackId = idOf(index);
+        } else if (deviceTrackId === -1 && lang === deviceLocale) {
+            deviceTrackId = idOf(index);
+        } else if (englishTrackId === -1 && lang === "en") {
+            englishTrackId = idOf(index);
+        }
+    }
+    if (preferredTrackId > -1) {
+        return preferredTrackId;
+    } else if (deviceTrackId > -1) {
+        return deviceTrackId;
+    } else if (englishTrackId > -1) {
+        return englishTrackId;
+    }
+    return 0;
+}
+
+/**
+ * Loads audio tracks from the active HLS/DASH stream and selects the preferred track.
  * @returns Active audio track index
  */
 function loadAudioTracks() {
     audioTracks.length = 0;
+    if (hls) {
+        return loadHlsAudioTracks();
+    } else if (dash) {
+        return loadDashAudioTracks();
+    }
+    return -1;
+}
+
+/**
+ * Loads audio tracks from HLS stream and selects preferred track.
+ * Prioritizes: audio language > device locale > English.
+ * @returns Active audio track index
+ */
+function loadHlsAudioTracks() {
     if (!hls) {
         return -1;
     }
-    let preferredTrackId = -1;
-    let deviceTrackId = -1;
-    let englishTrackId = -1;
+    const langs: string[] = [];
     for (const [index, track] of hls.audioTracks.entries()) {
         const audioTrack: MediaTrack = {
             id: `${index + 1}`,
@@ -439,45 +508,73 @@ function loadAudioTracks() {
             codec: track.audioCodec,
         };
         audioTracks.push(audioTrack);
-        // Format the language code
-        const lang = formatLocale(audioTrack.lang);
-        // Save the track ids for preferred locale, device locale and english
-        let deviceLocale = deviceData.locale.toLowerCase().slice(0, 2);
-        let audioLocale = deviceData.audioLanguage.toLowerCase().slice(0, 2);
-
-        if (preferredTrackId === -1 && lang === audioLocale) {
-            preferredTrackId = track.id;
-        } else if (deviceTrackId === -1 && lang === deviceLocale) {
-            deviceTrackId = track.id;
-        } else if (englishTrackId === -1 && lang === "en") {
-            englishTrackId = track.id;
-        }
+        langs.push(formatLocale(audioTrack.lang));
     }
-    let activeTrack = 0;
-    if (audioTracks.length > 0) {
-        // Set the active track prioritizing preferred locale, device locale and english
-        if (preferredTrackId > -1) {
-            activeTrack = preferredTrackId;
-        } else if (deviceTrackId > -1) {
-            activeTrack = deviceTrackId;
-        } else if (englishTrackId > -1) {
-            activeTrack = englishTrackId;
-        }
-        hls.audioTrack = activeTrack;
-        playList[playIndex].audioTrack = activeTrack;
-        if (activeTrack > -1 && playerState !== "play") {
-            player.currentTime = 1; // Force HLS to load audio track
-            // This play() only primes the audio-track load; the "playing" handler pauses it and
-            // swallows its side effects (priming flag), so the real start still goes through the
-            // buffering floor and prebuffer never starts audible playback.
-            priming = true;
-            const promise = player.play();
-            promise?.catch(() => {
-                priming = false; // autoplay rejection: no "playing" event will fire to swallow
-            });
-        }
+    if (audioTracks.length === 0) {
+        return 0;
+    }
+    const audioLocale = deviceData.audioLanguage.toLowerCase().slice(0, 2);
+    const activeTrack = selectPreferredTrack(langs, audioLocale, (index) => hls!.audioTracks[index].id);
+    hls.audioTrack = activeTrack;
+    playList[playIndex].audioTrack = activeTrack;
+    if (activeTrack > -1 && playerState !== "play") {
+        player.currentTime = 1; // Force HLS to load audio track
+        // This play() only primes the audio-track load; the "playing" handler pauses it and
+        // swallows its side effects (priming flag), so the real start still goes through the
+        // buffering floor and prebuffer never starts audible playback.
+        priming = true;
+        const promise = player.play();
+        promise?.catch(() => {
+            priming = false; // autoplay rejection: no "playing" event will fire to swallow
+        });
     }
     return activeTrack;
+}
+
+/**
+ * Loads audio tracks from a dash.js stream and selects the preferred track.
+ * Prioritizes: audio language > device locale > English.
+ * @returns Active audio track index
+ */
+function loadDashAudioTracks() {
+    dashAudioTrackInfos.length = 0;
+    if (!dash) {
+        return -1;
+    }
+    const langs: string[] = [];
+    for (const track of dash.getTracksFor("audio")) {
+        const audioTrack: MediaTrack = {
+            id: `${dashAudioTrackInfos.length + 1}`,
+            name: track.labels?.[0]?.text ?? track.lang ?? "",
+            lang: track.lang ?? "",
+            codec: track.codec ?? undefined,
+        };
+        audioTracks.push(audioTrack);
+        dashAudioTrackInfos.push(track);
+        langs.push(formatLocale(audioTrack.lang));
+    }
+    if (audioTracks.length === 0) {
+        return 0;
+    }
+    const audioLocale = deviceData.audioLanguage.toLowerCase().slice(0, 2);
+    const activeTrack = selectPreferredTrack(langs, audioLocale, (index) => index);
+    dash.setCurrentTrack(dashAudioTrackInfos[activeTrack]);
+    playList[playIndex].audioTrack = activeTrack;
+    return activeTrack;
+}
+
+/**
+ * Loads subtitle tracks from the active HLS/DASH stream and selects the preferred track.
+ * @returns Active subtitle track index
+ */
+function loadSubtitleTracks() {
+    textTracks.length = 0;
+    if (hls) {
+        return loadHlsSubtitleTracks();
+    } else if (dash) {
+        return loadDashSubtitleTracks();
+    }
+    return -1;
 }
 
 /**
@@ -485,14 +582,11 @@ function loadAudioTracks() {
  * Prioritizes: caption language > device locale > English.
  * @returns Active subtitle track index
  */
-function loadSubtitleTracks() {
-    textTracks.length = 0;
+function loadHlsSubtitleTracks() {
     if (!hls?.subtitleTracks?.length) {
         return -1;
     }
-    let preferredTrackId = -1;
-    let deviceTrackId = -1;
-    let englishTrackId = -1;
+    const langs: string[] = [];
     for (const [index, track] of hls.subtitleTracks.entries()) {
         const textTrack: MediaTrack = {
             id: `webvtt/${index + 1}`,
@@ -500,56 +594,82 @@ function loadSubtitleTracks() {
             lang: track.lang ?? "",
         };
         textTracks.push(textTrack);
-        // Format the language code
-        const lang = formatLocale(textTrack.lang);
-        // Save the track ids for preferred locale, device locale and english
-        let deviceLocale = deviceData.locale.toLowerCase().slice(0, 2);
-        let captionLocale = deviceData.captionLanguage.toLowerCase().slice(0, 2);
-        if (preferredTrackId === -1 && lang === captionLocale) {
-            preferredTrackId = index;
-        } else if (deviceTrackId === -1 && lang === deviceLocale) {
-            deviceTrackId = index;
-        } else if (englishTrackId === -1 && lang === "en") {
-            englishTrackId = index;
-        }
+        langs.push(formatLocale(textTrack.lang));
     }
-    let activeTrack = 0;
-    if (textTracks.length > 0) {
-        // Set the active track prioritizing preferred locale, device locale and english
-        if (preferredTrackId > -1) {
-            activeTrack = preferredTrackId;
-        } else if (deviceTrackId > -1) {
-            activeTrack = deviceTrackId;
-        } else if (englishTrackId > -1) {
-            activeTrack = englishTrackId;
-        }
-        hls.subtitleTrack = activeTrack;
-        playList[playIndex].subtitleTrack = activeTrack;
-    }
+    const captionLocale = deviceData.captionLanguage.toLowerCase().slice(0, 2);
+    const activeTrack = selectPreferredTrack(langs, captionLocale, (index) => index);
+    hls.subtitleTrack = activeTrack;
+    playList[playIndex].subtitleTrack = activeTrack;
     return activeTrack;
 }
 
 /**
- * Sets the active audio track for HLS playback.
+ * Loads subtitle tracks from a dash.js stream and selects the preferred track.
+ * Prioritizes: caption language > device locale > English.
+ * @returns Active subtitle track index
+ */
+function loadDashSubtitleTracks() {
+    dashTextTrackInfos.length = 0;
+    if (!dash) {
+        return -1;
+    }
+    const tracks = dash.getTracksFor("text");
+    if (!tracks.length) {
+        return -1;
+    }
+    const langs: string[] = [];
+    for (const track of tracks) {
+        const textTrack: MediaTrack = {
+            id: `webvtt/${dashTextTrackInfos.length + 1}`,
+            name: track.labels?.[0]?.text ?? track.lang ?? "",
+            lang: track.lang ?? "",
+        };
+        textTracks.push(textTrack);
+        dashTextTrackInfos.push(track);
+        langs.push(formatLocale(textTrack.lang));
+    }
+    const captionLocale = deviceData.captionLanguage.toLowerCase().slice(0, 2);
+    const activeTrack = selectPreferredTrack(langs, captionLocale, (index) => index);
+    dash.setCurrentTrack(dashTextTrackInfos[activeTrack]);
+    playList[playIndex].subtitleTrack = activeTrack;
+    return activeTrack;
+}
+
+/**
+ * Sets the active audio track for HLS/DASH playback.
  * @param index Audio track index to activate
  */
 function setAudioTrack(index: number) {
-    if (hls && audioTracks.length && index > -1 && index < audioTracks.length) {
+    if (!audioTracks.length || index < 0 || index >= audioTracks.length) {
+        return;
+    }
+    if (hls) {
         hls.audioTrack = index;
         playList[playIndex].audioTrack = index;
         Atomics.store(sharedArray, DataType.VAT, hls.audioTrack);
+    } else if (dash && dashAudioTrackInfos[index]) {
+        dash.setCurrentTrack(dashAudioTrackInfos[index]);
+        playList[playIndex].audioTrack = index;
+        Atomics.store(sharedArray, DataType.VAT, index);
     }
 }
 
 /**
- * Sets the active subtitle track for HLS playback.
+ * Sets the active subtitle track for HLS/DASH playback.
  * @param index Subtitle track index to activate
  */
 function setSubtitleTrack(index: number) {
-    if (hls && textTracks.length && index > -1 && index < textTracks.length) {
+    if (!textTracks.length || index < 0 || index >= textTracks.length) {
+        return;
+    }
+    if (hls) {
         hls.subtitleTrack = index;
         playList[playIndex].subtitleTrack = index;
         Atomics.store(sharedArray, DataType.VTT, hls.subtitleTrack);
+    } else if (dash && dashTextTrackInfos[index]) {
+        dash.setCurrentTrack(dashTextTrackInfos[index]);
+        playList[playIndex].subtitleTrack = index;
+        Atomics.store(sharedArray, DataType.VTT, index);
     }
 }
 
@@ -563,6 +683,8 @@ function clearVideoTracking() {
     currentFrame = 0;
     audioTracks.length = 0;
     textTracks.length = 0;
+    dashAudioTrackInfos.length = 0;
+    dashTextTrackInfos.length = 0;
     if (player.textTracks?.length) {
         // Disable all text tracks
         for (const track of player.textTracks) {
@@ -572,12 +694,26 @@ function clearVideoTracking() {
 }
 
 /**
+ * Publishes a fatal media failure: stores the error code, marks the event as failed, and warns.
+ * @param code MediaErrorCode to report
+ * @param message Warning message logged via notifyAll
+ */
+function reportMediaFailure(code: MediaErrorCode, message: string) {
+    Atomics.store(sharedArray, DataType.VDX, code);
+    Atomics.store(sharedArray, DataType.VDO, MediaEvent.Failed);
+    notifyAll("warning", message);
+}
+
+/**
  * Loads a video from the playlist into the player.
  * Handles different formats (mp4, mkv, hls) and sets up source.
  * @param buffer Whether to only buffer without playing (defaults to false)
  */
 function loadVideo(buffer = false) {
     canPlay = false;
+    dashLoadToken++; // invalidate any loadDash() still awaiting the dashjs import from a prior load
+    destroyHls(); // no-op when inactive; at most one adaptive backend is ever attached
+    destroyDash();
     const video = playList[playIndex];
     if (video && player) {
         notifyAll("load");
@@ -590,12 +726,14 @@ function loadVideo(buffer = false) {
         clearVideoTracking();
         bufferOnly = buffer;
         if (["mp4", "mkv"].includes(video.streamFormat)) {
-            destroyHls();
             player.setAttribute("type", "video/mp4");
         } else if (video.streamFormat === "hls") {
             if (!loadHls(videoSrc)) {
                 return;
             }
+        } else if (video.streamFormat === "dash") {
+            loadDash(videoSrc);
+            return; // dash.js owns the media source; never fall through to player.src = videoSrc
         } else {
             player.removeAttribute("type");
         }
@@ -604,9 +742,7 @@ function loadVideo(buffer = false) {
             player.load();
         }
     } else if (player) {
-        Atomics.store(sharedArray, DataType.VDX, MediaErrorCode.EmptyList);
-        Atomics.store(sharedArray, DataType.VDO, MediaEvent.Failed);
-        notifyAll("warning", `[video] Can't find video index: ${playIndex}`);
+        reportMediaFailure(MediaErrorCode.EmptyList, `[video] Can't find video index: ${playIndex}`);
     } else {
         notifyAll("error", `[video] Can't find a video player!`);
     }
@@ -628,11 +764,34 @@ function loadHls(videoSrc: string): boolean {
         player.setAttribute("type", "application/vnd.apple.mpegurl");
         native = true;
     } else {
-        Atomics.store(sharedArray, DataType.VDX, MediaErrorCode.Unsupported);
-        Atomics.store(sharedArray, DataType.VDO, MediaEvent.Failed);
-        notifyAll("warning", "[video] HLS is not supported");
+        reportMediaFailure(MediaErrorCode.Unsupported, "[video] HLS is not supported");
     }
     return native;
+}
+
+/**
+ * Loads a DASH stream using dash.js (no browser has native DASH support).
+ * @param videoSrc URL of the DASH manifest (.mpd)
+ */
+async function loadDash(videoSrc: string) {
+    if (typeof MediaSource === "undefined") {
+        reportMediaFailure(MediaErrorCode.Unsupported, "[video] DASH is not supported");
+        return;
+    }
+    const token = dashLoadToken;
+    try {
+        const dashjs = await loadDashjs();
+        if (token !== dashLoadToken) {
+            return; // superseded by a newer loadVideo()/stopVideo() while the import was in flight
+        }
+        createDashInstance(dashjs);
+        dash?.initialize(player, videoSrc, false);
+    } catch (error: any) {
+        if (token !== dashLoadToken) {
+            return;
+        }
+        reportMediaFailure(MediaErrorCode.Unsupported, `[video] Failed to load dash.js: ${error?.message ?? error}`);
+    }
 }
 
 /**
@@ -784,11 +943,10 @@ function nextVideo() {
  * @param error Whether video stopped due to error (defaults to false)
  */
 function stopVideo(error?: boolean) {
+    dashLoadToken++; // placed before the guard below: playerState can still read "stop" while a load is in flight
     if (player && (playerState !== "stop" || error)) {
         player.pause();
-        if (hls) {
-            destroyHls();
-        } else {
+        if (!destroyActiveEngine()) {
             player.removeAttribute("src"); // empty source
             player.load();
         }
@@ -954,6 +1112,77 @@ function destroyHls() {
     hls?.detachMedia();
     hls?.destroy();
     hls = undefined;
+}
+
+/**
+ * Creates and configures a new dash.js instance with error handlers.
+ * Sets up event listeners for errors and bandwidth reporting.
+ * @param dashjs The lazily-loaded dash.js module (see `loadDashjs`)
+ */
+function createDashInstance(dashjs: typeof import("dashjs")) {
+    // destroy(), not reset(): reset() reconfigures for reuse but does not free the instance's
+    // memory; a new MediaPlayer is created on every load, so the outgoing one must be destroyed.
+    dash?.destroy();
+    dash = dashjs.MediaPlayer().create();
+    dash.on(dashjs.MediaPlayer.events.ERROR, function (event) {
+        if (typeof event.error === "string") {
+            switch (event.error) {
+                case "capability":
+                case "mediasource":
+                    reportMediaFailure(
+                        MediaErrorCode.Unsupported,
+                        `[video] fatal dash error encountered: ${event.error}`
+                    );
+                    break;
+                case "download":
+                    // All retries and media options have been exhausted.
+                    reportMediaFailure(
+                        MediaErrorCode.Http,
+                        `[video] fatal dash download error encountered: ${event.event.url}`
+                    );
+                    break;
+                default:
+                    // cannot recover
+                    reportMediaFailure(MediaErrorCode.Unknown, "[video] fatal dash error encountered, cannot recover");
+                    break;
+            }
+        } else {
+            reportMediaFailure(
+                MediaErrorCode.Unknown,
+                `[video] fatal dash error ${event.error.code}: ${event.error.message}`
+            );
+        }
+    });
+
+    dash.on(dashjs.MediaPlayer.events.FRAGMENT_LOADING_COMPLETED, () => {
+        const bandwidth = dash?.getAverageThroughput("video");
+        if (bandwidth && !Number.isNaN(bandwidth)) {
+            notifyAll("bandwidth", Math.round(bandwidth));
+        }
+    });
+}
+
+/**
+ * Destroys the dash.js instance and frees resources.
+ */
+function destroyDash() {
+    dash?.destroy();
+    dash = undefined;
+}
+
+/**
+ * Tears down whichever adaptive-streaming backend (HLS or DASH) is currently active.
+ * @returns True if a backend was torn down, false if neither was active.
+ */
+function destroyActiveEngine(): boolean {
+    if (hls) {
+        destroyHls();
+        return true;
+    } else if (dash) {
+        destroyDash();
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/test/brsTypes/components/RoVideoPlayer.test.js
+++ b/test/brsTypes/components/RoVideoPlayer.test.js
@@ -59,6 +59,20 @@ describe("RoVideoPlayer", () => {
             ]);
         });
 
+        it("reads the url from a boxed string inside a stream object (dash)", () => {
+            let player = new RoVideoPlayer();
+            player.contentList = [
+                contentItem({
+                    stream: contentItem({ url: new RoString(new BrsString("http://example.com/stream.mpd")) }),
+                    streamFormat: new BrsString("dash"),
+                }),
+            ];
+
+            expect(player.getContent()).toEqual([
+                { url: "http://example.com/stream.mpd", streamFormat: "dash", audioTrack: -1 },
+            ]);
+        });
+
         it("lowercases a boxed streamFormat", () => {
             let player = new RoVideoPlayer();
             player.contentList = [


### PR DESCRIPTION
## Summary
- Adds DASH as a second adaptive-streaming backend in `src/api/video.ts`, alongside the existing hls.js integration, following the same load/play/pause/seek/stop and error-handling shape (create/destroy lifecycle, error-code classification, bandwidth reporting).
- Audio/subtitle track enumeration and selection for DASH share a common locale-priority selector with the existing HLS path (preferred locale > device locale > English).
- `dash.js` is loaded via a dynamic import kept in the main bundle (`webpackMode: "eager"`): its `imsc`/TTML dependency touches `window` at module-load time, which breaks a static import outside a browser (e.g. the Node-based test suite); a real split chunk would also silently require integrators to deploy an extra file beyond the documented `brs.api.js` + `brs.worker.js` contract.
- A load-generation counter guards the one async gap this introduces (the dash.js import) against a stale instance attaching after a newer load or an explicit stop superseded it.
- `videoFormats()`/`canDecodeVideo()` now report `"dash"` container support.
- `docs/limitations.md` updated — DASH is no longer listed as unsupported.
- This PR closes #248 

## Test plan
- [x] `npm run lint` / `npm run prettier` clean
- [x] Full `vitest` suite passes (216 test files / 2764 tests)
- [x] Dev and production browser builds verified to still emit exactly `brs.api.js` + `brs.worker.js` (no stray chunk file)
- [x] Manually verified in a browser against a real public DASH manifest (BBC's `elephants_dream` MPD): playback starts, audio track enumeration works, position updates, pause/seek/stop behave correctly
- [x] Went through `/code-review` and `/simplify` passes; fixed a load-order race, a `dash.js` instance memory leak, and de-duplicated the HLS/DASH track-selection and error-reporting code

🤖 Generated with [Claude Code](https://claude.com/claude-code)