### PR TITLE
fix(scenegraph): fixed 'limitsize' Poster display mode to adjust image dimensions correctly in 720p

### DIFF
--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -150,6 +150,15 @@ export class Poster extends Group {
                 this.drawImage(this.bitmap, this.scaleToFit(rect), rotation, alpha, draw2D, rgba);
             } else if (mode === "scaletozoom") {
                 draw2D?.doDrawCroppedBitmap(this.bitmap, this.scaleToZoom(rect), rect, rgba, alpha);
+            } else if (mode === "limitsize") {
+                const loadWidth = this.getValueJS("loadWidth") as number;
+                const loadHeight = this.getValueJS("loadHeight") as number;
+                if (loadWidth > 0 && loadHeight > 0) {
+                    const size = this.clampLoadSize(this.bitmap.width, this.bitmap.height, loadWidth, loadHeight);
+                    rect.width = size.width;
+                    rect.height = size.height;
+                }
+                this.drawImage(this.bitmap, rect, rotation, alpha, draw2D, rgba);
             } else {
                 this.drawImage(this.bitmap, rect, rotation, alpha, draw2D, rgba);
             }


### PR DESCRIPTION
Version 2.4.0 added support to the `limitsize` Poster display mode, but it was not working properly when the app was `fhd` in manifest running on a `hd` (720p)` device display.