### PR TITLE
fix(scenegraph): revert a change in TrickPlayBar that caused a regression on the ticker scale

### DIFF
--- a/src/extensions/scenegraph/nodes/TrickPlayBar.ts
+++ b/src/extensions/scenegraph/nodes/TrickPlayBar.ts
@@ -50,13 +50,8 @@ export class TrickPlayBar extends Group {
         const barBmpUri = `common:/images/${this.resolution}/trickplaybar.9.png`;
         this.backBack = this.addPoster(barBmpUri, [0, 0], this.barW, this.barH);
         this.barProgress = this.addPoster(barBmpUri, [0, 0], 1, this.barH);
-        this.barTicker = this.addPoster(
-            `common:/images/${this.resolution}/trickplayticker.png`,
-            [0, 0],
-            undefined,
-            undefined,
-            true
-        );
+        this.barTicker = this.addPoster(`common:/images/${this.resolution}/trickplayticker.png`, [0, 0]);
+        this.barTicker.noScaling = true;
         this.position = this.addLabel("textColor", [0, this.barH * 2], 0, this.barH * 2);
         this.backBack.setValueSilent("opacity", new Float(0.3));
         this.barProgress.setValueSilent("visible", BrsBoolean.False);


### PR DESCRIPTION
When the app was configured as `fhd` in the manifest running on a device that is using `hd` display mode the default ticker image of the TrickPlayBar was being scaled wrong.